### PR TITLE
feat(firmware): HotRC RC receiver → rf-remote translator

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -9,6 +9,9 @@ firmware/
 ├── common/vanchor_protocol.h   shared line protocol + CMD parser (the contract)
 ├── engine/engine.ino           thrust via a HIJACKED commercial speed controller + F/R relay
 ├── steering/steering.ino       closed-loop azimuth: worm gearmotor + H-bridge + feedback pot + PID
+├── hotrc_translator/           RC receiver → rf-remote protocol bridge (see below)
+│   ├── hotrc_translator.ino    reads HotRC PWM → emits STICK/BTN lines to the Pi
+│   └── README.md               wiring, BOM, calibration for the translator
 └── README.md                   this file (schematics, pin maps, wiring, BOM)
 ```
 
@@ -370,3 +373,20 @@ preferred) and the legacy combined `CMD` line (its `steer` field maps
 split thrust board is a fork of `firmware/engine/engine.ino` that reads
 `THRUST <pwm> <dir>` instead of `CMD`. The shared protocol header
 (`firmware/common/vanchor_protocol.h`) provides `vanchorParseSteerDeg()`.
+
+---
+
+## 7. HotRC translator — RC receiver → rf-remote bridge
+
+A third Arduino (or the same Nano on a spare USB port) that bridges a **HotRC**
+(or any standard RC PWM receiver) to the Pi's `rf-remote` connector. It reads
+PWM pulse widths from 3 receiver channels and emits the `STICK` / `BTN` / `PING`
+text protocol that `src/vanchor/connectors/rf_remote.py` expects.
+
+This gives physical handheld control: proportional thrust/steering on the sticks,
+plus a **3-position mode switch** for STOP / MANUAL / ANCHOR HOLD. The anchor
+button engages GPS station-keeping at the boat's current position — tap the switch
+while fishing and the boat holds the spot.
+
+See [`firmware/hotrc_translator/README.md`](hotrc_translator/README.md) for full
+wiring, BOM, calibration, and testing instructions.

--- a/firmware/hotrc_translator/README.md
+++ b/firmware/hotrc_translator/README.md
@@ -1,0 +1,147 @@
+# HotRC → Vanchor RF Remote Translator
+
+An Arduino sketch that bridges a **HotRC** (or any standard RC PWM receiver) to
+the Vanchor-NG **`rf-remote` connector**. It reads PWM pulse widths from the
+receiver's channels and emits the text protocol the Pi expects over USB serial.
+
+This is a **dumb translator** — all motor safety (deadman switch, control
+grants, slew limiting) lives in the Pi's `rf-remote` connector and the governed
+command path. This board never touches the motor bus directly.
+
+---
+
+## Why?
+
+The existing `rf-remote` connector expects a line protocol over serial. A HotRC
+(or FlySky, Radiolink, etc.) receiver outputs raw PWM pulses. This Arduino
+sits between them:
+
+```
+HotRC Transmitter (in your hand)
+    │ 2.4 GHz
+    ▼
+HotRC Receiver (on the boat)
+    │ PWM channels
+    ▼
+Arduino Nano (this sketch)
+    │ USB serial "STICK 0.5 -0.3\r\n" / "BTN ANCHOR\r\n"
+    ▼
+Raspberry Pi (vanchor --hardware)
+    │ rf-remote connector reads this
+    ▼
+Motor controller(s) via governed path
+```
+
+## Channel mapping
+
+| Receiver channel | Arduino pin | Function |
+|---|---|---|
+| CH1 (steering) | D3 (INT1) | Steering left/right [-1, 1] |
+| CH2 (thrust)   | D2 (INT0) | Thrust forward/reverse [-1, 1] |
+| CH3 (switch)   | D4         | Mode: STOP / MANUAL / ANCHOR |
+
+CH3 is typically a 2- or 3-position switch on the transmitter:
+
+| Switch position | Pulse width | Vanchor command |
+|---|---|---|
+| Low (~1000 µs)  | < 1250 µs  | `BTN STOP` — emergency stop |
+| Mid (~1500 µs)  | 1250–1750 µs | `BTN MANUAL` — sticks control the motor |
+| High (~2000 µs) | > 1750 µs  | `BTN ANCHOR` — hold current GPS position |
+
+## Protocol output
+
+Exactly what `src/vanchor/connectors/rf_remote.py` expects:
+
+```
+STICK <thrust> <steer>\r\n   — 20 Hz while sticks are off-centre
+BTN STOP\r\n                 — CH3 low, or signal lost
+BTN MANUAL\r\n               — CH3 mid (sticks active)
+BTN ANCHOR\r\n               — CH3 high (engage position hold)
+PING\r\n                     — keep-alive when sticks centred
+```
+
+## Wiring
+
+```
+                    HotRC 6-ch Receiver
+                    ┌─────────────────┐
+         CH1 sig ──┤ CH1              │
+         CH2 sig ──┤ CH2              │
+         CH3 sig ──┤ CH3              │   Receiver powered from
+              GND ─┤ GND      VCC ────┤── Pi 5V (via Arduino)
+                    └─────────────────┘   or receiver's own BEC
+
+     Arduino Nano
+     ┌───────────────────────────────┐
+     │ D2 ◄──── CH2 sig (thrust)    │
+     │ D3 ◄──── CH1 sig (steering)  │
+     │ D4 ◄──── CH3 sig (mode sw)   │
+     │ GND ──── receiver GND        │
+     │ 5V ───── receiver VCC (if no BEC) │
+     │ USB ───► Pi USB port          │
+     └───────────────────────────────┘
+```
+
+**Important:** Use D2 and D3 for thrust/steering because they support hardware
+interrupts (INT0/INT1) on ATmega328P boards. CH3 uses `pulseIn()` which is
+adequate for the infrequent mode switch reads.
+
+## BOM (additional to the main Vanchor build)
+
+| Qty | Part | Notes |
+|---|---|---|
+| 1 | Arduino Nano (ATmega328P) | translator board |
+| 1 | HotRC 2.4 GHz transmitter + receiver | e.g. [HotRC DS-4A](https://a.aliexpress.com/_m0PQPBN) |
+| 3 | Dupont jumper wires (M-F) | receiver signal → Arduino pins |
+| 1 | USB cable (Nano to Pi) | powers the Nano + serial data |
+
+Total added cost: ~$25-30 USD.
+
+## Pi-side configuration
+
+Enable the `rf-remote` connector in your Vanchor config (YAML):
+
+```yaml
+connectors:
+  rf-remote:
+    enabled: true
+    port: /dev/ttyUSB2       # adjust to the translator Nano's port
+    baudrate: 115200
+    expiry_s: 1.0            # deadman timeout (seconds of radio silence)
+```
+
+Or use Settings → Devices in the web UI to configure it.
+
+## Calibration
+
+1. **Stick range:** If your transmitter doesn't output exactly 1000–2000 µs,
+   adjust `PWM_MIN`, `PWM_CENTRE`, `PWM_MAX` in the sketch.
+2. **Deadzone:** Increase `PWM_DEADZONE` (default 40 µs) if sticks jitter near
+   centre.
+3. **Mode thresholds:** If your CH3 switch pulse widths differ, adjust
+   `MODE_STOP_THRESH` and `MODE_ANCHOR_THRESH`.
+4. **Channel swap:** If your transmitter's CH1/CH2 are reversed, swap
+   `PIN_CH_THRUST` and `PIN_CH_STEER`.
+
+## Testing
+
+1. Upload the sketch to an Arduino Nano.
+2. Open the Arduino Serial Monitor at 115200 baud.
+3. Move sticks — you should see `STICK 0.45 -0.20` lines at 20 Hz.
+4. Flip the mode switch — you should see `BTN ANCHOR` / `BTN MANUAL` / `BTN STOP`.
+5. Turn off the transmitter — you should see `BTN STOP` (signal loss).
+
+Once verified, plug the Nano into the Pi's USB and configure the `rf-remote`
+connector port.
+
+## Safety notes
+
+- **Signal loss = STOP.** If the receiver loses the transmitter signal, the
+  translator immediately sends `BTN STOP`.
+- **Deadman on the Pi side.** Even if this translator malfunctions, the
+  Pi's `rf-remote` connector has its own 1-second deadman that will STOP the
+  boat if STICK updates cease.
+- **STOP always wins.** The `BTN STOP` command bypasses the control grant
+  system — it is always accepted regardless of which connector has the grant.
+- **No direct motor access.** This board only talks to the Pi. It cannot drive
+  the motor even if it wanted to.

--- a/firmware/hotrc_translator/hotrc_translator.ino
+++ b/firmware/hotrc_translator/hotrc_translator.ino
@@ -1,0 +1,253 @@
+/*
+ * hotrc_translator.ino  --  HotRC receiver → Vanchor rf-remote protocol bridge.
+ *
+ * Reads PWM pulse widths from a standard RC receiver (HotRC or any PPM/PWM
+ * receiver) and emits the Vanchor rf-remote text protocol over USB serial to the
+ * Raspberry Pi. The Pi's rf-remote connector then bridges these commands into the
+ * governed motor path — no direct motor wiring from this board.
+ *
+ * Channel mapping (configurable below):
+ *   CH1 (PIN_CH_STEER)  → steering  [-1.0 .. +1.0]
+ *   CH2 (PIN_CH_THRUST) → thrust    [-1.0 .. +1.0]
+ *   CH3 (PIN_CH_MODE)   → mode button: ANCHOR / MANUAL / STOP
+ *
+ * Protocol output (to Pi, USB serial @ 115200 baud):
+ *   "STICK <thrust> <steer>\r\n"   — every UPDATE_INTERVAL_MS while sticks move
+ *   "BTN ANCHOR\r\n"               — when CH3 triggers anchor position
+ *   "BTN MANUAL\r\n"               — when CH3 triggers manual mode
+ *   "BTN STOP\r\n"                 — when CH3 triggers stop
+ *   "PING\r\n"                     — periodic keep-alive when sticks are centred
+ *
+ * The rf-remote connector on the Pi handles the deadman switch (1 s timeout),
+ * control grants, and safety. This board is a dumb translator — no motor logic.
+ *
+ * Hardware:
+ *   - Arduino Nano / Uno (ATmega328P, 5V)
+ *   - HotRC receiver (or any RC receiver with PWM outputs)
+ *   - 3 signal wires from receiver channels to Arduino digital pins
+ *   - Powered from Pi USB (5V) or receiver BEC
+ *
+ * Notes:
+ *   - RC PWM is 1000-2000 µs (centre 1500). We normalise to [-1, 1].
+ *   - A "no signal" condition (pulse < 800 or > 2200 µs) sends BTN STOP.
+ *   - CH3 is typically a 2- or 3-position switch:
+ *       Low  (~1000 µs) = STOP
+ *       Mid  (~1500 µs) = MANUAL (sticks active)
+ *       High (~2000 µs) = ANCHOR (hold current position)
+ *   - Stick deadzone prevents jitter near centre from spamming commands.
+ *
+ * Target: Arduino Nano / Uno (ATmega328P). No external libraries required.
+ */
+
+// ─────────────────────────────── pin map ─────────────────────────────────── //
+// Connect receiver CH1/CH2/CH3 signal wires to these pins. GND to common GND.
+// These pins support Pin Change Interrupts on the ATmega328P.
+const uint8_t PIN_CH_THRUST = 2;   // receiver CH2 → thrust (interrupt-capable)
+const uint8_t PIN_CH_STEER  = 3;   // receiver CH1 → steering (interrupt-capable)
+const uint8_t PIN_CH_MODE   = 4;   // receiver CH3 → mode switch
+
+// ────────────────────────────── calibration ──────────────────────────────── //
+// Standard RC PWM range. Adjust if your transmitter trims differently.
+const int PWM_MIN       = 1000;  // µs — full negative (reverse / port)
+const int PWM_CENTRE    = 1500;  // µs — centre (neutral)
+const int PWM_MAX       = 2000;  // µs — full positive (forward / starboard)
+const int PWM_DEADZONE  = 40;    // µs — ignore movement within ±deadzone of centre
+
+// Signal validity window. Outside this = receiver lost / no signal.
+const int PWM_VALID_MIN = 800;
+const int PWM_VALID_MAX = 2200;
+
+// CH3 mode switch thresholds (for a 3-position switch):
+//   < MODE_STOP_THRESH      → STOP
+//   STOP_THRESH .. ANCHOR_THRESH  → MANUAL
+//   > MODE_ANCHOR_THRESH    → ANCHOR
+const int MODE_STOP_THRESH   = 1250;  // µs — below this = STOP
+const int MODE_ANCHOR_THRESH = 1750;  // µs — above this = ANCHOR
+
+// ──────────────────────────────── timing ─────────────────────────────────── //
+const unsigned long UPDATE_INTERVAL_MS = 50;   // stick update rate (~20 Hz)
+const unsigned long PING_INTERVAL_MS   = 500;  // keep-alive when sticks idle
+const unsigned long DEBOUNCE_MS        = 200;  // mode switch debounce
+
+// ──────────────────────────────── state ──────────────────────────────────── //
+// Volatile because updated in ISRs.
+volatile unsigned long g_ch_thrust_rise = 0;
+volatile unsigned long g_ch_steer_rise  = 0;
+volatile int g_pw_thrust = PWM_CENTRE;  // last measured pulse width (µs)
+volatile int g_pw_steer  = PWM_CENTRE;
+
+unsigned long g_lastUpdateMs = 0;
+unsigned long g_lastPingMs   = 0;
+unsigned long g_lastModeChangeMs = 0;
+
+// Mode tracking — only send BTN when the mode CHANGES.
+enum Mode { MODE_STOP, MODE_MANUAL, MODE_ANCHOR };
+Mode g_currentMode = MODE_MANUAL;
+Mode g_lastSentMode = MODE_MANUAL;
+
+bool g_signalLost = false;
+
+// ─────────────────────── interrupt service routines ──────────────────────── //
+// Pin 2 (INT0) — thrust channel
+void isr_thrust() {
+  if (digitalRead(PIN_CH_THRUST) == HIGH) {
+    g_ch_thrust_rise = micros();
+  } else {
+    unsigned long pw = micros() - g_ch_thrust_rise;
+    if (pw >= PWM_VALID_MIN && pw <= PWM_VALID_MAX) {
+      g_pw_thrust = (int)pw;
+    }
+  }
+}
+
+// Pin 3 (INT1) — steering channel
+void isr_steer() {
+  if (digitalRead(PIN_CH_STEER) == HIGH) {
+    g_ch_steer_rise = micros();
+  } else {
+    unsigned long pw = micros() - g_ch_steer_rise;
+    if (pw >= PWM_VALID_MIN && pw <= PWM_VALID_MAX) {
+      g_pw_steer = (int)pw;
+    }
+  }
+}
+
+// ────────────────────────── utility functions ─────────────────────────────── //
+
+// Read CH3 (mode switch) via pulseIn — not interrupt-driven because mode
+// changes are infrequent and we can afford the blocking read.
+int readModePulse() {
+  unsigned long pw = pulseIn(PIN_CH_MODE, HIGH, 25000);  // 25ms timeout
+  if (pw == 0) return 0;  // timeout = no signal
+  return (int)pw;
+}
+
+// Normalise a PWM pulse width to [-1.0, 1.0] with deadzone.
+float normalise(int pw) {
+  if (pw < PWM_VALID_MIN || pw > PWM_VALID_MAX) return 0.0f;
+
+  int offset = pw - PWM_CENTRE;
+  if (abs(offset) <= PWM_DEADZONE) return 0.0f;
+
+  // Remove deadzone from the calculation range.
+  float range = (float)(PWM_MAX - PWM_CENTRE - PWM_DEADZONE);
+  float val;
+  if (offset > 0) {
+    val = (float)(offset - PWM_DEADZONE) / range;
+  } else {
+    val = (float)(offset + PWM_DEADZONE) / range;
+  }
+
+  // Clamp to [-1, 1].
+  if (val > 1.0f) val = 1.0f;
+  if (val < -1.0f) val = -1.0f;
+  return val;
+}
+
+// Determine mode from CH3 pulse width.
+Mode decodeMode(int pw) {
+  if (pw == 0 || pw < PWM_VALID_MIN) return MODE_STOP;  // no signal = stop
+  if (pw < MODE_STOP_THRESH)   return MODE_STOP;
+  if (pw > MODE_ANCHOR_THRESH) return MODE_ANCHOR;
+  return MODE_MANUAL;
+}
+
+// ──────────────────────────────── setup ──────────────────────────────────── //
+void setup() {
+  Serial.begin(115200);
+
+  pinMode(PIN_CH_THRUST, INPUT);
+  pinMode(PIN_CH_STEER, INPUT);
+  pinMode(PIN_CH_MODE, INPUT);
+
+  // Attach hardware interrupts for thrust and steering (pins 2, 3 on Uno/Nano).
+  attachInterrupt(digitalPinToInterrupt(PIN_CH_THRUST), isr_thrust, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(PIN_CH_STEER), isr_steer, CHANGE);
+
+  g_lastUpdateMs = millis();
+  g_lastPingMs = millis();
+}
+
+// ──────────────────────────────── loop ───────────────────────────────────── //
+void loop() {
+  unsigned long now = millis();
+
+  // ── Read mode switch (CH3) ──────────────────────────────────────────────
+  int modePw = readModePulse();
+  Mode newMode = decodeMode(modePw);
+
+  // Signal loss detection: if CH3 reads 0 (timeout), signal is lost.
+  if (modePw == 0) {
+    if (!g_signalLost) {
+      g_signalLost = true;
+      Serial.print("BTN STOP\r\n");
+    }
+    delay(100);
+    return;  // keep trying until signal returns
+  }
+
+  if (g_signalLost) {
+    g_signalLost = false;
+    // Signal recovered — send current mode on next iteration.
+    g_lastSentMode = MODE_MANUAL;  // force re-send
+  }
+
+  // ── Mode change detection (debounced) ───────────────────────────────────
+  if (newMode != g_currentMode && (now - g_lastModeChangeMs) > DEBOUNCE_MS) {
+    g_currentMode = newMode;
+    g_lastModeChangeMs = now;
+  }
+
+  // Send mode button only on CHANGE.
+  if (g_currentMode != g_lastSentMode) {
+    switch (g_currentMode) {
+      case MODE_STOP:
+        Serial.print("BTN STOP\r\n");
+        break;
+      case MODE_MANUAL:
+        Serial.print("BTN MANUAL\r\n");
+        break;
+      case MODE_ANCHOR:
+        Serial.print("BTN ANCHOR\r\n");
+        break;
+    }
+    g_lastSentMode = g_currentMode;
+  }
+
+  // ── Stick updates (only in MANUAL mode) ─────────────────────────────────
+  if (g_currentMode == MODE_MANUAL && (now - g_lastUpdateMs) >= UPDATE_INTERVAL_MS) {
+    g_lastUpdateMs = now;
+
+    // Read volatile values with interrupts briefly disabled for consistency.
+    noInterrupts();
+    int pwThrust = g_pw_thrust;
+    int pwSteer  = g_pw_steer;
+    interrupts();
+
+    float thrust = normalise(pwThrust);
+    float steer  = normalise(pwSteer);
+
+    // Only send if sticks are NOT both centred (deadzone).
+    if (thrust != 0.0f || steer != 0.0f) {
+      char buf[40];
+      // dtostrf for float-to-string on AVR (no printf %f).
+      char tStr[8], sStr[8];
+      dtostrf(thrust, 0, 2, tStr);
+      dtostrf(steer, 0, 2, sStr);
+      snprintf(buf, sizeof(buf), "STICK %s %s", tStr, sStr);
+      Serial.print(buf);
+      Serial.print("\r\n");
+      g_lastPingMs = now;  // stick update counts as activity
+    } else if ((now - g_lastPingMs) >= PING_INTERVAL_MS) {
+      // Sticks centred for a while — send periodic keep-alive.
+      Serial.print("PING\r\n");
+      g_lastPingMs = now;
+    }
+  }
+
+  // In ANCHOR or STOP mode, send periodic PING to show we're alive.
+  if (g_currentMode != MODE_MANUAL && (now - g_lastPingMs) >= PING_INTERVAL_MS) {
+    Serial.print("PING\r\n");
+    g_lastPingMs = now;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an Arduino sketch that bridges a **HotRC** (or any standard RC PWM receiver) to the existing `rf-remote` connector. Three receiver channels map to:

| Channel | Function |
|---|---|
| CH1 (D3) | Steering [-1, 1] |
| CH2 (D2) | Thrust [-1, 1] |
| CH3 (D4) | 3-position mode switch: STOP / MANUAL / **ANCHOR HOLD** |

## Motivation

The `rf-remote` connector (`src/vanchor/connectors/rf_remote.py`) already defines a clean line protocol for physical handsets, but there's no reference implementation showing how to wire a cheap off-the-shelf RC transmitter to it. This PR provides that bridge.

**Use case:** Physical handheld RC control of a trolling motor on a kayak/boat, with a dedicated switch position to engage GPS anchor hold at the current position — flip the switch while fishing and the boat holds the spot.

## What's included

- `firmware/hotrc_translator/hotrc_translator.ino` — the Arduino sketch
- `firmware/hotrc_translator/README.md` — wiring diagram, BOM, calibration, testing
- Updated `firmware/README.md` — directory listing + new Section 7

## Design decisions

- **No Python changes.** The translator emits the exact protocol `rf_remote.py` already expects (`STICK`/`BTN`/`PING`).
- **No motor access.** The translator only talks to the Pi over USB serial. All safety (deadman, slew, control grants) remains in the governed path.
- **Signal loss = STOP.** If the receiver loses transmitter signal, the translator immediately sends `BTN STOP`.
- **Hardware interrupts** for thrust/steering (D2/D3 = INT0/INT1) give accurate pulse measurement at 20 Hz without blocking.
- **`pulseIn()` for CH3** — mode switch changes are infrequent so blocking is acceptable.
- **Standard Arduino core only** — no external libraries required.

## Hardware cost

~$25-30 USD added (Arduino Nano + HotRC transmitter/receiver).

## Testing

Verified protocol output via Serial Monitor. No Pi-side changes needed — the existing `rf-remote` connector test suite covers the protocol contract.

---

Happy to adjust channel mappings, thresholds, or add support for additional button commands (e.g. a 4th channel for Return-to-Launch) if desired.