### PR TITLE
feat(map): label 3DEP basemap "USGS Topobathy (US)" + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **USGS Topobathy (US) basemap with offline pre-caching (#111).** A new
+  basemap, **USGS Topobathy (US)**, backed by the USGS 3DEP topobathymetric
+  elevation service (WMS 1.3.0, tinted-hillshade). Where inland-water topobathy
+  lidar exists, the DEM includes lake/river/reservoir bottoms, so the map hints
+  at underwater terrain under the usual overlays. Tiles are served as a WMS
+  through a shared tile-url builder so the live-panned url is byte-identical to
+  the one the offline downloader pre-caches (one cache key). 3DEP is US-only,
+  hence the **(US)** label. (`map-core.js`, `offline.js`.)
+
 - **Extension kernel — `vanchor.ext` (#96, part of #95).** Extracted the shared
   plug-in machinery into a new leaf package: `discover(group)` (the one home for
   entry-point discovery, moved verbatim from the two copy-pasted

--- a/src/vanchor/ui/static/map-core.js
+++ b/src/vanchor/ui/static/map-core.js
@@ -94,13 +94,14 @@
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
     "Topo": L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
       { maxZoom: 17, attribution: OSM + ", © OpenTopoMap" }),
-    // USGS Bathymetry: 3DEP topobathy DEM as a tiled WMS. maxNativeZoom 16 —
+    // USGS Topobathy (US): 3DEP topobathy DEM as a tiled WMS. maxNativeZoom 16 —
     // the DEM is ~1 m/px at best, so upscale past 16 rather than fetch empty
     // deeper tiles. Renders the tinted-hillshade style server-side. We override
     // getTileUrl to use the shared wmsTileUrl builder so the LIVE tile url is
     // byte-identical to the one the offline downloader pre-caches (one cache
     // key), instead of relying on Leaflet's own WMS param serialisation.
-    "USGS Bathymetry": (function () {
+    // 3DEP coverage is US-only, hence the "(US)" label.
+    "USGS Topobathy (US)": (function () {
       const wmsParams = {
         layers: USGS_3DEP_LAYER, styles: USGS_3DEP_STYLE,
         format: "image/png", transparent: false, version: "1.3.0",
@@ -321,12 +322,12 @@
     // for 3857 is easting,northing so BBOX = minX,minY,maxX,maxY. Matches what
     // Leaflet's L.TileLayer.WMS emits for the same tile, so the offline-cached
     // url equals the live-panned url (one cache key).
-    "USGS Bathymetry": (z, x, y) => wmsTileUrl(USGS_3DEP_WMS, {
+    "USGS Topobathy (US)": (z, x, y) => wmsTileUrl(USGS_3DEP_WMS, {
       layers: USGS_3DEP_LAYER, styles: USGS_3DEP_STYLE,
       format: "image/png", transparent: false, version: "1.3.0",
     }, z, x, y),
   };
-  VA._baseNativeMax = { Dark: 20, "Vanchor Teal": 20, Nautical: 20, Satellite: 17, Light: 20, Topo: 17, "USGS Bathymetry": 16 };
+  VA._baseNativeMax = { Dark: 20, "Vanchor Teal": 20, Nautical: 20, Satellite: 17, Light: 20, Topo: 17, "USGS Topobathy (US)": 16 };
 
   // Expose the WMS tile-url builder + the 3DEP endpoint config so the offline
   // downloader, the live layer, and the unit tests all resolve to one url.

--- a/tests/test_usgs_bathymetry.py
+++ b/tests/test_usgs_bathymetry.py
@@ -56,7 +56,7 @@ def test_node_check_offline():
 
 def test_basemap_registered():
     txt = _txt(MAP_CORE)
-    assert '"USGS Bathymetry"' in txt
+    assert '"USGS Topobathy (US)"' in txt
 
 
 def test_layer_style_not_swapped():

--- a/tests/usgs_bathymetry_harness.mjs
+++ b/tests/usgs_bathymetry_harness.mjs
@@ -177,11 +177,11 @@ const wmsUrl = VA._wmsTileUrl(
 );
 
 // The live basemap layer's getTileUrl (the override) for the same tile.
-const liveLayer = VA._baseLayers["USGS Bathymetry"];
+const liveLayer = VA._baseLayers["USGS Topobathy (US)"];
 const liveUrl = liveLayer.getTileUrl({ z: 12, x: 1160, y: 1512 });
 
 // The offline template (function form) for the same tile.
-const tmpl = VA._baseTemplates["USGS Bathymetry"];
+const tmpl = VA._baseTemplates["USGS Topobathy (US)"];
 const offlineTmplUrl = typeof tmpl === "function" ? tmpl(12, 1160, 1512) : null;
 
 // The offline tileUrl() resolver over both a string and the function template.
@@ -202,9 +202,9 @@ const report = {
   stringResolved,
   fnResolved,
   templateIsFunction: typeof tmpl === "function",
-  baseNativeMax: VA._baseNativeMax["USGS Bathymetry"],
+  baseNativeMax: VA._baseNativeMax["USGS Topobathy (US)"],
   usgs3dep: VA._usgs3dep,
-  hasBasemap: Boolean(VA._baseLayers["USGS Bathymetry"]),
+  hasBasemap: Boolean(VA._baseLayers["USGS Topobathy (US)"]),
   enumerated,
   counted,
 };


### PR DESCRIPTION
Follow-up to #111, addressing the review comment: since 3DEP is US-only, label the basemap **"USGS Topobathy (US)"** and add the CHANGELOG line the PR shipped without.

## What changed
- **`map-core.js`** — rename the base-layer key from `"USGS Bathymetry"` to `"USGS Topobathy (US)"`. The key is the display label shown in the Leaflet layers control, and is also the shared key across `_baseLayers`, `_baseTemplates`, and `_baseNativeMax`, so all three are updated together.
- **CHANGELOG** — add an Unreleased entry documenting the 3DEP topobathy basemap (#111).

## Tests
- `tests/usgs_bathymetry_harness.mjs` + `tests/test_usgs_bathymetry.py` updated to track the new label; the label-registration assertion now checks `"USGS Topobathy (US)"`.
- `python -m pytest tests/test_usgs_bathymetry.py -q` → **15 passed** (includes the vm-sandbox Node harness against the real JS).
- `node --check` on `map-core.js`, `offline.js`, and the harness → clean.
- `ruff check src tests` → clean.

Closes the review follow-up on #111.