### PR TITLE
Paint a route (free-hand) + trace-tightly corner hugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Paint a route (free-hand).** A new way to build a route in Route mode: tap
+  **🖌 Paint a route** and drag on the map to draw a continuous line, then tap
+  **Finished** to turn it into waypoints. The simplification is turn-aware —
+  straights collapse to a couple of marks, turns keep their shape, and a turn
+  *after a long straight* gets extra marks packed around the corner (a deliberate
+  swerve is usually dodging an obstacle, so it's traced faithfully). An always-on
+  toolbar carries a **Draw / Pan** toggle — pause the line to pan or zoom, then
+  resume drawing from where you stopped — with **Finished** and **Cancel** always
+  visible. (`route.js` `VA.paint.pathToWaypoints`: RDP + curvature densification.)
+- **Trace tightly (hug corners).** A new per-route option (checkbox in the route
+  panel; auto-enabled for painted routes) that shrinks the waypoint arrival radius
+  (~5 m → ~1.5 m) so the boat hugs each corner instead of turning early and
+  cutting inside it — for routes where the exact shape matters, e.g. steering
+  around an obstacle. The abeam perpendicular-pass gate keeps the normal radius,
+  so a tight route can't stall on GPS noise/drift. (`state.route_trace_tight`,
+  `WaypointConfig.tight_arrival_radius_m`.)
 - **Two new stylized basemaps.** Added a **Nautical** chartplotter style (CARTO
   Voyager — soft chart-blue water, cream land — with a light marine tint, pairs
   with the sea-marks + depth overlays) and an on-brand **Vanchor Teal** dark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
   *after a long straight* gets extra marks packed around the corner (a deliberate
   swerve is usually dodging an obstacle, so it's traced faithfully). An always-on
   toolbar carries a **Draw / Pan** toggle — pause the line to pan or zoom, then
-  resume drawing from where you stopped — with **Finished** and **Cancel** always
-  visible. (`route.js` `VA.paint.pathToWaypoints`: RDP + curvature densification.)
+  resume drawing from where you stopped — plus **Undo** (drop the last segment)
+  and always-visible **Finished** / **Cancel**. (`route.js`
+  `VA.paint.pathToWaypoints`: RDP + curvature densification.)
 - **Trace tightly (hug corners).** A new per-route option (checkbox in the route
   panel; auto-enabled for painted routes) that shrinks the waypoint arrival radius
   (~5 m → ~1.5 m) so the boat hugs each corner instead of turning early and

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -113,6 +113,16 @@ telemetry + route snapshots, set from a `goto`/`load_route` flag):
   adjacent in-range mark). Distinct from `route_loop`; a plain route (neither
   flag) completes and idles.
 
+**Trace-tightly (`route_trace_tight`).** A third route flag (goto/load_route +
+route snapshot). When set, `WaypointMode` swaps `arrival_radius_m` for the much
+smaller `tight_arrival_radius_m` (5 m → 1.5 m) everywhere it decides arrival —
+including the multi-advance loop — so the boat **hugs corners** instead of turning
+early and cutting inside. Set for hand-drawn "paint" routes and any route where
+the exact shape matters. The passed-perpendicular gate deliberately keeps the
+*normal* radius (its 3× bound) so a tight circle the boat is blown just outside of
+can't wedge the route — the abeam pass still advances the leg. Front end sends it
+via the **Trace tightly** checkbox (auto-ticked when a painted route loads).
+
 **Work Area mode (`WorkAreaMode`).** Visit each spot, HOLD position there, then
 advance. The spots are `state.waypoints`; `active_waypoint` is the current spot.
 A two-phase machine: TRAVEL reuses the waypoint leg (cross-track + fwd/reverse);

--- a/docs/llms/frontend.md
+++ b/docs/llms/frontend.md
@@ -62,6 +62,7 @@ auto-reload.
 | `VA.map.setOnMapClick(fn)` | the fallback click handler (`fn(lat,lon,armed)`). |
 | `VA.map.setGotoArmed/isGotoArmed`, `setGotoMarker/clearGotoMarker` | go-to ("tap map") state. |
 | `VA.map.addPending(lat,lon)`, `pending()`, `setPending(arr)`, `redrawWaypoints()`, `onWaypointChange(fn)`, `onRouteEdit(fn)` | the pending-route-waypoint editor. |
+| `VA.paint.pathToWaypoints(latlngs, mpp)` | pure geometry (in `route.js`): simplify a free-hand drawn line into waypoints (RDP + curvature densification — sparse on straights, dense on turns, extra detail on a turn after a long straight). Used by the **Paint a route** tool; `mpp` = metres/screen-pixel for scale-relative tolerance. |
 | `VA.map.setDepthShow`, `setContourShow`, `redrawDepth` | depth overlays. |
 | `VA.routeEditor` (in `app.js`) | `setLoop/clearLoop/refresh` — refresh the route list after editing pending waypoints. |
 

--- a/docs/modes/route.md
+++ b/docs/modes/route.md
@@ -38,10 +38,12 @@ route you saved last trip.
 
 *Paint a route (free-hand):* tap **🖌 Paint a route** to draw the line instead of
 placing pins one by one.
-1. An always-on toolbar appears with a **Draw / Pan** toggle and **Finished** /
-   **Cancel**. In **Draw** mode, drag on the map to draw a continuous line.
+1. An always-on toolbar appears with a **Draw / Pan** toggle, **Undo**, and
+   **Finished** / **Cancel**. In **Draw** mode, drag on the map to draw a
+   continuous line.
 2. Release to pause. Tap the toggle to **🤚 Pan** to pan or zoom the map, then tap
    **✏️ Draw** and keep drawing **from where you stopped** — the line joins up.
+   Drew a stretch wrong? Tap **↶ Undo** to drop the last segment and redraw it.
 3. Tap **✓ Finished**. The line becomes waypoints and lands **unstarted** in the
    editor to review. Straights collapse to a couple of marks; turns keep their
    shape; a turn *after a long straight* gets extra marks packed around the corner

--- a/docs/modes/route.md
+++ b/docs/modes/route.md
@@ -36,6 +36,18 @@ route you saved last trip.
 3. Tap **＋ Add waypoints** again (or it clears on start) when done.
 4. Press **▶ Start route**.
 
+*Paint a route (free-hand):* tap **🖌 Paint a route** to draw the line instead of
+placing pins one by one.
+1. An always-on toolbar appears with a **Draw / Pan** toggle and **Finished** /
+   **Cancel**. In **Draw** mode, drag on the map to draw a continuous line.
+2. Release to pause. Tap the toggle to **🤚 Pan** to pan or zoom the map, then tap
+   **✏️ Draw** and keep drawing **from where you stopped** — the line joins up.
+3. Tap **✓ Finished**. The line becomes waypoints and lands **unstarted** in the
+   editor to review. Straights collapse to a couple of marks; turns keep their
+   shape; a turn *after a long straight* gets extra marks packed around the corner
+   (a deliberate swerve is usually dodging something, so it's traced faithfully).
+   **Trace tightly** is auto-enabled (see Settings). Review, then **▶ Start route**.
+
 *"Take me here" smart water routing:* open **Take me here (smart route)** in the
 panel.
 1. Tap **Pick destination**, then tap the map. (Or long-press / right-click any
@@ -74,6 +86,12 @@ restart at waypoint 1.
 - **Patrol (there & back)** — checkbox in the route panel. At each end, reverse
   and run the route back, indefinitely. *Default off.* A **↩ patrol** badge lights
   while active.
+- **Trace tightly (hug corners)** — checkbox in the route panel. Shrinks the
+  arrival radius (~5 m → ~1.5 m) so the boat hugs each corner instead of turning
+  early and cutting inside it. *Default off; auto-enabled for painted routes.* Use
+  it whenever the exact drawn shape matters — e.g. the line steers around an
+  obstacle. The boat still can't stall on it: passing a mark abeam advances the
+  leg even when noise or drift holds it just outside the tighter circle.
 - **Loop** — set by the **Loop around island** planner (not a manual checkbox).
   At the end the route wraps to waypoint 1 and circles continuously. A **↻ loop**
   badge lights. Clearing or starting a normal route drops the loop flag.

--- a/e2e_smoke.py
+++ b/e2e_smoke.py
@@ -152,6 +152,34 @@ def frontend_checks():
             check(f"settings card #{cid}", pg.locator("#" + cid).count() == 1)
         check("measure tool control", pg.locator(".measure-btn").count() == 1)
         check("alert-history bell", pg.locator("#alerts-open").count() == 1)
+
+        # --- Paint route (free-hand) ---------------------------------------
+        # Exercise the pure path->waypoints algorithm in-browser (deterministic,
+        # no flaky synthetic pointer drags): a long straight into a sharp turn
+        # should collapse the straight yet keep detail at the corner.
+        n_wp = pg.evaluate(
+            """() => {
+                const base = {lat: 59.66275, lon: 13.32247};
+                const path = [];
+                for (let i = 0; i < 120; i++) path.push({lat: base.lat, lon: base.lon + 0.0009 * (i/119)});
+                for (let i = 1; i < 120; i++) path.push({lat: base.lat + 0.0009 * (i/119), lon: base.lon + 0.0009});
+                return VA.paint.pathToWaypoints(path, 1.2).length;
+            }"""
+        )
+        check(f"paint algorithm yields waypoints ({n_wp})", 3 <= n_wp <= 80)
+        # UI wiring: Paint button reveals the always-visible toolbar; the Draw/Pan
+        # toggle flips; Cancel tears it back down.
+        pg.evaluate("()=>document.getElementById('wp-paint').click()")
+        pg.wait_for_timeout(100)
+        check("paint toolbar shows", not pg.locator("#paint-bar").evaluate("el=>el.classList.contains('hidden')"))
+        check("finished + cancel visible", pg.locator("#paint-finish").is_visible() and pg.locator("#paint-cancel").is_visible())
+        pg.evaluate("()=>document.getElementById('paint-toggle').click()")
+        pg.wait_for_timeout(50)
+        check("draw/pan toggle flips", pg.locator("#paint-toggle").evaluate("el=>el.classList.contains('panning')"))
+        pg.evaluate("()=>document.getElementById('paint-cancel').click()")
+        pg.wait_for_timeout(50)
+        check("paint toolbar hides on cancel", pg.locator("#paint-bar").evaluate("el=>el.classList.contains('hidden')"))
+
         check("no console errors", not errs)
         if errs:
             print("    console errors:", errs[:5])

--- a/e2e_smoke.py
+++ b/e2e_smoke.py
@@ -154,9 +154,10 @@ def frontend_checks():
         check("alert-history bell", pg.locator("#alerts-open").count() == 1)
 
         # --- Paint route (free-hand) ---------------------------------------
-        # Exercise the pure path->waypoints algorithm in-browser (deterministic,
-        # no flaky synthetic pointer drags): a long straight into a sharp turn
-        # should collapse the straight yet keep detail at the corner.
+        # First the pure path->waypoints algorithm (deterministic): a long
+        # straight into a sharp turn should collapse the straight yet keep detail
+        # at the corner. The actual drawing is exercised further down with real
+        # PointerEvents.
         n_wp = pg.evaluate(
             """() => {
                 const base = {lat: 59.66275, lon: 13.32247};
@@ -176,9 +177,47 @@ def frontend_checks():
         pg.evaluate("()=>document.getElementById('paint-toggle').click()")
         pg.wait_for_timeout(50)
         check("draw/pan toggle flips", pg.locator("#paint-toggle").evaluate("el=>el.classList.contains('panning')"))
-        pg.evaluate("()=>document.getElementById('paint-cancel').click()")
-        pg.wait_for_timeout(50)
-        check("paint toolbar hides on cancel", pg.locator("#paint-bar").evaluate("el=>el.classList.contains('hidden')"))
+        pg.evaluate("()=>document.getElementById('paint-toggle').click()")  # back to Draw
+
+        # ACTUAL drawing: dispatch real PointerEvents for two strokes with a pan
+        # toggle between them (resume). This drives onPaintDown/Move/Up end-to-end
+        # — the earlier checks would miss a lat/lon-shaped bug where nothing draws.
+        drew = pg.evaluate(
+            """() => {
+                const c = VA.map.leaflet.getContainer(), r = c.getBoundingClientRect();
+                const fire = (t, x, y, b) => (t === 'pointerdown' ? c : window).dispatchEvent(
+                    new PointerEvent(t, {bubbles:true, cancelable:true, pointerId:1,
+                        pointerType:'mouse', button:0, buttons:b, clientX:r.left+x, clientY:r.top+y}));
+                const stroke = (pts) => { fire('pointerdown', pts[0][0], pts[0][1], 1);
+                    for (let i=1;i<pts.length;i++) fire('pointermove', pts[i][0], pts[i][1], 1);
+                    fire('pointerup', pts[pts.length-1][0], pts[pts.length-1][1], 0); };
+                const line = () => { let n=0; VA.map.leaflet.eachLayer(l=>{ if (l instanceof L.Polyline
+                    && l.options.color==='#1be4ff' && l.options.weight===4) n=l.getLatLngs().length; }); return n; };
+                const s1=[]; for (let i=0;i<24;i++) s1.push([120+i*18, 300+Math.sin(i/3)*90]); stroke(s1);
+                const a1 = line();
+                document.getElementById('paint-toggle').click();   // pause -> pan
+                document.getElementById('paint-toggle').click();   // -> draw (resume)
+                const s2=[]; for (let i=0;i<16;i++) s2.push([520+i*12, 500-i*10]); stroke(s2);
+                return {a1, a2: line()};
+            }"""
+        )
+        check(f"paint stroke draws a line ({drew['a1']} pts)", drew["a1"] >= 3)
+        check(f"paint resumes after pause ({drew['a1']} -> {drew['a2']} pts)", drew["a2"] > drew["a1"])
+        # Undo removes the last stroke (back to the pre-resume length).
+        undone = pg.evaluate(
+            """() => { const b=document.getElementById('paint-undo'); const was=b.disabled; b.click();
+                let n=0; VA.map.leaflet.eachLayer(l=>{ if (l instanceof L.Polyline
+                    && l.options.color==='#1be4ff' && l.options.weight===4) n=l.getLatLngs().length; });
+                return {was, n}; }"""
+        )
+        check(f"undo removes last stroke ({drew['a2']} -> {undone['n']} pts)", (not undone["was"]) and undone["n"] == drew["a1"])
+        pg.evaluate("()=>document.getElementById('paint-finish').click()")
+        pg.wait_for_timeout(150)
+        n_pending = pg.evaluate("()=>VA.map.pending().length")
+        check(f"Finished builds waypoints ({n_pending})", 3 <= n_pending <= 80)
+        check("trace-tight auto-enabled for paint", pg.evaluate("()=>document.getElementById('wp-tight').checked"))
+        check("paint toolbar hides after finish", pg.locator("#paint-bar").evaluate("el=>el.classList.contains('hidden')"))
+        pg.evaluate("()=>document.getElementById('wp-clear').click()")  # tidy up the pending route
 
         check("no console errors", not errs)
         if errs:

--- a/src/vanchor/controller/controller.py
+++ b/src/vanchor/controller/controller.py
@@ -789,6 +789,8 @@ class Controller:
                     self.state.route_loop = bool(command.get("loop", False))
                     # Patrol: at each end, reverse and run the route back.
                     self.state.route_patrol = bool(command.get("patrol", False))
+                    # Trace tightly: hug corners (small arrival radius) -- paint routes.
+                    self.state.route_trace_tight = bool(command.get("trace_tight", False))
                     self.set_mode(ControlModeName.WAYPOINT)
                 else:
                     n = len(self.state.waypoints)
@@ -801,6 +803,7 @@ class Controller:
                 self.state.active_waypoint = 0
                 self.state.route_loop = bool(command.get("loop", False))
                 self.state.route_patrol = bool(command.get("patrol", False))
+                self.state.route_trace_tight = bool(command.get("trace_tight", False))
                 if "throttle" in command:
                     cast(
                         WaypointMode, self.modes[ControlModeName.WAYPOINT]
@@ -989,6 +992,7 @@ class Controller:
             "route_on_arrival": self.state.route_on_arrival,
             "route_loop": self.state.route_loop,
             "route_patrol": self.state.route_patrol,
+            "route_trace_tight": self.state.route_trace_tight,
             "target_heading": self.state.target_heading,
             "anchor": self.state.anchor,
             "anchor_radius_m": self.state.anchor_radius_m,
@@ -1016,6 +1020,7 @@ class Controller:
         self.state.route_on_arrival = snap["route_on_arrival"]
         self.state.route_loop = snap.get("route_loop", False)
         self.state.route_patrol = snap.get("route_patrol", False)
+        self.state.route_trace_tight = snap.get("route_trace_tight", False)
         self.state.target_heading = snap["target_heading"]
         self.state.anchor = snap["anchor"]
         self.state.anchor_radius_m = snap["anchor_radius_m"]

--- a/src/vanchor/controller/modes.py
+++ b/src/vanchor/controller/modes.py
@@ -594,6 +594,13 @@ def maneuver_to_bearing(
 @dataclass
 class WaypointConfig:
     arrival_radius_m: float = 5.0
+    # Arrival radius used when the route is flagged "trace tightly"
+    # (state.route_trace_tight) -- hand-drawn paint routes and any route where the
+    # exact shape matters. Much smaller than the normal radius so the boat hugs
+    # each corner instead of turning off early and cutting inside it. The abeam
+    # perpendicular-pass gate still advances the leg, so a tight radius can't stall
+    # the route if GPS noise or drift keeps the boat just outside the circle.
+    tight_arrival_radius_m: float = 1.5
     throttle: float = 0.6
     # Degrees of heading correction per metre of cross-track error.
     xte_gain: float = 2.0
@@ -679,13 +686,21 @@ class WaypointMode(ControlMode):
         if self._leg_start is None:
             self._leg_start = pos
 
+        # Effective arrival radius: tiny when the route is flagged "trace tightly"
+        # (paint routes) so corners are hugged, not cut inside the normal radius.
+        radius = (
+            self.config.tight_arrival_radius_m
+            if state.route_trace_tight
+            else self.config.arrival_radius_m
+        )
+
         target = state.waypoints[state.active_waypoint].point
         distance = haversine_m(pos, target)
         state.distance_to_waypoint_m = distance
 
         # Arrival: within the radius, OR passed the leg's perpendicular (the
         # boat sailed past the waypoint abeam without entering the circle).
-        arrived = distance <= self.config.arrival_radius_m
+        arrived = distance <= radius
         if not arrived:
             leg_len = haversine_m(self._leg_start, target)
             if leg_len > 0.0:
@@ -696,6 +711,10 @@ class WaypointMode(ControlMode):
                     math.radians(angle_difference(brg_leg, brg_pos))
                 )
                 xte_m = abs(cross_track(self._leg_start, target, pos).distance_m)
+                # This abeam gate deliberately keeps the NORMAL radius even when
+                # tracing tightly: it's the anti-stall net that advances the leg
+                # once the boat has passed the mark's perpendicular, so a 1.5 m
+                # circle the boat is blown just outside of can't wedge the route.
                 if along >= leg_len and xte_m <= 3.0 * self.config.arrival_radius_m:
                     arrived = True
 
@@ -710,7 +729,7 @@ class WaypointMode(ControlMode):
                 if not 0 <= state.active_waypoint < len(state.waypoints):
                     break
                 nxt = state.waypoints[state.active_waypoint].point
-                if haversine_m(pos, nxt) <= self.config.arrival_radius_m:
+                if haversine_m(pos, nxt) <= radius:
                     self._post_speed(state, state.active_waypoint)
                     state.active_waypoint += self._step
                     self._leg_start = nxt

--- a/src/vanchor/core/state.py
+++ b/src/vanchor/core/state.py
@@ -141,6 +141,11 @@ class NavigationState:
     # back the other way -- a continuous there-and-back "patrol" (distinct from
     # route_loop, which closes the ring). Set via the goto/load_route "patrol" flag.
     route_patrol: bool = False
+    # When True, follow the route TIGHTLY: WaypointMode uses a much smaller arrival
+    # radius so it hugs each corner instead of cutting it inside the normal radius.
+    # Set for hand-drawn "paint" routes (and any route where the exact traced shape
+    # matters -- e.g. steering around an obstacle). Via the goto/load_route flag.
+    route_trace_tight: bool = False
 
     # --- Work Area mode: visit spots, hold at each, then advance. -------- #
     # The spots are state.waypoints; active_waypoint is the current spot. While

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -136,6 +136,7 @@
        from where you stopped; Finished + Cancel stay on screen throughout. -->
   <div id="paint-bar" class="paint-bar hidden" role="toolbar" aria-label="Paint route">
     <button id="paint-toggle" type="button" class="paint-toggle">✏️ Draw</button>
+    <button id="paint-undo" type="button" class="paint-undo" disabled title="Undo the last segment you drew">↶ Undo</button>
     <span id="paint-hint" class="paint-hint">Drag on the map to draw your route.</span>
     <span id="paint-count" class="paint-count"></span>
     <div class="paint-actions">

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -131,6 +131,19 @@
     <button id="arm-banner-cancel" type="button">Cancel</button>
   </div>
 
+  <!-- Paint-route toolbar: always visible while free-hand drawing a route.
+       The Draw / Pan toggle lets you pause the line to pan/zoom, then resume
+       from where you stopped; Finished + Cancel stay on screen throughout. -->
+  <div id="paint-bar" class="paint-bar hidden" role="toolbar" aria-label="Paint route">
+    <button id="paint-toggle" type="button" class="paint-toggle">✏️ Draw</button>
+    <span id="paint-hint" class="paint-hint">Drag on the map to draw your route.</span>
+    <span id="paint-count" class="paint-count"></span>
+    <div class="paint-actions">
+      <button id="paint-finish" type="button" class="paint-finish">&#x2713; Finished</button>
+      <button id="paint-cancel" type="button" class="paint-cancel">Cancel</button>
+    </div>
+  </div>
+
   <!-- Alert history (#97): a dialog listing recent safety alerts, newest first.
        Driven by VA.logAlert(); persisted to localStorage. -->
   <dialog id="alerts-dialog" class="alerts-dialog">
@@ -574,12 +587,16 @@
 
       <!-- WAYPOINT / ROUTE -->
       <div class="ctx-panel" id="ctx-waypoint" data-for="waypoint">
-        <div class="hint">Turn on <b>Add waypoints</b> to drop pins by tapping the map; otherwise map taps do nothing.</div>
+        <div class="hint">Turn on <b>Add waypoints</b> to drop pins by tapping the map; otherwise map taps do nothing. Or <b>Paint a route</b> to free-hand draw a line and turn it into waypoints.</div>
         <div class="btn-row">
           <button id="wp-arm" class="btn-primary wide">＋ Add waypoints</button>
         </div>
+        <div class="btn-row">
+          <button id="wp-paint" class="btn-ghost wide">🖌 Paint a route (free-hand)</button>
+        </div>
         <ol id="wp-list" class="wp-list"></ol>
         <label class="switch" title="At the end of the route, reverse and run it back — patrolling there-and-back continuously."><input type="checkbox" id="wp-patrol" /><span class="track"></span> Patrol (there &amp; back)</label>
+        <label class="switch" title="Follow the route tightly — hug each corner instead of cutting inside it. Auto-enabled for painted routes; good when the exact shape matters (e.g. steering around an obstacle)."><input type="checkbox" id="wp-tight" /><span class="track"></span> Trace tightly (hug corners)</label>
         <div class="btn-row">
           <button id="wp-go" class="btn-primary">▶ Start route</button>
           <button id="wp-clear" class="btn-ghost">Clear</button>

--- a/src/vanchor/ui/static/route.js
+++ b/src/vanchor/ui/static/route.js
@@ -439,17 +439,22 @@
   const paintMap = VA.map.leaflet;
   const paintBar = $("paint-bar");
   const paintToggle = $("paint-toggle");
+  const paintUndoBtn = $("paint-undo");
   const paintHint = $("paint-hint");
   const paintCount = $("paint-count");
   let paintArmed = false, paintPanning = false, paintDrawing = false;
   let paintPts = [];              // accumulated latlngs across all strokes
+  let paintStrokeStarts = [];     // index into paintPts where each stroke began (for Undo)
   let paintLine = null;           // live Leaflet polyline
   let paintLastClient = null;     // last raw client point (pixel throttle)
 
   function mapEl() { return document.getElementById("map"); }
   function paintLatLng(ev) {
     const rect = paintMap.getContainer().getBoundingClientRect();
-    return paintMap.containerPointToLatLng(L.point(ev.clientX - rect.left, ev.clientY - rect.top));
+    // Leaflet's LatLng uses `.lng`; the rest of the paint code (and the waypoint
+    // model) uses `.lon` — normalise here so the drawn points carry `.lon`.
+    const ll = paintMap.containerPointToLatLng(L.point(ev.clientX - rect.left, ev.clientY - rect.top));
+    return { lat: ll.lat, lon: ll.lng };
   }
   function metresPerPixel() {
     const c = paintMap.getSize();
@@ -473,6 +478,15 @@
         : (paintPts.length ? "Drag to keep drawing where you left off." : "Drag on the map to draw your route.");
     }
     if (paintCount) paintCount.textContent = paintPts.length ? paintPts.length + " pts" : "";
+    if (paintUndoBtn) paintUndoBtn.disabled = paintStrokeStarts.length === 0;
+  }
+  // Undo the last STROKE (everything drawn since the last pointer-down) — the
+  // natural unit when a stretch comes out wrong: pause, tap Undo, redraw it.
+  function undoPaintStroke() {
+    if (!paintStrokeStarts.length) return;
+    const start = paintStrokeStarts.pop();
+    paintPts.length = start;         // drop that stroke's points
+    paintDrawLine(); paintUpdateBar();
   }
   function paintZoomHandlers(enable) {
     // Toggle Leaflet's own gestures so Draw mode locks the map and Pan mode frees it.
@@ -497,10 +511,21 @@
     if (!paintArmed || paintPanning) return;
     if (ev.button !== undefined && ev.button !== 0) return;   // left / primary only
     ev.preventDefault();
+    // Release the browser's IMPLICIT pointer capture, which targets whichever tile
+    // element is under the cursor at pointerdown. Leaflet can swap that tile out
+    // mid-stroke; the pointerup would then fire on a detached node and never reach
+    // us, so the stroke never "ends" and the next one can't start. With it
+    // released, events hit-test normally and reach the window listeners below —
+    // which we bind per-stroke so move/up keep flowing even off the map element.
+    try { if (ev.target && ev.target.releasePointerCapture) ev.target.releasePointerCapture(ev.pointerId); } catch (e) { /* ignore */ }
     paintDrawing = true;
+    paintStrokeStarts.push(paintPts.length);   // mark this stroke's start for Undo
     paintLastClient = { x: ev.clientX, y: ev.clientY };
     paintPts.push(paintLatLng(ev));
     paintDrawLine(); paintUpdateBar();
+    window.addEventListener("pointermove", onPaintMove);
+    window.addEventListener("pointerup", onPaintUp);
+    window.addEventListener("pointercancel", onPaintUp);
   }
   function onPaintMove(ev) {
     if (!paintDrawing) return;
@@ -509,20 +534,25 @@
     paintPts.push(paintLatLng(ev));
     paintDrawLine(); paintUpdateBar();
   }
-  function onPaintUp() { paintDrawing = false; }   // pause; the drawn path is kept
+  function onPaintUp() {
+    window.removeEventListener("pointermove", onPaintMove);
+    window.removeEventListener("pointerup", onPaintUp);
+    window.removeEventListener("pointercancel", onPaintUp);
+    paintDrawing = false;   // pause; the drawn path is kept
+  }
+  // A native drag started on a tile <img> would eat the stroke — cancel it.
+  function onPaintDragStart(ev) { if (paintArmed && !paintPanning) ev.preventDefault(); }
 
   function enterPaint() {
     if (paintArmed) return;
     setWpArmed(false); setGotoArmed(false);        // paint owns the map alone
-    paintArmed = true; paintPts = []; paintDrawing = false;
+    paintArmed = true; paintPts = []; paintStrokeStarts = []; paintDrawing = false;
     if (paintLine) { paintMap.removeLayer(paintLine); paintLine = null; }
     if (paintBar) paintBar.classList.remove("hidden");
     if (VA.sheet && VA.sheet.collapse) VA.sheet.collapse();   // clear the map to draw on
     const c = paintMap.getContainer();
-    c.addEventListener("pointerdown", onPaintDown);
-    c.addEventListener("pointermove", onPaintMove);
-    c.addEventListener("pointerup", onPaintUp);
-    c.addEventListener("pointercancel", onPaintUp);
+    c.addEventListener("pointerdown", onPaintDown);   // move/up bind per-stroke on window
+    c.addEventListener("dragstart", onPaintDragStart);
     paintSetPanning(false);                         // start in Draw mode
   }
   function exitPaint() {
@@ -530,9 +560,8 @@
     paintArmed = false; paintDrawing = false;
     const c = paintMap.getContainer();
     c.removeEventListener("pointerdown", onPaintDown);
-    c.removeEventListener("pointermove", onPaintMove);
-    c.removeEventListener("pointerup", onPaintUp);
-    c.removeEventListener("pointercancel", onPaintUp);
+    c.removeEventListener("dragstart", onPaintDragStart);
+    onPaintUp();   // unbind any live per-stroke window listeners
     mapEl().classList.remove("painting");
     paintZoomHandlers(true);                        // restore normal map gestures
     if (paintLine) { paintMap.removeLayer(paintLine); paintLine = null; }
@@ -553,6 +582,7 @@
   }
 
   if (paintToggle) paintToggle.addEventListener("click", () => paintSetPanning(!paintPanning));
+  if (paintUndoBtn) paintUndoBtn.addEventListener("click", undoPaintStroke);
   const paintBtn = $("wp-paint");
   if (paintBtn) paintBtn.addEventListener("click", enterPaint);
   const paintFinishBtn = $("paint-finish");

--- a/src/vanchor/ui/static/route.js
+++ b/src/vanchor/ui/static/route.js
@@ -17,6 +17,7 @@
   // map tap (panning, deselecting) doesn't litter the route with pins.
   let wpArmed = false;
   function setWpArmed(on) {
+    if (on && paintArmed) exitPaint();   // adding pins ends free-hand paint
     wpArmed = on;
     const b = $("wp-arm");
     if (b) { b.classList.toggle("active", on); b.textContent = on ? "✓ Tap map to add — done" : "＋ Add waypoints"; }
@@ -33,6 +34,7 @@
     }
   }
   VA.map.setOnMapClick((lat, lon, armed) => {
+    if (paintArmed) return;                       // free-hand paint owns the map
     if (armed) { gotoTo(lat, lon); setGotoArmed(false); return; }
     if (wpArmed) { VA.map.addPending(lat, lon); renderWpList(); return; }
     if (VA.pinPopup) VA.pinPopup.open(lat, lon);   // item 18: plain tap = pin popup
@@ -103,6 +105,10 @@
   // #wp-patrol checkbox in the route editor.
   const patrolBox = $("wp-patrol");
   const routeIsPatrol = () => !!(patrolBox && patrolBox.checked);
+  // Trace-tightly flag: hug corners (small arrival radius on the backend) instead
+  // of cutting inside them. Auto-ticked for painted routes (see finishPaint).
+  const tightBox = $("wp-tight");
+  const routeIsTight = () => !!(tightBox && tightBox.checked);
   function updatePatrolIndicator(active) {
     const el = $("patrol-indicator");
     if (el) el.classList.toggle("hidden", !(routeIsPatrol() || !!active));
@@ -122,6 +128,7 @@
     };
     if (routeIsLoop) cmd.loop = true;       // circle continuously around the island
     if (routeIsPatrol()) cmd.patrol = true; // run the route there-and-back continuously
+    if (routeIsTight()) cmd.trace_tight = true; // hug corners (paint / exact-shape routes)
     send(cmd);
     // The route is now ACTIVE — its committed waypoints come back via telemetry
     // and render as the active (coloured) route. Clear the editable "not started"
@@ -246,6 +253,7 @@
   $("wp-clear").addEventListener("click", () => {
     VA.map.setPending([]); renderWpList(); setWpArmed(false);
     setLoopFlag(false);   // clearing the route drops any island-loop flag
+    if (tightBox) tightBox.checked = false;   // ...and the trace-tightly flag
   });
 
   // Live editing of an ACTIVE route: when the user drags or edits a committed
@@ -254,6 +262,7 @@
     if (!waypoints || !waypoints.length) { send({ type: "stop" }); setLoopFlag(false); return; }
     const cmd = { type: "goto", waypoints, throttle: 0.6 };
     if (routeIsLoop) cmd.loop = true;   // (loop/patrol also preserved server-side on edits)
+    if (routeIsTight()) cmd.trace_tight = true;
     // active = resume index: keep navigating from the current target instead of
     // restarting at waypoint 1 when a committed waypoint is dragged/edited (#51).
     if (Number.isInteger(resume)) cmd.active = resume;
@@ -264,6 +273,7 @@
   const gotoArm = $("goto-arm");
   const gotoAction = $("goto-action");
   function setGotoArmed(on) {
+    if (on && paintArmed) exitPaint();   // go-to arming ends free-hand paint
     VA.map.setGotoArmed(on);
     if (gotoArm) {
       gotoArm.classList.toggle("active", on);
@@ -318,6 +328,237 @@
     }).catch(() => { if (contourStatus) contourStatus.textContent = "Contour lookup failed."; });
     return true;                            // consumed the click
   });
+
+  // ===== Paint route (free-hand) ===========================================
+  // Draw a continuous line on the map; Finished simplifies it into waypoints.
+  // The simplification is turn-aware: straights collapse to a couple of points,
+  // turns keep their shape, and a turn that FOLLOWS a long straight gets extra
+  // waypoints packed around the corner — a long run into a sudden turn usually
+  // means the skipper is threading past an obstacle, so we trace it faithfully
+  // instead of letting the boat cut the corner. A Draw / Pan toggle lets you
+  // pause mid-line to pan or zoom, then resume from where you stopped; Finished
+  // and Cancel stay on screen the whole time.
+
+  // ---- pure geometry: raw drawn path -> waypoints -------------------------
+  const PDEG = Math.PI / 180, PR = 6371000;
+  function paintProject(latlngs) {
+    // Equirectangular projection to local metres (accurate over a lake-sized draw).
+    const cos0 = Math.cos(latlngs[0].lat * PDEG);
+    return latlngs.map((p) => ({ x: p.lon * PDEG * cos0 * PR, y: p.lat * PDEG * PR, lat: p.lat, lon: p.lon }));
+  }
+  function pDist(a, b) { return Math.hypot(a.x - b.x, a.y - b.y); }
+  function pPerp(p, a, b) {
+    const dx = b.x - a.x, dy = b.y - a.y, L2 = dx * dx + dy * dy;
+    if (L2 === 0) return pDist(p, a);
+    let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / L2;
+    t = Math.max(0, Math.min(1, t));
+    return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+  }
+  function pRdp(P, eps) {
+    // Ramer–Douglas–Peucker: keep the vertices that carry the line's shape.
+    const n = P.length;
+    if (n < 3) return P.map((_, i) => i);
+    const keep = new Array(n).fill(false);
+    keep[0] = keep[n - 1] = true;
+    const stack = [[0, n - 1]];
+    while (stack.length) {
+      const seg = stack.pop(), a = seg[0], b = seg[1];
+      let maxD = -1, idx = -1;
+      for (let i = a + 1; i < b; i++) {
+        const d = pPerp(P[i], P[a], P[b]);
+        if (d > maxD) { maxD = d; idx = i; }
+      }
+      if (maxD > eps && idx > -1) { keep[idx] = true; stack.push([a, idx]); stack.push([idx, b]); }
+    }
+    const out = [];
+    for (let i = 0; i < n; i++) if (keep[i]) out.push(i);
+    return out;
+  }
+  function pTurn(prev, cur, next) {
+    const ax = cur.x - prev.x, ay = cur.y - prev.y, bx = next.x - cur.x, by = next.y - cur.y;
+    const la = Math.hypot(ax, ay), lb = Math.hypot(bx, by);
+    if (la === 0 || lb === 0) return 0;
+    let c = (ax * bx + ay * by) / (la * lb);
+    c = Math.max(-1, Math.min(1, c));
+    return Math.acos(c) / PDEG;                   // degrees of course change
+  }
+  function pArc(P, i, j) { let s = 0; for (let k = i; k < j; k++) s += pDist(P[k], P[k + 1]); return s; }
+  function pWalk(P, from, dir, target) {
+    // Walk raw indices from `from` until the arc length reaches `target` metres.
+    let acc = 0, i = from;
+    for (;;) {
+      const nx = i + dir;
+      if (nx < 0 || nx >= P.length) return i;
+      acc += pDist(P[i], P[nx]); i = nx;
+      if (acc >= target) return i;
+    }
+  }
+  function pathToWaypoints(latlngs, mpp, opts) {
+    opts = opts || {};
+    const MAX_WP = opts.maxWp || 80, MIN_SPACING = opts.minSpacing || 1.5;
+    const TURN_SOFT = 25, TURN_HARD = 60;
+    if (!latlngs || latlngs.length < 2) return (latlngs || []).map((p) => ({ lat: p.lat, lon: p.lon }));
+    const P = paintProject(latlngs);
+    // Base tolerance ~6 screen px, clamped to a sane metric band: finer where the
+    // user zoomed in to draw carefully, coarser on a low-zoom overview sketch.
+    let eps = Math.max(1.5, Math.min(25, 6 * (mpp || 1)));
+    let selected = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const kept = pRdp(P, eps);
+      const marks = new Set(kept);
+      const LONG = 6 * eps;                        // "long straight" threshold
+      for (let k = 1; k < kept.length - 1; k++) {
+        const r = kept[k];
+        const ang = pTurn(P[kept[k - 1]], P[r], P[kept[k + 1]]);
+        if (ang < TURN_SOFT) continue;
+        let nExtra = ang >= TURN_HARD ? 2 : 1;
+        if (pArc(P, kept[k - 1], r) > LONG) nExtra += 1;   // obstacle-avoidance detail
+        nExtra = Math.min(3, nExtra);
+        for (let j = 1; j <= nExtra; j++) {
+          marks.add(pWalk(P, r, -1, j * eps));
+          marks.add(pWalk(P, r, +1, j * eps));
+        }
+      }
+      selected = Array.from(marks).sort((a, b) => a - b);
+      if (selected.length <= MAX_WP) break;
+      eps *= 1.6;                                  // too many — coarsen and retry
+    }
+    // Drop points closer than the min spacing (but never the final one).
+    const out = [];
+    let last = null;
+    for (let i = 0; i < selected.length; i++) {
+      const p = P[selected[i]], isLast = i === selected.length - 1;
+      if (last && !isLast && pDist(p, last) < MIN_SPACING) continue;
+      out.push({ lat: p.lat, lon: p.lon }); last = p;
+    }
+    return out;
+  }
+  VA.paint = { pathToWaypoints };   // exposed for tests
+
+  // ---- paint UI controller ------------------------------------------------
+  const paintMap = VA.map.leaflet;
+  const paintBar = $("paint-bar");
+  const paintToggle = $("paint-toggle");
+  const paintHint = $("paint-hint");
+  const paintCount = $("paint-count");
+  let paintArmed = false, paintPanning = false, paintDrawing = false;
+  let paintPts = [];              // accumulated latlngs across all strokes
+  let paintLine = null;           // live Leaflet polyline
+  let paintLastClient = null;     // last raw client point (pixel throttle)
+
+  function mapEl() { return document.getElementById("map"); }
+  function paintLatLng(ev) {
+    const rect = paintMap.getContainer().getBoundingClientRect();
+    return paintMap.containerPointToLatLng(L.point(ev.clientX - rect.left, ev.clientY - rect.top));
+  }
+  function metresPerPixel() {
+    const c = paintMap.getSize();
+    const a = paintMap.containerPointToLatLng(L.point(0, c.y / 2));
+    const b = paintMap.containerPointToLatLng(L.point(100, c.y / 2));
+    return haversineM(a.lat, a.lng, b.lat, b.lng) / 100;
+  }
+  function paintDrawLine() {
+    const pts = paintPts.map((p) => [p.lat, p.lon]);
+    if (!paintLine) paintLine = L.polyline(pts, { color: "#1be4ff", weight: 4, opacity: 0.9 }).addTo(paintMap);
+    else paintLine.setLatLngs(pts);
+  }
+  function paintUpdateBar() {
+    if (paintToggle) {
+      paintToggle.textContent = paintPanning ? "🤚 Pan" : "✏️ Draw";
+      paintToggle.classList.toggle("panning", paintPanning);
+    }
+    if (paintHint) {
+      paintHint.textContent = paintPanning
+        ? "Pan / zoom the map, then tap Draw to keep going."
+        : (paintPts.length ? "Drag to keep drawing where you left off." : "Drag on the map to draw your route.");
+    }
+    if (paintCount) paintCount.textContent = paintPts.length ? paintPts.length + " pts" : "";
+  }
+  function paintZoomHandlers(enable) {
+    // Toggle Leaflet's own gestures so Draw mode locks the map and Pan mode frees it.
+    ["dragging", "scrollWheelZoom", "touchZoom", "doubleClickZoom"].forEach((h) => {
+      try { paintMap[h][enable ? "enable" : "disable"](); } catch (e) { /* ignore */ }
+    });
+  }
+  function paintSetPanning(on) {
+    paintPanning = !!on;
+    if (paintPanning) {
+      paintDrawing = false;
+      mapEl().classList.remove("painting");
+      paintZoomHandlers(true);      // free the map to pan / zoom
+    } else {
+      mapEl().classList.add("painting");
+      paintZoomHandlers(false);     // lock the map so a drag paints
+    }
+    paintUpdateBar();
+  }
+
+  function onPaintDown(ev) {
+    if (!paintArmed || paintPanning) return;
+    if (ev.button !== undefined && ev.button !== 0) return;   // left / primary only
+    ev.preventDefault();
+    paintDrawing = true;
+    paintLastClient = { x: ev.clientX, y: ev.clientY };
+    paintPts.push(paintLatLng(ev));
+    paintDrawLine(); paintUpdateBar();
+  }
+  function onPaintMove(ev) {
+    if (!paintDrawing) return;
+    if (paintLastClient && Math.hypot(ev.clientX - paintLastClient.x, ev.clientY - paintLastClient.y) < 3) return;
+    paintLastClient = { x: ev.clientX, y: ev.clientY };
+    paintPts.push(paintLatLng(ev));
+    paintDrawLine(); paintUpdateBar();
+  }
+  function onPaintUp() { paintDrawing = false; }   // pause; the drawn path is kept
+
+  function enterPaint() {
+    if (paintArmed) return;
+    setWpArmed(false); setGotoArmed(false);        // paint owns the map alone
+    paintArmed = true; paintPts = []; paintDrawing = false;
+    if (paintLine) { paintMap.removeLayer(paintLine); paintLine = null; }
+    if (paintBar) paintBar.classList.remove("hidden");
+    if (VA.sheet && VA.sheet.collapse) VA.sheet.collapse();   // clear the map to draw on
+    const c = paintMap.getContainer();
+    c.addEventListener("pointerdown", onPaintDown);
+    c.addEventListener("pointermove", onPaintMove);
+    c.addEventListener("pointerup", onPaintUp);
+    c.addEventListener("pointercancel", onPaintUp);
+    paintSetPanning(false);                         // start in Draw mode
+  }
+  function exitPaint() {
+    if (!paintArmed) return;
+    paintArmed = false; paintDrawing = false;
+    const c = paintMap.getContainer();
+    c.removeEventListener("pointerdown", onPaintDown);
+    c.removeEventListener("pointermove", onPaintMove);
+    c.removeEventListener("pointerup", onPaintUp);
+    c.removeEventListener("pointercancel", onPaintUp);
+    mapEl().classList.remove("painting");
+    paintZoomHandlers(true);                        // restore normal map gestures
+    if (paintLine) { paintMap.removeLayer(paintLine); paintLine = null; }
+    if (paintBar) paintBar.classList.add("hidden");
+  }
+  function finishPaint() {
+    if (paintPts.length < 2) {
+      if (VA.toast) VA.toast("Draw a line on the map first, then tap Finished.");
+      return;
+    }
+    const wps = pathToWaypoints(paintPts, metresPerPixel())
+      .map((w, i) => ({ name: "WP" + (i + 1), lat: w.lat, lon: w.lon }));
+    exitPaint();
+    VA.map.setPending(wps); renderWpList(); setWpArmed(false);
+    if (tightBox) tightBox.checked = true;   // a hand-drawn line is traced tightly by default
+    if (VA.sheet && VA.sheet.reveal) VA.sheet.reveal("mid");   // show the list to review
+    if (VA.toast) VA.toast(wps.length + " waypoints from your line — review, then Start route.");
+  }
+
+  if (paintToggle) paintToggle.addEventListener("click", () => paintSetPanning(!paintPanning));
+  const paintBtn = $("wp-paint");
+  if (paintBtn) paintBtn.addEventListener("click", enterPaint);
+  const paintFinishBtn = $("paint-finish");
+  if (paintFinishBtn) paintFinishBtn.addEventListener("click", finishPaint);
+  const paintCancelBtn = $("paint-cancel");
+  if (paintCancelBtn) paintCancelBtn.addEventListener("click", exitPaint);
 
   // Render the (empty) waypoint list once at startup.
   renderWpList();

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -3106,19 +3106,24 @@ body.mobile .dock button.info-dot { min-height: 28px; }
 .paint-bar.hidden { display: none; }
 .paint-hint { color: var(--muted); font-size: 12px; }
 .paint-count { color: var(--accent); font: 700 12px var(--font-num); }
-.paint-toggle, .paint-finish, .paint-cancel {
+.paint-toggle, .paint-undo, .paint-finish, .paint-cancel {
   flex-shrink: 0; padding: 7px 13px; border-radius: 9px; cursor: pointer;
   border: 1px solid var(--line); background: transparent; color: var(--text);
   font: 700 12px var(--font-display); letter-spacing: 0.03em;
 }
 .paint-toggle { border-color: var(--accent); color: var(--accent); min-width: 84px; }
+.paint-undo:disabled { opacity: 0.4; cursor: default; }
+.paint-undo:not(:disabled):hover { background: rgba(var(--accent-rgb), 0.1); }
 .paint-toggle.panning { border-color: var(--line); color: var(--text); }
 .paint-actions { display: flex; gap: 8px; margin-left: 4px; }
 .paint-finish { border-color: var(--accent); color: var(--accent); background: rgba(var(--accent-rgb), 0.14); }
 .paint-cancel:hover, .paint-toggle:hover { background: rgba(var(--accent-rgb), 0.1); }
 /* While actively drawing, the map shows a crosshair and swallows touch-scroll so
-   a finger-drag paints the line instead of panning the page. */
-#map.painting, #map.painting .leaflet-container { cursor: crosshair; touch-action: none; }
+   a finger-drag paints the line instead of panning the page. user-select /
+   user-drag off stop a mouse-drag over the tile <img>s from starting a native
+   image-drag or text selection that would eat the stroke. */
+#map.painting, #map.painting .leaflet-container { cursor: crosshair; touch-action: none; -webkit-user-select: none; user-select: none; }
+#map.painting img { -webkit-user-drag: none; user-drag: none; pointer-events: none; }
 
 /* ---- Peek-echo: collapsed sheet head flips red during a drag alarm (item 21).
    The ctx cell already reddens via #si-ctx[data-ctx="alarm"]; this reinforces

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -3093,6 +3093,33 @@ body.mobile .dock button.info-dot { min-height: 28px; }
 #arm-banner-done.hidden { display: none; }
 #arm-banner-cancel:hover { background: rgba(var(--accent-rgb), 0.1); }
 
+/* ---- Paint-route toolbar (free-hand route drawing) ---- */
+.paint-bar {
+  position: fixed; left: 50%; bottom: 24px; transform: translateX(-50%);
+  z-index: 1600; display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  justify-content: center; max-width: calc(100vw - 24px);
+  padding: 8px 10px 8px 12px; border-radius: 14px;
+  background: var(--glass-solid); border: 1px solid var(--accent); box-shadow: var(--shadow);
+  -webkit-backdrop-filter: blur(14px); backdrop-filter: blur(14px);
+  font: 600 13px var(--font-display); color: var(--text);
+}
+.paint-bar.hidden { display: none; }
+.paint-hint { color: var(--muted); font-size: 12px; }
+.paint-count { color: var(--accent); font: 700 12px var(--font-num); }
+.paint-toggle, .paint-finish, .paint-cancel {
+  flex-shrink: 0; padding: 7px 13px; border-radius: 9px; cursor: pointer;
+  border: 1px solid var(--line); background: transparent; color: var(--text);
+  font: 700 12px var(--font-display); letter-spacing: 0.03em;
+}
+.paint-toggle { border-color: var(--accent); color: var(--accent); min-width: 84px; }
+.paint-toggle.panning { border-color: var(--line); color: var(--text); }
+.paint-actions { display: flex; gap: 8px; margin-left: 4px; }
+.paint-finish { border-color: var(--accent); color: var(--accent); background: rgba(var(--accent-rgb), 0.14); }
+.paint-cancel:hover, .paint-toggle:hover { background: rgba(var(--accent-rgb), 0.1); }
+/* While actively drawing, the map shows a crosshair and swallows touch-scroll so
+   a finger-drag paints the line instead of panning the page. */
+#map.painting, #map.painting .leaflet-container { cursor: crosshair; touch-action: none; }
+
 /* ---- Peek-echo: collapsed sheet head flips red during a drag alarm (item 21).
    The ctx cell already reddens via #si-ctx[data-ctx="alarm"]; this reinforces
    the whole head so the peek reads as an alarm at a glance. ---- */

--- a/tests/test_route_trace_tight.py
+++ b/tests/test_route_trace_tight.py
@@ -1,0 +1,117 @@
+"""Trace-tightly routes (hand-drawn "paint" routes and any exact-shape route).
+
+The ``trace_tight`` goto/load_route flag makes WaypointMode use a much smaller
+arrival radius so the boat HUGS each corner instead of turning early and cutting
+inside it. Two things must hold:
+
+  1. the flag is plumbed onto the state (fresh goto, load_route, pause/resume);
+  2. it demonstrably hugs a corner closer than the normal radius, while STILL
+     completing the route (the abeam perpendicular-pass gate keeps the tight
+     radius from stalling the boat when GPS noise/drift holds it just outside).
+"""
+
+from __future__ import annotations
+
+import math
+
+from vanchor.controller.controller import Controller
+from vanchor.core.geo import haversine_m
+from vanchor.core.models import ControlModeName, GeoPoint
+from vanchor.core.state import NavigationState
+from vanchor.sim.devices import SimMotorController
+
+from harness import Harness
+
+
+def _ctl():
+    state = NavigationState()
+    return Controller(state, SimMotorController()), state
+
+
+def _wps(n=3):
+    return [{"name": f"W{i}", "lat": 59.0 + i * 0.001, "lon": 18.0} for i in range(n)]
+
+
+# --- command plumbing ------------------------------------------------------ #
+
+def test_goto_sets_and_defaults_trace_tight():
+    ctl, state = _ctl()
+    ctl.handle_command({"type": "goto", "waypoints": _wps()})
+    assert state.route_trace_tight is False          # default off
+    ctl.handle_command({"type": "goto", "waypoints": _wps(), "trace_tight": True})
+    assert state.route_trace_tight is True
+
+
+def test_load_route_sets_trace_tight():
+    ctl, state = _ctl()
+    state.waypoints = []  # load_route expects waypoints already placed; empty is fine here
+    ctl.handle_command({"type": "load_route", "trace_tight": True})
+    assert state.route_trace_tight is True
+
+
+def test_pause_resume_preserves_trace_tight():
+    ctl, state = _ctl()
+    ctl.handle_command({"type": "goto", "waypoints": _wps(), "trace_tight": True})
+    ctl.handle_command({"type": "pause_nav"})
+    assert state.mode == ControlModeName.ANCHOR_HOLD
+    ctl.handle_command({"type": "resume_nav"})
+    assert state.mode == ControlModeName.WAYPOINT
+    assert state.route_trace_tight is True
+
+
+# --- closed-loop corner behaviour ------------------------------------------ #
+
+_LAT, _LON = 59.3293, 18.0686
+_MLAT = 111320.0
+_MLON = 111320.0 * math.cos(math.radians(_LAT))
+
+
+def _off(base: GeoPoint, east_m: float, north_m: float) -> GeoPoint:
+    return GeoPoint(base.lat + north_m / _MLAT, base.lon + east_m / _MLON)
+
+
+def _run_corner(tight: bool):
+    """Drive a straight leg into a 90° corner; return (closest approach to the
+    corner apex, route_complete)."""
+    a = GeoPoint(_LAT, _LON)
+    b = _off(a, 120.0, 0.0)       # 120 m east — the corner apex
+    c = _off(a, 120.0, 120.0)     # then 120 m north — a 90° left turn
+    h = Harness(start=a, model="fossen")
+    h.sim.truth().heading_deg = 90.0   # pointed straight down the first leg
+    cmd = {
+        "type": "goto",
+        "waypoints": [
+            {"name": "B", "lat": b.lat, "lon": b.lon},
+            {"name": "C", "lat": c.lat, "lon": c.lon},
+        ],
+        "throttle": 0.6,
+    }
+    if tight:
+        cmd["trace_tight"] = True
+    h.command(cmd)
+
+    dt = h.physics_dt
+    next_gps = next_compass = next_ctrl = 0.0
+    min_to_apex = 1e9
+    t = 0.0
+    while t < 360.0:
+        h.sim.step(dt)
+        if t >= next_gps:
+            h.nav.handle_sentence(h.gps.sample(h.sim.truth())); next_gps += 1.0 / h.gps_hz
+        if t >= next_compass:
+            h.nav.handle_sentence(h.compass.sample(h.sim.truth())); next_compass += 1.0 / h.compass_hz
+        if t >= next_ctrl:
+            h.controller.control_tick(1.0 / h.control_hz); next_ctrl += 1.0 / h.control_hz
+        min_to_apex = min(min_to_apex, haversine_m(h.sim.truth().point, b))
+        t += dt
+    return min_to_apex, h.state.route_complete
+
+
+def test_trace_tight_hugs_corner_and_completes():
+    normal, normal_done = _run_corner(tight=False)
+    tight, tight_done = _run_corner(tight=True)
+    # Both must finish — a tight radius must not wedge the route.
+    assert normal_done and tight_done
+    # Tight tracing passes closer to the apex (hugs the corner instead of cutting).
+    assert tight < normal
+    assert tight < 0.5          # essentially reaches the corner


### PR DESCRIPTION
## Summary

Adds a **Paint a route** tool to Route mode and a **trace-tightly** corner-hugging
option for waypoint routes.

### Paint a route (free-hand)
- Tap **🖌 Paint a route**, drag on the map to draw a continuous line, tap
  **Finished** → it becomes waypoints.
- Always-on toolbar: **Draw / Pan** toggle (pause to pan/zoom, resume from where
  you stopped), **↶ Undo** (drop the last stroke), and always-visible
  **Finished** / **Cancel**.
- `VA.paint.pathToWaypoints` (pure, tested): RDP simplification + curvature
  densification — straights collapse, turns keep shape, and a turn *after a long
  straight* gets extra detail (a deliberate swerve is usually dodging an
  obstacle).

### Trace tightly (hug corners)
- Per-route flag (`state.route_trace_tight`, panel checkbox, auto-on for painted
  routes) shrinks `WaypointMode`'s arrival radius (~5 m → ~1.5 m) so corners are
  hugged, not cut. The abeam perpendicular gate keeps the normal radius so a tight
  route can't stall on GPS noise/drift.

A full continuous path-tracker (pure-pursuit) was scoped as the follow-up:
AlexAsplund/Vanchor#35.

## Testing
- `python -m pytest -q` green (2137 passed); new `tests/test_route_trace_tight.py`
  (flag plumbing + a closed-loop fossen corner sim: apex approach ~1.3 m → ~0 m,
  both routes complete).
- e2e smoke **28/28**, incl. actually drawing with real PointerEvents (two strokes
  + pan-toggle resume + undo + Finish → waypoints), no console errors.
- All static JS passes `node --check`.

## Notes
- Fixes a `.lon`/`.lng` bug where the drawn line never rendered; the smoke now
  draws for real so it can't regress.
- No service-worker bump needed (the SW cache name is an auto content-hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
