### PR TITLE
refactor(app): extract TripService to runtime/trips.py (#78)

### DIFF
--- a/src/vanchor/app.py
+++ b/src/vanchor/app.py
@@ -89,6 +89,7 @@ from .runtime.nav_glue import NavGlue  # noqa: E402
 from .runtime.safety_runtime import SafetyRuntime  # noqa: E402
 from .runtime.sessions import SessionService  # noqa: E402
 from .runtime.telemetry import TelemetryBuilder  # noqa: E402
+from .runtime.trips import TripService  # noqa: E402
 
 logger = logging.getLogger("vanchor.app")
 
@@ -296,6 +297,10 @@ class Runtime:
         # nav-glue methods live in NavGlue; Runtime delegates via shims or
         # direct repoints.
         self._nav = NavGlue(self)
+        # Trip-recorder cluster (issue #78): trip_start, trip_stop, trip_list,
+        # trip_get, trip_gpx, trip_delete all live in TripService; Runtime
+        # delegates via shims (server.py + tests call Runtime methods).
+        self._trips = TripService(self)
         # Black-box / backup / replay cluster (issue #77): _build_blackbox,
         # _install_blackbox_hook, blackbox_dumps, blackbox_path_for,
         # create_backup, restore_backup, start_replay, stop_replay all live in
@@ -1421,29 +1426,31 @@ class Runtime:
         return result
 
     # ------------------------------------------------------------------ #
-    # Trip log (#66)
+    # Trip log (#66) — shims → TripService (issue #78)
     # ------------------------------------------------------------------ #
     def trip_start(self, name: str | None = None) -> dict:
-        """Manually start a trip (overrides/replaces any active one)."""
-        trip = self.trip.start(name, self._now_fn())
-        return self.trip.snapshot(self._now_fn())
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_start(name)
 
     def trip_stop(self) -> dict:
-        """Manually stop + persist the active trip. No-op when none is active."""
-        self.trip.stop(self._now_fn())
-        return self.trip.snapshot(self._now_fn())
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_stop()
 
     def trip_list(self) -> list[dict]:
-        return self.trip.list_trips()
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_list()
 
     def trip_get(self, trip_id: str) -> dict | None:
-        return self.trip.get_trip(trip_id)
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_get(trip_id)
 
     def trip_gpx(self, trip_id: str) -> str | None:
-        return self.trip.gpx(trip_id)
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_gpx(trip_id)
 
     def trip_delete(self, trip_id: str) -> bool:
-        return self.trip.delete_trip(trip_id)
+        """Shim → TripService (issue #78)."""
+        return self._trips.trip_delete(trip_id)
 
     # ------------------------------------------------------------------ #
     # Battery (#60)

--- a/src/vanchor/runtime/trips.py
+++ b/src/vanchor/runtime/trips.py
@@ -1,0 +1,47 @@
+"""Trip-recorder cluster extracted from Runtime (issue #78).
+
+The 6 methods that handle trip management (start, stop, list, get, GPX export,
+delete) live here.  ``TripService`` holds a back-reference to ``Runtime`` via
+``self._rt`` for shared state that remains on Runtime (``trip``, ``_now_fn``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("vanchor.app")
+
+
+class TripService:
+    """Trip-recorder cluster -- split out of Runtime."""
+
+    def __init__(self, rt) -> None:
+        self._rt = rt   # back-reference to Runtime for shared state
+
+    # ------------------------------------------------------------------ #
+    # Trip log (#66)
+    # ------------------------------------------------------------------ #
+
+    def trip_start(self, name: str | None = None) -> dict:
+        """Manually start a trip (overrides/replaces any active one)."""
+        rt = self._rt
+        trip = rt.trip.start(name, rt._now_fn())
+        return rt.trip.snapshot(rt._now_fn())
+
+    def trip_stop(self) -> dict:
+        """Manually stop + persist the active trip. No-op when none is active."""
+        rt = self._rt
+        rt.trip.stop(rt._now_fn())
+        return rt.trip.snapshot(rt._now_fn())
+
+    def trip_list(self) -> list[dict]:
+        return self._rt.trip.list_trips()
+
+    def trip_get(self, trip_id: str) -> dict | None:
+        return self._rt.trip.get_trip(trip_id)
+
+    def trip_gpx(self, trip_id: str) -> str | None:
+        return self._rt.trip.gpx(trip_id)
+
+    def trip_delete(self, trip_id: str) -> bool:
+        return self._rt.trip.delete_trip(trip_id)


### PR DESCRIPTION
## Summary

- Moves the 6 trip-recorder methods (`trip_start`, `trip_stop`, `trip_list`, `trip_get`, `trip_gpx`, `trip_delete`) from `Runtime` into a new `TripService` collaborator at `src/vanchor/runtime/trips.py`
- Follows the established `NavGlue` pattern: `self._rt` back-reference, `logger = logging.getLogger("vanchor.app")`, construct + delegate
- All 6 Runtime methods become shims (`→ TripService (issue #78)`) — `server.py`, `tests/`, and `commands.py` callers continue to work unchanged
- `self._trips = TripService(self)` added in `Runtime.__init__` after `self._nav`

## Shimmed vs repointed

- **Shimmed (6)**: `trip_start`, `trip_stop`, `trip_list`, `trip_get`, `trip_gpx`, `trip_delete` — all called externally via `server.py`, `tests/test_trip.py`, and `runtime/commands.py`
- **Repointed (0)**: no internal-only callers; all callers go through the Runtime shim

## Test plan

- [x] `python -c "import vanchor.app; import vanchor.runtime.trips"` — no cycle
- [x] `ruff check src tests` — clean
- [x] `python -m pytest -q` — 2137 passed, 6 skipped

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D1jaT7bgAo4phgKqSYCtT