### PR TITLE
feat(map): USGS 3DEP topobathy basemap with offline pre-caching

### DIFF
--- a/src/vanchor/ui/static/map-core.js
+++ b/src/vanchor/ui/static/map-core.js
@@ -35,6 +35,43 @@
   // {r} = retina suffix; maxNativeZoom upscales beyond the tiles' native max.
   const OSM = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
   const CARTO = '© <a href="https://carto.com/attributions">CARTO</a>';
+  const USGS = '© <a href="https://www.usgs.gov/">USGS 3DEP</a>';
+
+  // USGS 3DEP topobathymetric elevation (WMS 1.3.0). Where inland-water
+  // topobathy lidar exists, the DEM includes lake/river/reservoir bottoms, so
+  // the tinted-hillshade render reads as a depth-shaded chart of the water body.
+  // This is the permanent BASE layer; the live sonar depth grid (map-depth.js)
+  // layers on top of it. See feat/usgs-inland-bathymetry-basemap.
+  const USGS_3DEP_WMS = "https://elevation.nationalmap.gov/arcgis/services/3DEPElevation/ImageServer/WMSServer";
+  // In this WMS each server-side render is its own named LAYER; the only valid
+  // STYLE for every layer is "default". So the tinted-hillshade render goes in
+  // LAYERS and STYLES stays "default" (NOT the other way round).
+  const USGS_3DEP_LAYER = "3DEPElevation:Hillshade Elevation Tinted";
+  const USGS_3DEP_STYLE = "default";
+
+  // Web-Mercator (EPSG:3857) tile -> WMS 1.3.0 GetMap URL for that single 256px
+  // tile. Used by the offline downloader to pre-cache a WMS basemap through the
+  // same {z,x,y} enumeration the XYZ sources use. The half-extent of the 3857
+  // world in metres; tiles subdivide [-R, R] on both axes.
+  const MERC_R = 20037508.342789244;
+  function wmsTileUrl(endpoint, params, z, x, y) {
+    const span = (2 * MERC_R) / Math.pow(2, z);   // tile edge length in metres
+    const minX = -MERC_R + x * span;
+    const maxX = minX + span;
+    const maxY = MERC_R - y * span;               // y grows southward
+    const minY = maxY - span;
+    // WMS 1.3.0 + EPSG:3857 uses easting,northing axis order: minX,minY,maxX,maxY.
+    const q = {
+      SERVICE: "WMS", REQUEST: "GetMap", VERSION: params.version || "1.3.0",
+      LAYERS: params.layers || "", STYLES: params.styles || "",
+      CRS: "EPSG:3857", BBOX: [minX, minY, maxX, maxY].join(","),
+      WIDTH: 256, HEIGHT: 256, FORMAT: params.format || "image/png",
+      TRANSPARENT: params.transparent ? "TRUE" : "FALSE",
+    };
+    const qs = Object.keys(q).map((k) => k + "=" + encodeURIComponent(q[k])).join("&");
+    return endpoint + (endpoint.indexOf("?") >= 0 ? "&" : "?") + qs;
+  }
+
   const base = {
     "Dark": L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
@@ -57,6 +94,23 @@
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
     "Topo": L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
       { maxZoom: 17, attribution: OSM + ", © OpenTopoMap" }),
+    // USGS Bathymetry: 3DEP topobathy DEM as a tiled WMS. maxNativeZoom 16 —
+    // the DEM is ~1 m/px at best, so upscale past 16 rather than fetch empty
+    // deeper tiles. Renders the tinted-hillshade style server-side. We override
+    // getTileUrl to use the shared wmsTileUrl builder so the LIVE tile url is
+    // byte-identical to the one the offline downloader pre-caches (one cache
+    // key), instead of relying on Leaflet's own WMS param serialisation.
+    "USGS Bathymetry": (function () {
+      const wmsParams = {
+        layers: USGS_3DEP_LAYER, styles: USGS_3DEP_STYLE,
+        format: "image/png", transparent: false, version: "1.3.0",
+      };
+      const layer = L.tileLayer("", { maxZoom: 22, maxNativeZoom: 16, attribution: USGS });
+      layer.getTileUrl = function (coords) {
+        return wmsTileUrl(USGS_3DEP_WMS, wmsParams, coords.z, coords.x, coords.y);
+      };
+      return layer;
+    })(),
   };
   base.Dark.addTo(map);
 
@@ -250,6 +304,12 @@
   // Expose the base layers + their template URLs so the offline-map downloader
   // (#52) can wire an IndexedDB tile cache into createTile and enumerate tiles.
   VA._baseLayers = base;
+  // A template is either a URL string with {z}/{x}/{y} placeholders (offline.js
+  // substitutes them) OR a function (z,x,y) => absoluteUrl for sources whose
+  // tile URL isn't a simple XYZ path (e.g. a bbox-based WMS GetMap). Both the
+  // live cache patch (via getTileUrl) and the offline downloader (via this
+  // template) resolve to the SAME url string, so a tile fetched live and a tile
+  // pre-cached share one cache key.
   VA._baseTemplates = {
     Dark: "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
     "Vanchor Teal": "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
@@ -257,8 +317,21 @@
     Satellite: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     Light: "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
     Topo: "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
+    // WMS 1.3.0 GetMap for a single XYZ tile (EPSG:3857, 256px). CRS axis order
+    // for 3857 is easting,northing so BBOX = minX,minY,maxX,maxY. Matches what
+    // Leaflet's L.TileLayer.WMS emits for the same tile, so the offline-cached
+    // url equals the live-panned url (one cache key).
+    "USGS Bathymetry": (z, x, y) => wmsTileUrl(USGS_3DEP_WMS, {
+      layers: USGS_3DEP_LAYER, styles: USGS_3DEP_STYLE,
+      format: "image/png", transparent: false, version: "1.3.0",
+    }, z, x, y),
   };
-  VA._baseNativeMax = { Dark: 20, "Vanchor Teal": 20, Nautical: 20, Satellite: 17, Light: 20, Topo: 17 };
+  VA._baseNativeMax = { Dark: 20, "Vanchor Teal": 20, Nautical: 20, Satellite: 17, Light: 20, Topo: 17, "USGS Bathymetry": 16 };
+
+  // Expose the WMS tile-url builder + the 3DEP endpoint config so the offline
+  // downloader, the live layer, and the unit tests all resolve to one url.
+  VA._wmsTileUrl = wmsTileUrl;
+  VA._usgs3dep = { endpoint: USGS_3DEP_WMS, layer: USGS_3DEP_LAYER, style: USGS_3DEP_STYLE };
 
   // Tile-cache integration point. offline.js installs VA.tileCache.get(url) ->
   // Promise<Blob|null> and VA.tileCache.put(url, blob). We patch createTile on

--- a/src/vanchor/ui/static/offline.js
+++ b/src/vanchor/ui/static/offline.js
@@ -128,13 +128,24 @@
     return total;
   }
 
-  // Build a real tile URL from a template + the {s} subdomain rotation.
+  // Build a real tile URL from a template + the {s} subdomain rotation. A
+  // template is either a {z}/{x}/{y} URL string OR a function (z,x,y) => url
+  // (used by bbox-based WMS sources, e.g. the USGS 3DEP bathymetry basemap);
+  // the function returns the exact url the live cache patch also fetches, so
+  // pre-cached and live tiles share one cache key.
   const SUBS = ["a", "b", "c"];
   function tileUrl(template, z, x, y) {
+    if (typeof template === "function") return template(z, x, y);
     return template
       .replace("{s}", SUBS[(x + y) % SUBS.length])
       .replace("{z}", z).replace("{x}", x).replace("{y}", y).replace("{r}", "");
   }
+
+  // Expose the pure tile-maths so unit tests can exercise the real enumeration
+  // and (string OR function) template resolution without a DOM. This block runs
+  // before the DOM early-return below, so it is set even on a page that has no
+  // offline-download card.
+  VA._offline = { enumerateTiles, countTiles, tileUrl };
 
   // ---- DOM ----------------------------------------------------------------
   const card = $("offline-card");

--- a/tests/test_usgs_bathymetry.py
+++ b/tests/test_usgs_bathymetry.py
@@ -1,0 +1,154 @@
+"""USGS 3DEP inland-bathymetry basemap — unit tests.
+
+Two layers of coverage for feat/usgs-inland-bathymetry-basemap:
+
+1. Behavioural — a Node harness (usgs_bathymetry_harness.mjs) loads the REAL
+   map-core.js and offline.js in a vm sandbox and reports the URLs/values the
+   shipped code actually produces. We assert the WMS bbox maths, the
+   layer/style wiring, the one-cache-key invariant, and the offline template
+   resolution against that report.
+2. Static — node --check on the two modified files + content assertions that
+   the exports and the layer/style bug fix are present (mirrors the repo's
+   existing test_t5_map_daylight.py convention).
+"""
+import json
+import math
+import subprocess
+import pathlib
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+STATIC = ROOT / "src/vanchor/ui/static"
+MAP_CORE = STATIC / "map-core.js"
+OFFLINE = STATIC / "offline.js"
+HARNESS = pathlib.Path(__file__).parent / "usgs_bathymetry_harness.mjs"
+
+MERC_R = 20037508.342789244
+
+
+def _txt(p):
+    return p.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def report():
+    """Run the Node harness once and hand every test the parsed report."""
+    r = subprocess.run(
+        ["node", str(HARNESS), str(STATIC)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, f"harness failed:\n{r.stderr}"
+    return json.loads(r.stdout)
+
+
+# ---------------------------------------------------------------- static checks
+def test_node_check_map_core():
+    r = subprocess.run(["node", "--check", str(MAP_CORE)], capture_output=True)
+    assert r.returncode == 0, r.stderr.decode()
+
+
+def test_node_check_offline():
+    r = subprocess.run(["node", "--check", str(OFFLINE)], capture_output=True)
+    assert r.returncode == 0, r.stderr.decode()
+
+
+def test_basemap_registered():
+    txt = _txt(MAP_CORE)
+    assert '"USGS Bathymetry"' in txt
+
+
+def test_layer_style_not_swapped():
+    """Regression guard: the render name goes in LAYERS, STYLES stays 'default'.
+
+    The earlier draft had these backwards (LAYERS='3DEPElevation:None',
+    STYLES=<render>), which the live WMS rejects with a ServiceException.
+    """
+    txt = _txt(MAP_CORE)
+    assert 'USGS_3DEP_LAYER = "3DEPElevation:Hillshade Elevation Tinted"' in txt
+    assert 'USGS_3DEP_STYLE = "default"' in txt
+    # the broken combo must be gone
+    assert "3DEPElevation:None" not in txt
+
+
+def test_offline_tileurl_accepts_function():
+    txt = _txt(OFFLINE)
+    assert 'if (typeof template === "function") return template(z, x, y);' in txt
+
+
+def test_offline_exposes_tile_maths():
+    txt = _txt(OFFLINE)
+    assert "VA._offline = { enumerateTiles, countTiles, tileUrl };" in txt
+
+
+# ------------------------------------------------------------- behavioural (harness)
+def test_basemap_present(report):
+    assert report["hasBasemap"] is True
+
+
+def test_template_is_function(report):
+    """WMS is bbox-based, so its offline template must be a (z,x,y)=>url fn."""
+    assert report["templateIsFunction"] is True
+
+
+def test_native_max_zoom(report):
+    """3DEP DEM is ~1 m/px; upscale past z16 rather than fetch empty tiles."""
+    assert report["baseNativeMax"] == 16
+
+
+def test_usgs_endpoint_config(report):
+    cfg = report["usgs3dep"]
+    assert cfg["endpoint"].endswith("/3DEPElevation/ImageServer/WMSServer")
+    assert cfg["layer"] == "3DEPElevation:Hillshade Elevation Tinted"
+    assert cfg["style"] == "default"
+
+
+def test_one_cache_key_invariant(report):
+    """The live layer's getTileUrl, the offline template, the offline tileUrl()
+    resolver, and the raw wmsTileUrl builder must all emit the SAME url for a
+    given tile — otherwise a pre-cached tile and a live-panned tile miss each
+    other in the IndexedDB cache."""
+    urls = {report["wmsUrl"], report["liveUrl"], report["offlineTmplUrl"], report["fnResolved"]}
+    assert len(urls) == 1, f"cache-key divergence: {urls}"
+
+
+def test_wms_query_params(report):
+    q = parse_qs(urlparse(report["wmsUrl"]).query)
+    assert q["SERVICE"] == ["WMS"]
+    assert q["REQUEST"] == ["GetMap"]
+    assert q["VERSION"] == ["1.3.0"]
+    assert q["CRS"] == ["EPSG:3857"]
+    assert q["WIDTH"] == ["256"] and q["HEIGHT"] == ["256"]
+    assert q["FORMAT"] == ["image/png"]
+    # the fix: render name in LAYERS, default style in STYLES
+    assert q["LAYERS"] == ["3DEPElevation:Hillshade Elevation Tinted"]
+    assert q["STYLES"] == ["default"]
+
+
+def test_wms_bbox_matches_web_mercator_tile(report):
+    """Independently recompute the EPSG:3857 bbox for tile z12/x1160/y1512 and
+    assert the code's BBOX matches (easting,northing axis order for 1.3.0)."""
+    z, x, y = 12, 1160, 1512
+    span = (2 * MERC_R) / (2 ** z)
+    exp_min_x = -MERC_R + x * span
+    exp_max_x = exp_min_x + span
+    exp_max_y = MERC_R - y * span
+    exp_min_y = exp_max_y - span
+
+    q = parse_qs(urlparse(report["wmsUrl"]).query)
+    got = [float(v) for v in q["BBOX"][0].split(",")]
+    expected = [exp_min_x, exp_min_y, exp_max_x, exp_max_y]
+    for g, e in zip(got, expected):
+        assert math.isclose(g, e, rel_tol=0, abs_tol=1e-6), f"bbox {got} != {expected}"
+
+
+def test_string_template_still_works(report):
+    """The function-template branch must not regress the plain XYZ string path."""
+    assert report["stringResolved"] == "https://a.basemaps.cartocdn.com/dark_all/5/3/7.png"
+
+
+def test_enumerate_matches_count(report):
+    """enumerateTiles() length and countTiles() must agree for the same bbox."""
+    assert report["enumerated"] == report["counted"]
+    assert report["counted"] > 0

--- a/tests/usgs_bathymetry_harness.mjs
+++ b/tests/usgs_bathymetry_harness.mjs
@@ -1,0 +1,211 @@
+/*
+ * Node harness for the USGS 3DEP bathymetry basemap unit tests.
+ *
+ * Loads the REAL map-core.js and offline.js in a vm sandbox with just-enough
+ * `L` / `window` / `document` / `localStorage` stubs, so the tests exercise the
+ * actual shipped code (not a copy). Emits a JSON report on stdout that the
+ * Python test (test_usgs_bathymetry.py) asserts against.
+ *
+ * Run: node tests/usgs_bathymetry_harness.mjs <static-dir>
+ */
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+const STATIC = process.argv[2];
+if (!STATIC) {
+  console.error("usage: node usgs_bathymetry_harness.mjs <static-dir>");
+  process.exit(2);
+}
+
+// A no-op Leaflet stub. L.tileLayer returns a plain object whose getTileUrl can
+// be overridden (which is exactly what map-core does for the WMS basemap). The
+// chainable methods return the layer so `.addTo(map)` etc. don't throw.
+function makeLayer() {
+  const layer = {
+    options: {},
+    getTileUrl() { return ""; },
+    addTo() { return layer; },
+    on() { return layer; },
+    setZIndex() { return layer; },
+    redraw() { return layer; },
+  };
+  return layer;
+}
+// A chainable no-op object: every method returns itself, every property read
+// returns another chainable. Stands in for a Leaflet map / control / pane so
+// map-core.js's boot code (setView, on, addLayer, createPane, ...) never throws.
+function chainable() {
+  const target = function () { return proxy; };
+  const proxy = new Proxy(target, {
+    get(_t, prop) {
+      if (prop === Symbol.toPrimitive) return () => "";
+      if (prop === "then") return undefined; // not a thenable
+      return proxy;
+    },
+    apply() { return proxy; },
+    set() { return true; },
+  });
+  return proxy;
+}
+// A callable factory that also answers ANY sub-property (e.g. L.control.zoom,
+// L.control.layers, L.tileLayer.wms) with another callable factory returning a
+// chainable. This absorbs every Leaflet entry point map-core.js touches at boot
+// without us enumerating each one.
+function factory(makeResult) {
+  const fn = function () { return makeResult(...arguments); };
+  return new Proxy(fn, {
+    get(t, prop) {
+      if (prop in t) return t[prop];
+      return factory(makeResult);
+    },
+    apply(_t, _this, args) { return makeResult(...args); },
+  });
+}
+// A class-like stub whose .extend() returns another extendable class and whose
+// instances are chainable — covers L.GridLayer.extend({...}), L.Control.extend,
+// `new (L.GridLayer.extend(...))()`, etc.
+function klass() {
+  function Ctor() { return chainable(); }
+  Ctor.extend = () => klass();
+  Ctor.include = () => Ctor;
+  return new Proxy(Ctor, {
+    construct() { return chainable(); },
+    get(t, prop) { if (prop in t) return t[prop]; return factory(() => chainable()); },
+  });
+}
+
+const Lbase = {
+  tileLayer: factory((url, opts) => { const l = makeLayer(); l.options = opts || {}; l._url = url; return l; }),
+  map: factory(() => chainable()),
+  control: factory(() => chainable()),
+  layerGroup: factory(() => chainable()),
+  featureGroup: factory(() => chainable()),
+  GridLayer: klass(),
+  Control: klass(),
+  Layer: klass(),
+  Class: klass(),
+  DomUtil: { create() { return { classList: { add() {}, remove() {} }, style: {} }; } },
+  Util: { template(str, data) { return str.replace(/\{ *([\w_-]+) *\}/g, (_, k) => data[k]); } },
+};
+// Fallback: any unspecified L.* becomes a permissive factory so boot-time calls
+// (L.latLng, L.point, L.icon, ...) never throw.
+const L = new Proxy(Lbase, {
+  get(t, prop) {
+    if (prop in t) return t[prop];
+    if (typeof prop === "symbol") return undefined;
+    return factory(() => chainable());
+  },
+});
+
+// A permissive Proxy stands in for the DOM / browser globals map-core.js and
+// offline.js touch at load time. Reads return another no-op proxy; calls are
+// no-ops. This lets both IIFEs run to the point where they publish their VA.*
+// exports without a real DOM.
+function noopProxy() {
+  const fn = function () { return proxy; };
+  const proxy = new Proxy(fn, {
+    get(_t, prop) {
+      if (prop === Symbol.toPrimitive) return () => "";
+      if (prop === "length") return 0;
+      return proxy;
+    },
+    apply() { return proxy; },
+    set() { return true; },
+  });
+  return proxy;
+}
+
+const store = new Map();
+const localStorage = {
+  getItem(k) { return store.has(k) ? store.get(k) : null; },
+  setItem(k, v) { store.set(k, String(v)); },
+  removeItem(k) { store.delete(k); },
+};
+
+const win = {};
+const VA = {};
+win.VA = VA;
+win.L = L;
+win.localStorage = localStorage;
+win.addEventListener = () => {};
+win.dispatchEvent = () => {};
+win.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+win.location = { href: "http://localhost:8000/", protocol: "http:", host: "localhost:8000" };
+win.innerWidth = 1024;
+win.innerHeight = 768;
+win.CustomEvent = function () {};
+win.setTimeout = () => 0;
+win.clearTimeout = () => {};
+win.setInterval = () => 0;
+win.indexedDB = undefined; // offline.js degrades gracefully when absent
+
+const sandbox = {
+  window: win,
+  VA, // core.js sets a bare global VA = (window.VA = window.VA || {})
+  L,
+  document: noopProxy(),
+  localStorage,
+  navigator: { onLine: true, serviceWorker: undefined },
+  console,
+  fetch: () => Promise.resolve({ ok: false }),
+  setTimeout: () => 0,
+  clearTimeout: () => {},
+  setInterval: () => 0,
+  CustomEvent: function () {},
+  Image: function () { return {}; },
+  URL: { createObjectURL: () => "", revokeObjectURL: () => {} },
+};
+sandbox.globalThis = sandbox;
+vm.createContext(sandbox);
+
+function run(file) {
+  const src = fs.readFileSync(path.join(STATIC, file), "utf-8");
+  vm.runInContext(src, sandbox, { filename: file });
+}
+
+// core.js establishes the global VA; but running the whole thing is fragile, so
+// we pre-seed VA (mirrors core.js's single effect that map-core/offline rely on).
+run("map-core.js");
+run("offline.js");
+
+// ---- gather results ----
+const wmsUrl = VA._wmsTileUrl(
+  VA._usgs3dep.endpoint,
+  { layers: VA._usgs3dep.layer, styles: VA._usgs3dep.style, format: "image/png", transparent: false, version: "1.3.0" },
+  12, 1160, 1512
+);
+
+// The live basemap layer's getTileUrl (the override) for the same tile.
+const liveLayer = VA._baseLayers["USGS Bathymetry"];
+const liveUrl = liveLayer.getTileUrl({ z: 12, x: 1160, y: 1512 });
+
+// The offline template (function form) for the same tile.
+const tmpl = VA._baseTemplates["USGS Bathymetry"];
+const offlineTmplUrl = typeof tmpl === "function" ? tmpl(12, 1160, 1512) : null;
+
+// The offline tileUrl() resolver over both a string and the function template.
+const stringResolved = VA._offline.tileUrl(
+  "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png", 5, 3, 7
+);
+const fnResolved = VA._offline.tileUrl(tmpl, 12, 1160, 1512);
+
+// enumerateTiles / countTiles agreement on a small bbox.
+const bbox = [-94.40, 47.14, -94.38, 47.16];
+const enumerated = VA._offline.enumerateTiles(bbox, 12, 13).length;
+const counted = VA._offline.countTiles(bbox, 12, 13);
+
+const report = {
+  wmsUrl,
+  liveUrl,
+  offlineTmplUrl,
+  stringResolved,
+  fnResolved,
+  templateIsFunction: typeof tmpl === "function",
+  baseNativeMax: VA._baseNativeMax["USGS Bathymetry"],
+  usgs3dep: VA._usgs3dep,
+  hasBasemap: Boolean(VA._baseLayers["USGS Bathymetry"]),
+  enumerated,
+  counted,
+};
+process.stdout.write(JSON.stringify(report));


### PR DESCRIPTION
## Summary
- Adds a USGS 3DEP topobathymetric hillshade basemap (WMS 1.3.0 GetMap) so inland lakes/rivers/ponds get a permanent depth-shaded base under the live sonar depth overlay.
- Shared `wmsTileUrl` bbox builder turns Web-Mercator `{z}/{x}/{y}` tiles into GetMap requests whose URL is the same cache key used by live panning and the offline downloader — existing IndexedDB tile cache works with no URL-builder fork.
- Tests: Node harness + 15 pytest cases covering basemap registration, WMS params, tile math, function-template offline path, and the one-cache-key invariant.

## Test plan
- [ ] Load map UI and select the USGS topobathy basemap; confirm tiles render over inland water.
- [ ] Pan/zoom and confirm sonar depth overlay still layers above the new base.
- [ ] Trigger offline pre-cache for the USGS layer; confirm tiles hit IndexedDB and reload offline.
- [ ] Run `pytest tests/test_usgs_bathymetry.py` (15 cases).