### PR TITLE
docs: move roadmap to GitHub issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,24 @@ guide):
   keep internal `.md` links valid.
 - **`docs/api/` is generated** by `make docs` — don't hand-edit it.
 
-## 5. Verify before done
+## 5. The roadmap lives in GitHub issues
+
+Planned/future work is tracked as **GitHub issues labelled `roadmap`** (plus an
+area label: `adoption`, `control-ml`, `safety`, `hardware`, `sim`), not in a
+markdown file. [`docs/roadmap.md`](docs/roadmap.md) is only a pointer.
+
+- **See what's next:** `gh issue list --label roadmap` (filter by area, e.g.
+  `--label safety`).
+- **Propose work:** `gh issue create` and label it `roadmap` + an area label.
+  State what, why, acceptance, and the files it touches — concretely.
+- **When it ships:** close the issue and add a dated [`CHANGELOG`](CHANGELOG.md)
+  entry. Don't reintroduce a roadmap list in the docs.
+
+Design detail for two big areas still lives in docs the issues link to:
+[`docs/simulator.md`](docs/simulator.md) (sim-vs-real gaps) and
+[`docs/extension-packs.md`](docs/extension-packs.md) (the pack system).
+
+## 6. Verify before done
 
 `python -m pytest -q` green, `node --check` any JS you touched, and for UI work a
 headless Playwright pass (no console errors). See the testing guide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,8 @@ The interfaces the front end and integrations build against.
 
 ## Project
 
-- **[roadmap.md](roadmap.md)** — what's next (done work lives in the CHANGELOG).
+- **[roadmap.md](roadmap.md)** — pointer to the roadmap, which now lives in
+  GitHub issues (label `roadmap`); done work lives in the CHANGELOG.
 - **[assumptions.md](assumptions.md)** — the deliberate simplifications taken.
 - **[extension-packs.md](extension-packs.md)** — design notes for a future
   HACS-style pack system (not yet built).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,80 +1,34 @@
 # Roadmap
 
-What's next. For what's **done**, see the [CHANGELOG](../CHANGELOG.md) and
+**The roadmap now lives in GitHub issues**, not this file. Planned work is tracked
+as issues labelled [`roadmap`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap),
+grouped by area label:
+
+| Area | Label |
+|---|---|
+| Adoption / onboarding / UX | [`adoption`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Aadoption) |
+| Control loops, modes, ML anchor | [`control-ml`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Acontrol-ml) |
+| Safety floor, failsafes, robustness | [`safety`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Asafety) |
+| Boards, sensors, motors, bench work | [`hardware`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Ahardware) |
+| Simulator fidelity | [`sim`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Asim) |
+
+For what's **done**, see the [CHANGELOG](../CHANGELOG.md) and
 [FEATURES.md](FEATURES.md) — the original v1.0-alpha roadmap and the 2026-07
 full-project review (Phases 0–7: safety floor, robustness, UI/API, nav/control,
 sim depth, hardware, community groundwork) all shipped.
 
-## Adoption pack — in progress
+## Working with the roadmap
 
-Making Vanchor attractive and easy for new users. Shipped: SD image + supervisor,
-hardware setup wizard, demo mode, push notifications, passive anchor-alarm. Still
-open:
+- **See what's next:** `gh issue list --label roadmap` (add `--label safety`, etc.
+  to filter by area).
+- **Propose work:** open an issue and label it `roadmap` plus an area label. Keep
+  it concrete: what, why, acceptance, and the files it touches.
+- **When it ships:** close the issue and add a dated entry to the
+  [CHANGELOG](../CHANGELOG.md). Don't re-open a roadmap section here.
 
-- **WiFi onboarding** — hotspot-first captive "join your WiFi" page. *(S)*
-- **Guided "first anchor" overlay** — script the magic moment once. *(S)*
-- **Simple/advanced UI split** — map + anchor + take-me-here + STOP by default;
-  expert features behind a toggle. *(M)*
-- **Spot memory** — named spots with depth/notes; anchor-at / route-to. *(S)*
-- **Weather overlay + "holdable?" check** — forecast vs the trained wind cap. *(M)*
-- **One-tap trolling presets**; **metric/imperial + i18n**; **in-UI trip replay
-  polish**. *(S each)*
-- **NMEA-0183 output over WiFi** — feed fish finders / OpenCPN / Navionics. *(M)*
-- **Pre-departure check screen**; **battery endurance estimate** (INA226 +
-  thrust history). *(S / M)*
-- **Depth-chart sharing** (cmapper export/import exists; community library later)
-  and the **driver-pack install UI** — both lead into [extension
-  packs](extension-packs.md). *(M)*
+Two areas keep their design detail in dedicated docs (the issues link to them):
 
-## Control & ML
-
-- **Reverse dead-time retrain (L).** The anchor-policy training env models
-  steering slew but not the motor's 1 s forward↔reverse dead-time, so Smart/Leif
-  over-reverse and the interlock blocks ~45% of their commands. Shipped a
-  deployment mitigation (output low-pass, `thrust_tau_s`); the real fix is to add
-  the dead-time + a reversal penalty to `experiments/anchor_policy/env.py`,
-  regenerate, and re-run the promote gauntlet. See [anchor-ml.md](anchor-ml.md).
-- **`sqrt`-shaped anchor-hold position term** and **min-effective-thrust /
-  deadband compensation** — both cheap to prototype in the Fossen sim. *(S)*
-- **Background gyro-bias learning**, persisted across boots; **passive
-  self-improving compass cal** with a health meter. *(S / M)*
-
-## Safety & robustness
-
-- **PWA-heartbeat failsafe** defaulting to HOLD (not just serial-link loss), with
-  the trigger reason in the alarm/push. *(S)*
-- **Uniform `FailsafeAction {STOP, HOLD, RETURN}`**, one per trigger, default
-  HOLD. *(M)*
-- **Brownout story** — Pi reset → MCU link-loss failsafe (never open-throttle),
-  documented + tested. *(S)*
-- **SITL-style regression** — assert the shipped control stack at real-time in CI;
-  **deterministic session replay** through the real stack from recordings. *(M)*
-- **Firmware heartbeat round-trip** (sequence echoed in the `A` line) so the Pi
-  detects one-way serial failure. *(S)*
-
-## Hardware
-
-- **Steering-head hardware selection** — RC servo (MVP) vs custom worm gearbox;
-  neither is bench-verified yet. See [custom-hardware.md](custom-hardware.md).
-- **Interactive magnetometer calibration** — the 360° hard/soft-iron fit exists
-  but the raw mag vector isn't plumbed into the navigator (HWT901B emits fused
-  heading); surface it to close the loop. *(S)*
-- **Hardware watchdog chain** — Pi heartbeat GPIO → external relay on the motor
-  supply (covers a Pi hard-hang the firmware watchdog can't). *(M)*
-- **Battery / driver / watchdog health** — configurable via YAML now; expose in
-  the Settings UI + telemetry. *(S)*
-- Bench-verify: N2K + SocketCAN, the split-channel line protocols, the helm PCB
-  I²C tunnel, and HIL (bench Arduino) tests.
-
-## Sim fidelity
-
-The known sim-vs-real gaps (steering-head lag, prop spin-up, sim steering
-feedback, sea-state/IMU model, realistic GPS/compass noise) are tracked in
-[simulator.md](simulator.md) — most need bench/water data to close.
-
-## Future — extension packs
-
-A HACS-style way to share drivers, views, tunes, charts, and scenarios without
-editing core. Designed, not built; the keystone is the versioned driver API +
-capability object. Design and the non-negotiable safety floor in
-[extension-packs.md](extension-packs.md).
+- **Simulator fidelity** — the known sim-vs-real gaps live in
+  [simulator.md](simulator.md).
+- **Extension packs** — the HACS-style sharing design lives in
+  [extension-packs.md](extension-packs.md).


### PR DESCRIPTION
Moves the roadmap out of `docs/roadmap.md` and into **GitHub issues** labelled
[`roadmap`](https://github.com/AlexAsplund/Vanchor/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap)
(26 issues, migrated 1:1) with area labels `adoption` / `control-ml` / `safety` /
`hardware` / `sim`.

- `docs/roadmap.md` → a short pointer (label links + working rules).
- `AGENTS.md` §5 documents the workflow: `gh issue list --label roadmap` to see
  what's next; open a labelled issue to propose work; close + CHANGELOG on ship.
- `docs/README.md` bullet updated.

Includes the new feature issue #35 (continuous path-tracking / pure-pursuit
controller — the paint-route follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
