### PR TITLE
fix(nav): path-tracking acquires the route start (shoreline routes)

### DIFF
--- a/src/vanchor/controller/modes.py
+++ b/src/vanchor/controller/modes.py
@@ -962,29 +962,57 @@ class PathTrackMode(ControlMode):
         heading = normalize_deg(bearing - correction + crab)
         return GuidedSetpoint(target_heading=heading, thrust=self.config.throttle)
 
+    def _seg_index(self, cum, s):
+        for i in range(len(cum) - 1):
+            if s <= cum[i + 1]:
+                return i
+        return max(0, len(cum) - 2)
+
     def _project(self, P, seglen, cum, total, loop):
-        """Nearest point on the polyline to the boat (origin), constrained to a
-        forward window from the cursor so the along-track cursor advances
-        monotonically (robust to loops / self-crossings)."""
-        window = max(2.5 * self.config.max_lookahead_m, 20.0)
-        back = self.config.max_lookahead_m
-        best = None            # (dist2, s, seg_i)
-        fallback = None        # global nearest, if nothing lands in the window
+        """Along-track cursor = the nearest point on the polyline WITHIN the arc
+        window ahead of the cursor. Restricting to the window — and clamping each
+        segment TO the window (so a long first segment still contributes its near
+        end) — makes the boat acquire the route from its START and follow it in
+        order. It must NOT snap to the globally-nearest point: for a route the boat
+        begins far from (e.g. a shoreline route hugging the far bank, first mark
+        hundreds of metres away) that would cut straight across the middle instead
+        of driving to the first mark and tracking the line."""
+        cursor = self._cursor
+        win = max(2.5 * self.config.max_lookahead_m, 20.0)
+        if self._step >= 0:
+            lo, hi = cursor, cursor + win
+        else:
+            lo, hi = cursor - win, cursor
+        # Loop: also test each segment shifted by +/- one lap so the window wraps.
+        shifts = (0.0, total, -total) if loop else (0.0,)
+        best = None   # (dist2, s, seg_i)
         for i in range(len(seglen)):
+            seg = seglen[i]
+            if seg <= 1e-9:
+                continue
+            s0 = cum[i]
             ax, ay = P[i]
             bx, by = P[i + 1]
-            _t, _fx, _fy, d2 = self._nearest_on_seg(ax, ay, bx, by, 0.0, 0.0)
-            s = cum[i] + _t * seglen[i]
-            if fallback is None or d2 < fallback[0]:
-                fallback = (d2, s, i)
-            fwd = ((s - self._cursor) % total) if loop else (s - self._cursor)
-            in_window = (-back <= fwd <= window) if self._step > 0 else (-window <= fwd <= back)
-            if not in_window:
-                continue
-            if best is None or d2 < best[0]:
-                best = (d2, s, i)
-        chosen = best or fallback
-        return chosen[1], chosen[2]
+            dx, dy = bx - ax, by - ay
+            L2 = dx * dx + dy * dy
+            t_un = 0.0 if L2 <= 1e-12 else -(ax * dx + ay * dy) / L2   # proj of origin (0,0)
+            for sh in shifts:
+                a = max(s0 + sh, lo)
+                b = min(s0 + sh + seg, hi)
+                if a > b:
+                    continue                       # this lap of the segment misses the window
+                ta = (a - sh - s0) / seg
+                tb = (b - sh - s0) / seg
+                t = _clamp(t_un, ta, tb)
+                fx, fy = ax + t * dx, ay + t * dy
+                d2 = fx * fx + fy * fy
+                s = s0 + t * seg
+                if best is None or d2 < best[0]:
+                    best = (d2, s, i)
+        if best is None:                            # degenerate -> hold the cursor
+            s = cursor % total if loop else _clamp(cursor, 0.0, total)
+            return s, self._seg_index(cum, s)
+        return best[1], best[2]
 
     def _maybe_post_speed(self, state: NavigationState, cum, s_near) -> None:
         """Adopt a waypoint's per-mark speed as the cursor passes it (mirrors

--- a/tests/test_path_track.py
+++ b/tests/test_path_track.py
@@ -155,3 +155,47 @@ def test_path_track_patrol_runs():
     st = _run([(0, 0), (150, 0)], patrol=True)
     assert st.mode == ControlModeName.PATH_TRACK
     assert st.route_complete is False   # patrol reverses at each end, never done
+
+
+def test_path_track_acquires_route_start_when_boat_is_off_the_line():
+    """Regression: a route whose first mark is far from the boat (e.g. an
+    along-shoreline route that starts at the bank) must be ACQUIRED from its
+    start — drive to WP1, then follow — not snap to the globally-nearest point,
+    which would cut straight across. The boat begins 60 m off the route start."""
+    a = GeoPoint(_LAT, _LON)
+    # WP1 is 60 m north of the boat (which is heading east), then an S-hug north.
+    pts = [_off(a, e, n) for e, n in [(0, 60), (25, 95), (0, 130), (25, 165), (0, 200)]]
+    h = Harness(start=a, model="fossen")
+    h.sim.truth().heading_deg = 90.0
+    h.command({
+        "type": "goto", "throttle": 0.6, "follow": "path",
+        "waypoints": [{"name": f"W{i}", "lat": p.lat, "lon": p.lon} for i, p in enumerate(pts)],
+    })
+    dt = h.physics_dt
+    ng = nc = nt = 0.0
+    t = 0.0
+    wp1_min = 1e9
+    xte_on_line = 0.0
+    reached = False
+    while t < 260.0:
+        h.sim.step(dt)
+        if t >= ng:
+            h.nav.handle_sentence(h.gps.sample(h.sim.truth())); ng += 1.0 / h.gps_hz
+        if t >= nc:
+            h.nav.handle_sentence(h.compass.sample(h.sim.truth())); nc += 1.0 / h.compass_hz
+        if t >= nt:
+            h.controller.control_tick(1.0 / h.control_hz); nt += 1.0 / h.control_hz
+        pos = h.sim.truth().point
+        d1 = haversine_m(pos, pts[0])
+        wp1_min = min(wp1_min, d1)
+        if d1 < 3.0:
+            reached = True
+        if reached and not h.state.route_complete:
+            near = min(abs(cross_track(pts[i], pts[i + 1], pos).distance_m) for i in range(len(pts) - 1))
+            xte_on_line = max(xte_on_line, near)
+        if h.state.route_complete:
+            break
+        t += dt
+    assert wp1_min < 3.0, f"never reached the route start (WP1): closest {wp1_min:.1f} m"
+    assert h.state.route_complete, "route did not complete after acquiring the start"
+    assert xte_on_line < 8.0, f"cut across / poor tracking once on the line: max xte {xte_on_line:.1f} m"


### PR DESCRIPTION
**Bug (reported):** enabling Path Tracking then planning an along-shoreline route → the boat cut across open water instead of following the line.

**Cause:** `PathTrackMode._project` fell back to the *globally-nearest* point when nothing was in the forward window, snapping the cursor to a mid-route segment for a route whose first mark is far from the boat (shoreline routes start ~hundreds of m away at the bank; measured cross-track ~220 m).

**Fix:** restrict the projection to the arc window ahead of the cursor and clamp each segment to it, so a long first segment still contributes its near end — the boat acquires the route from WP1 and follows in order (like WaypointMode). No global teleport.

## Tests
- [x] New regression `test_path_track_acquires_route_start_when_boat_is_off_the_line` (boat 60 m off WP1 → reaches it, hugs the S, completes, xte < 8 m). Full suite **2152 passed**; loop/patrol/corner/S-curve unaffected. Re-verified against the live shoreline planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)