### PR TITLE
docs: PR template (tests required when applicable) + conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Keep this short. Delete any section that doesn't apply. -->
+
+## What & why
+
+<!-- One or two lines: what changes, and why. -->
+
+Linking an issue is **optional but encouraged** (never required):
+`Closes #123` / `Refs #123`. Roadmap work should reference its `roadmap` issue.
+
+## Tests
+
+<!-- Required to acknowledge. Tests are part of the change: any new behaviour,
+     bug fix, or edge case must add or update tests that would fail without it. -->
+
+- [ ] Tests added/updated for this change, **or** not applicable because:
+      <!-- e.g. docs-only, comment/typo, pure refactor already covered -->
+
+## Checklist
+
+- [ ] `python -m pytest -q` green locally
+- [ ] `ruff check src tests` clean; `node --check` on any JS touched
+- [ ] Docs updated (`docs/`, `docs/llms/*`, `CHANGELOG.md`) if behaviour changed
+- [ ] Branch is up to date with `main` (the required checks will run on the PR)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,18 @@ Protection also has **strict** mode on: a PR must be **up to date with `main`**
 before it merges (rebase/merge `main` in if it moved). No reviews are required
 (solo maintainer).
 
+**Tests are part of the change.** Every PR that changes behaviour — a new
+feature, a bug fix, a handled edge case — must **add or update tests** that would
+fail without the change. If a change genuinely isn't testable (docs, comments, a
+pure refactor already covered), say so in the PR's *Tests* section. The
+[`.github/pull_request_template.md`](.github/pull_request_template.md) checklist
+makes this explicit on every PR.
+
+**Issues are optional for a PR** — an issue is *never* required to open a PR, but
+linking or opening one is **encouraged** for anything non-trivial (`Closes #N`),
+and roadmap work should reference its [`roadmap`](#5-the-roadmap-lives-in-github-issues)
+issue.
+
 **Flow:**
 ```bash
 git checkout -b feat/<slug>          # or fix/… , docs/…


### PR DESCRIPTION
## What & why

Adds `.github/pull_request_template.md` and documents PR/issue conventions in
AGENTS.md §6: tests are part of any behaviour change (or state why N/A), and a
linked issue is optional but encouraged.

## Tests

- [x] Not applicable — PR-template + docs only (no code changed).

## Checklist

- [x] `python -m pytest -q` unaffected (no code changed)
- [x] Docs updated (AGENTS.md §6)
- [x] Branch up to date with `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
