### PR TITLE
refactor(ext): extract vanchor.ext kernel; drivers + connectors consume discover (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Extension kernel — `vanchor.ext` (#96, part of #95).** Extracted the shared
+  plug-in machinery into a new leaf package: `discover(group)` (the one home for
+  entry-point discovery, moved verbatim from the two copy-pasted
+  `_iter_entry_points` helpers), plus scaffolding for future seams — a generic
+  typed `Registry` (log-and-skip on duplicate name / API-version mismatch), a
+  frozen hashable `Manifest`, and a narrow `Capability` marker base. Drivers and
+  connectors now consume `discover`; their bespoke registries are unchanged
+  (migration onto `Registry` is follow-up). Behaviour-preserving — the plug-in
+  groups, public `register_*` functions, and discovery behaviour are identical.
+
 - **Path tracking — continuous pure-pursuit route follower (#35).** An opt-in
   alternative to the leg-by-leg waypoint steering, selectable via a **Path
   tracking (follow the line)** switch in the route panel. It treats the whole

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -21,19 +21,30 @@ extract it once and apply it to *every* part.
 
 ## The extension kernel (`vanchor.ext`)
 
-One small module owns the shared machinery (today `_iter_entry_points` is copy-
-pasted in `hardware/drivers/__init__.py` and `connectors/__init__.py`):
+**Shipped (#96) and consumed by drivers + connectors.** One small leaf package
+(`src/vanchor/ext/`, imports nothing from app/runtime/controller) now owns the
+shared machinery that `_iter_entry_points` was copy-pasted for in
+`hardware/drivers/__init__.py` and `connectors/__init__.py`:
 
 - **`discover(group)`** — entry-point discovery across importlib versions; never
-  raises when zero packs are installed.
-- **`Registry`** — a typed name→factory map with API-version + duplicate checks.
-- **`Manifest`** — name, version, kind, targeted API version, declared
-  capabilities, author (hashable, so consent can key on it).
-- **`Capability`** — the narrow object a plug-in receives instead of `Runtime`.
+  raises when zero packs are installed. **Shipped + consumed:** both driver and
+  connector loaders call `discover(GROUP)`; their local `_iter_entry_points` is
+  gone.
+- **`Registry`** — a typed name→factory map with API-version + duplicate checks
+  (log-and-skip, never raises). **Shipped** as scaffolding; drivers/connectors
+  keep their bespoke registries for now — migrating them onto `Registry` is
+  follow-up.
+- **`Manifest`** — a frozen (hashable, so consent can key on it) dataclass:
+  name, version, kind, targeted API version, declared capabilities, author.
+  **Shipped.**
+- **`Capability`** — the narrow marker base a plug-in receives instead of
+  `Runtime`. **Shipped** (minimal; per-seam verbs land on subclasses).
 - **Lifecycle** — `on_load(kernel)`, `on_start`, `on_stop`, `on_config_change`.
+  *Planned.*
 
-Drivers and connectors become the first two *consumers* of the kernel rather than
-two bespoke implementations.
+Drivers and connectors are the first two *consumers* of the kernel (via
+`discover`) rather than two bespoke discovery implementations; full migration of
+their registries to `Registry` remains follow-up.
 
 ## The seams — a plug-in group for every part
 

--- a/src/vanchor/connectors/__init__.py
+++ b/src/vanchor/connectors/__init__.py
@@ -31,6 +31,8 @@ import importlib
 import logging
 import pkgutil
 
+from ..ext import discover
+
 logger = logging.getLogger("vanchor.connectors")
 
 # Entry-point group a pip-installed connector pack registers under.
@@ -39,36 +41,10 @@ CONNECTOR_ENTRY_POINT_GROUP = "vanchor.connectors"
 _loaded = False
 
 
-def _iter_entry_points(group: str):
-    """Yield entry points in ``group`` across importlib.metadata API versions.
-
-    A quiet no-op when metadata is unavailable — zero installed packs (the common
-    case) must never raise."""
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:  # pragma: no cover - importlib.metadata is stdlib on 3.11+
-        return
-    try:
-        eps = entry_points()
-    except Exception as exc:  # noqa: BLE001 - never let discovery crash startup
-        logger.debug("entry-point discovery unavailable: %s", exc)
-        return
-    try:
-        selected = (
-            eps.select(group=group)
-            if hasattr(eps, "select")
-            else eps.get(group, [])  # type: ignore[attr-defined]  # older importlib.metadata
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("entry-point discovery failed: %s", exc)
-        return
-    yield from selected
-
-
 def _load_pack_connectors() -> None:
     """Discover + register connectors from installed packs via entry points. A pack
     that fails to load or register is logged and skipped; no-op with no packs."""
-    for ep in _iter_entry_points(CONNECTOR_ENTRY_POINT_GROUP):
+    for ep in discover(CONNECTOR_ENTRY_POINT_GROUP):
         try:
             hook = ep.load()
             if callable(hook):

--- a/src/vanchor/ext/__init__.py
+++ b/src/vanchor/ext/__init__.py
@@ -1,0 +1,23 @@
+"""The extension kernel — shared plug-in machinery for every vanchor seam.
+
+This is the one home for the plug-in *skeleton* that drivers and connectors were
+each re-implementing: **entry-point discovery**, a **typed name→factory
+registry**, a **manifest**, and the narrow **capability** a plug-in receives
+instead of the ``Runtime``. See ``docs/extensibility.md`` ("The extension
+kernel").
+
+``vanchor.ext`` is a **leaf**: it must never import ``app`` / ``runtime`` /
+``controller`` (no import cycle — it sits below every consumer). Drivers and
+connectors are the first two consumers; today they consume :func:`discover`
+while keeping their own bespoke registries (full migration to :class:`Registry`
+is follow-up).
+"""
+
+from __future__ import annotations
+
+from .capability import Capability
+from .discovery import discover
+from .manifest import Manifest
+from .registry import Registry
+
+__all__ = ["Capability", "Manifest", "Registry", "discover"]

--- a/src/vanchor/ext/capability.py
+++ b/src/vanchor/ext/capability.py
@@ -1,0 +1,21 @@
+"""The narrow capability a plug-in receives instead of the ``Runtime``.
+
+:class:`Capability` is the marker base for the narrow object handed to a plug-in
+— the whole point of the safety floor is that a pack talks only to a capability,
+**never** the ``Runtime``, the motor, or the governor. The rich verbs (event
+bus, scheduler, config, routes, telemetry, ui, alarms — see
+``docs/extensibility.md``) land on subclasses as the seams are built; this base
+is deliberately minimal for now.
+"""
+
+from __future__ import annotations
+
+
+class Capability:
+    """Marker base for the narrow object a plug-in is given.
+
+    A plug-in only ever talks to a capability, so core can evolve underneath it
+    and a rogue/hung plug-in degrades safely — it never holds the ``Runtime``,
+    the motor, or the governor. Concrete verbs (bus, scheduler, config, routes,
+    telemetry, ui, alarms) are added by subclasses per seam.
+    """

--- a/src/vanchor/ext/discovery.py
+++ b/src/vanchor/ext/discovery.py
@@ -1,0 +1,38 @@
+"""Entry-point discovery — the one home for finding installed plug-in packs.
+
+:func:`discover` is the verbatim ``_iter_entry_points`` helper that was copy-
+pasted in ``hardware/drivers/__init__.py`` and ``connectors/__init__.py``. It
+yields the entry points in a group across importlib.metadata API versions and is
+a **quiet no-op** when metadata is unavailable or zero packs are installed — it
+must never raise, so a boat with no packs starts exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+logger = logging.getLogger("vanchor.ext")
+
+
+def discover(group: str) -> Iterator:
+    """Yield entry points in ``group`` across importlib.metadata API versions.
+
+    Returns nothing (a quiet no-op) if metadata is unavailable — the common case
+    of zero installed packs must never raise."""
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:  # pragma: no cover - importlib.metadata is stdlib on 3.11+
+        return
+    try:
+        eps = entry_points()
+    except Exception as exc:  # noqa: BLE001 - never let discovery crash startup
+        logger.debug("entry-point discovery unavailable: %s", exc)
+        return
+    # Python 3.12: EntryPoints.select(group=...); older: a dict-like .get(group).
+    try:
+        selected = eps.select(group=group) if hasattr(eps, "select") else eps.get(group, [])
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("entry-point discovery failed: %s", exc)
+        return
+    yield from selected

--- a/src/vanchor/ext/manifest.py
+++ b/src/vanchor/ext/manifest.py
@@ -1,0 +1,31 @@
+"""The plug-in manifest — what a pack declares about itself.
+
+A small, **frozen** (hashable, so consent can key on it) dataclass carrying the
+identity + contract a pack advertises: name, version, kind, the API version it
+targets, its declared capabilities, and author. See ``docs/extensibility.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """What a plug-in pack declares about itself (hashable — consent can key on it).
+
+    * ``name`` — the pack's unique name.
+    * ``version`` — the pack's own version string.
+    * ``kind`` — which seam it plugs into (e.g. ``"driver"`` / ``"connector"``).
+    * ``api_version`` — the seam's API version the pack targets, so core can
+      refuse an incompatible pack rather than mis-build it.
+    * ``capabilities`` — the narrow capabilities it declares it needs.
+    * ``author`` — free-form provenance.
+    """
+
+    name: str
+    version: str
+    kind: str
+    api_version: int
+    capabilities: tuple[str, ...] = ()
+    author: str = ""

--- a/src/vanchor/ext/registry.py
+++ b/src/vanchor/ext/registry.py
@@ -1,0 +1,73 @@
+"""A small, generic, typed name→factory registry.
+
+New scaffolding for future seams. Drivers and connectors keep their bespoke
+registries for now (full migration is follow-up); this is the shared shape they
+will converge on: a ``kind``-scoped, API-versioned map that **logs-and-skips** a
+duplicate name or an API-version mismatch rather than raising — the same
+degrade-safely posture as ``hardware/registry.py`` (a bad pack must never break
+startup).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Generic, TypeVar
+
+from .manifest import Manifest
+
+logger = logging.getLogger("vanchor.ext")
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    """A typed ``name -> factory`` registry scoped to one ``kind`` + API version.
+
+    ``register`` **logs-and-skips** (never raises) on a duplicate name or an
+    ``api_version`` mismatch, so a bad pack degrades safely instead of breaking
+    startup or clobbering a good registration.
+    """
+
+    def __init__(self, kind: str, api_version: int) -> None:
+        self.kind = kind
+        self.api_version = api_version
+        self._factories: dict[str, T] = {}
+        self._manifests: dict[str, Manifest | None] = {}
+
+    def register(
+        self,
+        name: str,
+        factory: T,
+        *,
+        api_version: int | None = None,
+        manifest: Manifest | None = None,
+    ) -> None:
+        """Register ``factory`` under ``name``.
+
+        Skips (logs a warning, no raise) if ``name`` is already registered or if
+        ``api_version`` is given and does not match this registry's version."""
+        if name in self._factories:
+            logger.warning(
+                "%s plug-in %r already registered; skipping duplicate", self.kind, name
+            )
+            return
+        if api_version is not None and api_version != self.api_version:
+            logger.warning(
+                "%s plug-in %r targets API v%s but registry is v%s; skipping",
+                self.kind, name, api_version, self.api_version,
+            )
+            return
+        self._factories[name] = factory
+        self._manifests[name] = manifest
+
+    def get(self, name: str) -> T:
+        """The factory registered under ``name`` (raises ``KeyError`` if absent)."""
+        return self._factories[name]
+
+    def names(self) -> list[str]:
+        """Registered names, stable/sorted."""
+        return sorted(self._factories)
+
+    def all(self) -> dict[str, T]:
+        """A copy of the ``name -> factory`` map."""
+        return dict(self._factories)

--- a/src/vanchor/hardware/drivers/__init__.py
+++ b/src/vanchor/hardware/drivers/__init__.py
@@ -25,6 +25,8 @@ import importlib
 import logging
 import pkgutil
 
+from ...ext import discover
+
 logger = logging.getLogger("vanchor.hardware.drivers")
 
 # Entry-point group a pip-installed driver pack registers under (roadmap #43).
@@ -33,36 +35,13 @@ DRIVER_ENTRY_POINT_GROUP = "vanchor.drivers"
 _loaded = False
 
 
-def _iter_entry_points(group: str):
-    """Yield entry points in ``group`` across importlib.metadata API versions.
-
-    Returns nothing (a quiet no-op) if metadata is unavailable — the common case
-    of zero installed packs must never raise."""
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:  # pragma: no cover - importlib.metadata is stdlib on 3.11+
-        return
-    try:
-        eps = entry_points()
-    except Exception as exc:  # noqa: BLE001 - never let discovery crash startup
-        logger.debug("entry-point discovery unavailable: %s", exc)
-        return
-    # Python 3.12: EntryPoints.select(group=...); older: a dict-like .get(group).
-    try:
-        selected = eps.select(group=group) if hasattr(eps, "select") else eps.get(group, [])
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("entry-point discovery failed: %s", exc)
-        return
-    yield from selected
-
-
 def _load_pack_drivers() -> None:
     """Discover + register drivers from installed packs via entry points.
 
     Each entry point resolves to a callable (a registration hook); we call it so
     the pack registers its driver(s). A pack that fails to load or register is
     logged and skipped. No-op when no packs are installed."""
-    for ep in _iter_entry_points(DRIVER_ENTRY_POINT_GROUP):
+    for ep in discover(DRIVER_ENTRY_POINT_GROUP):
         try:
             hook = ep.load()
             if callable(hook):

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -187,7 +187,7 @@ def test_entry_point_discovery_invokes_pack_hook(monkeypatch):
                 called["ok"] = True
             return hook
 
-    monkeypatch.setattr(drivers, "_iter_entry_points", lambda group: [_FakeEP()])
+    monkeypatch.setattr(drivers, "discover", lambda group: [_FakeEP()])
     try:
         drivers._load_pack_drivers()
         assert called.get("ok") is True
@@ -197,7 +197,7 @@ def test_entry_point_discovery_invokes_pack_hook(monkeypatch):
 
 
 def test_entry_point_discovery_noops_with_no_packs(monkeypatch):
-    monkeypatch.setattr(drivers, "_iter_entry_points", lambda group: [])
+    monkeypatch.setattr(drivers, "discover", lambda group: [])
     drivers._load_pack_drivers()  # must not raise
 
 
@@ -210,10 +210,10 @@ def test_entry_point_discovery_survives_a_broken_pack(monkeypatch):
         def load(self):
             raise RuntimeError("bad pack")
 
-    monkeypatch.setattr(drivers, "_iter_entry_points", lambda group: [_BoomEP()])
+    monkeypatch.setattr(drivers, "discover", lambda group: [_BoomEP()])
     drivers._load_pack_drivers()  # must not raise
 
 
 def test_real_entry_point_iteration_is_safe():
     # With no driver packs installed this must be a quiet no-op (no exception).
-    assert list(drivers._iter_entry_points("vanchor.drivers")) == [] or True
+    assert list(drivers.discover("vanchor.drivers")) == [] or True

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,0 +1,84 @@
+"""Tests for the extension kernel (:mod:`vanchor.ext`).
+
+Covers the three pieces this PR ships as the shared plug-in machinery:
+:func:`discover` (never raises with no packs), :class:`Registry`
+(register/get/names, duplicate + api-version skips), and the :class:`Manifest`
+frozen dataclass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vanchor.ext import Capability, Manifest, Registry, discover
+
+
+# --------------------------------------------------------------------------- #
+# discover
+# --------------------------------------------------------------------------- #
+def test_discover_noops_with_no_packs() -> None:
+    """No packs installed under an unknown group -> a quiet no-op, never raises."""
+    assert list(discover("vanchor._no_such_group_")) == []
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+def test_registry_register_get_names_all() -> None:
+    reg: Registry[object] = Registry("driver", api_version=1)
+    a, b = object(), object()
+    reg.register("alpha", a)
+    reg.register("beta", b)
+    assert reg.get("alpha") is a
+    assert reg.names() == ["alpha", "beta"]   # sorted/stable
+    assert reg.all() == {"alpha": a, "beta": b}
+
+
+def test_registry_duplicate_name_is_skipped_not_raised() -> None:
+    reg: Registry[object] = Registry("driver", api_version=1)
+    first, second = object(), object()
+    reg.register("dup", first)
+    reg.register("dup", second)   # logged + skipped, no raise
+    assert reg.get("dup") is first   # original kept
+
+
+def test_registry_api_version_mismatch_is_skipped() -> None:
+    reg: Registry[object] = Registry("driver", api_version=1)
+    reg.register("mismatch", object(), api_version=2)   # logged + skipped
+    assert "mismatch" not in reg.names()
+    with pytest.raises(KeyError):
+        reg.get("mismatch")
+
+
+def test_registry_matching_api_version_registers() -> None:
+    reg: Registry[object] = Registry("driver", api_version=1)
+    dev = object()
+    reg.register("ok", dev, api_version=1)
+    assert reg.get("ok") is dev
+
+
+# --------------------------------------------------------------------------- #
+# Manifest / Capability
+# --------------------------------------------------------------------------- #
+def test_manifest_fields_and_defaults() -> None:
+    m = Manifest(name="pack", version="1.2.3", kind="driver", api_version=1)
+    assert (m.name, m.version, m.kind, m.api_version) == ("pack", "1.2.3", "driver", 1)
+    assert m.capabilities == ()
+    assert m.author == ""
+
+
+def test_manifest_is_frozen_and_hashable() -> None:
+    m = Manifest(
+        name="pack", version="1", kind="connector", api_version=2,
+        capabilities=("read",), author="alex",
+    )
+    assert hash(m) == hash(m)   # hashable (consent can key on it)
+    with pytest.raises(Exception):
+        m.name = "other"  # type: ignore[misc]  # frozen
+
+
+def test_capability_is_a_marker_base() -> None:
+    class MyCap(Capability):
+        pass
+
+    assert isinstance(MyCap(), Capability)


### PR DESCRIPTION
## What & why

Keystone of the extensibility epic (#95): extract the shared plug-in machinery into a new `vanchor.ext` **leaf** kernel and make the existing drivers + connectors consume it. **Behaviour-preserving** — the public plug-in surface (entry-point groups, `register_*` functions, discovery behaviour) is unchanged.

New package `src/vanchor/ext/`:

- **`discover(group)`** — the one home for entry-point discovery, moved **verbatim** from the two identical `_iter_entry_points` helpers in `hardware/drivers/__init__.py` and `connectors/__init__.py` (same robustness: quiet no-op with zero packs, never raises, same debug logging).
- **`Registry`** — generic typed `name -> factory` map; `register` **logs-and-skips** on a duplicate name or an api-version mismatch (mirrors `hardware/registry.py`). Scaffolding for future seams; **not** adopted by drivers/connectors in this PR.
- **`Manifest`** — frozen (hashable) dataclass: name, version, kind, api_version, capabilities, author.
- **`Capability`** — narrow marker base a plug-in receives instead of `Runtime`.

Drivers + connectors now `from ..ext import discover` and call `discover(GROUP)`; their local `_iter_entry_points` is deleted. `vanchor.ext` imports nothing from app/runtime/controller (verified: no import cycle).

`docs/extensibility.md` "extension kernel" section updated to mark `vanchor.ext` shipped + consumed by drivers + connectors (full registry migration remains follow-up).

Closes #96. Part of #95.

## Tests

- [x] Tests added/updated for this change — new `tests/test_ext.py` (discover no-op, Registry register/get/names/duplicate-skip/api-mismatch-skip, Manifest fields/frozen, Capability marker); `tests/test_device_registry.py` monkeypatch targets updated (`_iter_entry_points` -> `discover`).

## Checklist

- [x] `python -m pytest -q` green locally (2151 passed, 6 skipped)
- [x] `ruff check src tests` clean
- [x] Docs updated (`docs/extensibility.md`, `CHANGELOG.md`)
- [x] Branch based on latest `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D1jaT7bgAo4phgKqSYCtT