### PR TITLE
feat(map): edgeless + blended composition fill; region-cache the fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Bottom-composition overlay: cleaner look + much cheaper panning.** The
+  composition polygons now render **edgeless** (no per-polygon stroke) at ~0.6
+  opacity with a light edge-blur, so the bottom-hardness bands blend into smooth
+  gradients instead of a dark boundary mesh that muddied the map and competed
+  with the depth contours (which now read crisply on top — closer to the cmapper
+  reference render). Performance: the ~5 MB composition payload is now
+  **region-cached** — while the viewport stays inside the last fully-loaded
+  extent it's redrawn, not refetched + re-parsed, so panning within a lake no
+  longer re-hits the network every move. (Interim step; a server-rendered raster
+  **tile** cache for the static composition/contour layers is the planned
+  follow-up.) (`map-depth.js`.)
+
 - **Gzipped depth-chart imports.** `POST /api/depth/import` (and
   `Runtime.import_depth_map`) now accept a **gzip-compressed** upload,
   transparently decompressed. Detection is by the gzip **magic bytes**

--- a/docs/llms/frontend.md
+++ b/docs/llms/frontend.md
@@ -193,7 +193,14 @@ module (Catches, heatmap, no-go).
   (`setData` → chain segments → Chaikin smooth → stroke).
 - **Bottom composition** — the `CompositionLayer`: filled translucent YlOrBr
   polygons from `GET /api/depth/composition`, drawn in its OWN map pane
-  (`composition`, z-index 350) so it sits **below** the contour lines.
+  (`composition`, z-index 350) so it sits **below** the contour lines. Rendered
+  **edgeless** (no per-polygon stroke) at ~0.6 opacity with a small CSS
+  `blur(COMPOSITION_BLUR_PX)` on the whole canvas, so the pct bands blend into
+  gradients instead of drawing seams that fight the depth isobaths. The fetch is
+  **region-cached** (`compositionBBox`): while the viewport stays inside the last
+  fully-loaded extent the ~5 MB payload is **not** refetched — only redrawn — so
+  panning within a lake is cheap. A truncated (`?limit=`-capped) fetch is partial,
+  so it's never cached (always refetched as the view changes).
 
 ### `CanvasOverlayMixin` — two load-bearing invariants (do not regress)
 

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -934,16 +934,22 @@
   let contourShow = false;       // Depth contours overlay on/off (default off)
 
   // ---- bottom-composition overlay (composition polygons) ----------
-  // Composition is a VECTOR POLYGON layer (RENDERING_COMPOSITION.md §3/§5):
-  // FILLED polygons coloured by pct on a sequential YlOrBr ramp (0..100, FIXED,
-  // uncalibrated -- no substrate names, polarity unknown), fill-opacity ~0.5 with
-  // a thin stroke, drawn UNDER the contour lines. Distinct from BOTH the depth
-  // palette AND the 0..127 hardness ramp -- never conflate them. Never rasterise
-  // it and never fill bare areas -- patchy coverage is missing data, not 0%.
+  // Composition is a VECTOR POLYGON layer: FILLED polygons coloured by pct on a
+  // sequential YlOrBr ramp (0..100, FIXED, uncalibrated -- no substrate names,
+  // polarity unknown), drawn UNDER the contour lines. Rendered EDGELESS (no
+  // per-polygon stroke) at fill-opacity ~0.6: the chart is made of thousands of
+  // small polygons, so stroking each one drew a dark mesh that muddied the fill;
+  // structure comes from the depth-contour isobaths overlaid on top instead
+  // (matches the cmapper reference render). Distinct from BOTH the depth palette
+  // AND the 0..127 hardness ramp -- never conflate them. Never rasterise it and
+  // never fill bare areas -- patchy coverage is missing data, not 0%.
   const COMPOSITION_STOPS = [
     [0.0, [255, 255, 229]], [0.25, [254, 227, 145]], [0.5, [254, 153, 41]],
     [0.75, [217, 95, 14]], [1.0, [153, 52, 4]],
   ];
+  // Edge-blend blur (CSS px) applied to the whole composition canvas so the
+  // pct-band boundaries soften into gradients instead of hard seams.
+  const COMPOSITION_BLUR_PX = 2.5;
   function compositionColorRGB(pct) {
     const f = Math.max(0, Math.min(1, (+pct || 0) / 100));   // fixed 0..100 domain
     const stops = COMPOSITION_STOPS;
@@ -968,6 +974,12 @@
       const c = this._canvas = L.DomUtil.create("canvas", "leaflet-depth-composition");
       c.style.position = "absolute";
       c.style.pointerEvents = "none";
+      // Soften the hard pct-step edges so adjacent bands BLEND instead of drawing
+      // crisp seams that read like isobaths and fight the depth-contour overlay.
+      // A GPU compositor blur on the whole layer (cheap, once per frame at
+      // composite) -- NOT a per-vertex draw cost, and it never touches the
+      // separate, crisp contour canvas sitting above it. (COMPOSITION_BLUR_PX)
+      c.style.filter = "blur(" + COMPOSITION_BLUR_PX + "px)";
       (m.getPane("composition") || m.getPanes().overlayPane).appendChild(c);
       m.on("moveend zoomend resize", this._scheduleReset, this);
       if (m.options.zoomAnimation) m.on("zoomanim", this._animateZoom, this);
@@ -1022,15 +1034,13 @@
       }
       ctx2.save();
       clipToWaterMask(ctx2, m);               // never paint composition over land
-      ctx2.globalAlpha = 0.5;                 // fill-opacity ~0.5 so basemap/depth read through (spec §5)
-      ctx2.lineWidth = 0.6;                   // thin stroke on each polygon (spec §5)
-      ctx2.lineJoin = "round";
+      ctx2.globalAlpha = 0.6;                 // fill-opacity ~0.6 so basemap/depth read through
+      // EDGELESS fill (one fill() per pct group, no stroke): stroking each of the
+      // thousands of small polygons drew a dark boundary mesh that muddied the
+      // map. Boundaries read from the pct colour steps + the contour overlay.
       for (const [pct, rings] of byPct) {
         const rgb = compositionColorRGB(pct);
         ctx2.fillStyle = `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`;
-        // Thin stroke: a darkened shade of the same fill so boundaries read
-        // without introducing a second (conflatable) colour scale.
-        ctx2.strokeStyle = `rgb(${Math.round(rgb[0] * 0.6)},${Math.round(rgb[1] * 0.6)},${Math.round(rgb[2] * 0.6)})`;
         ctx2.beginPath();
         for (const ring of rings) {
           const p0 = m.latLngToContainerPoint([ring[0][0] + off.lat, ring[0][1] + off.lon]);
@@ -1042,7 +1052,6 @@
           ctx2.closePath();
         }
         ctx2.fill();
-        ctx2.stroke();
       }
       ctx2.restore();
     },
@@ -1110,24 +1119,44 @@
     const badge = document.getElementById("depth-state");
     if (badge && !depthShow) badge.textContent = msg || "";
   }
+  // Region cache: the extent the loaded polygons cover, and whether that fetch
+  // was capped. The composition payload is large (~5 MB / hundreds of k
+  // vertices) and the polygons for a region don't change with pan/zoom, so we
+  // skip the refetch while the viewport stays inside a fully-loaded extent --
+  // panning within a lake no longer re-hits the network + re-parses. (perf)
+  let compositionBBox = null;        // {w,s,e,n} last fetched extent, or null
+  let compositionTruncated = false;  // last fetch was ?limit=-capped (partial)
   async function fetchComposition() {
     if (!compositionShow || compositionBusy) return;
     if (map.getZoom() < DEPTH_MIN_ZOOM) {   // zoom gate (perf): clear + hint
       compositionLayer.setData([]);
       compHint("zoom in for composition");
+      compositionBBox = null;
+      return;
+    }
+    const b = map.getBounds().pad(0.3);
+    // Already fully covered by a non-truncated fetch -> reuse; just redraw.
+    if (!compositionTruncated && compositionBBox &&
+        b.getWest() >= compositionBBox.w && b.getSouth() >= compositionBBox.s &&
+        b.getEast() <= compositionBBox.e && b.getNorth() <= compositionBBox.n) {
       return;
     }
     compositionBusy = true;
     try {
-      const b = map.getBounds().pad(0.3);
       const r = await VA.getJSON(
         "/api/depth/composition?west=" + b.getWest() + "&south=" + b.getSouth() +
         "&east=" + b.getEast() + "&north=" + b.getNorth());
       const ps = r && Array.isArray(r.polygons) ? r.polygons : [];
       if (!map.hasLayer(compositionLayer)) compositionLayer.addTo(map);
       compositionLayer.setData(ps);
+      compositionTruncated = !!(r && r.truncated);
+      // Cache the covered extent only when the fetch was complete; a capped
+      // (truncated) fetch is partial, so always refetch as the view changes.
+      compositionBBox = compositionTruncated
+        ? null
+        : { w: b.getWest(), s: b.getSouth(), e: b.getEast(), n: b.getNorth() };
       // Server may cap the payload (?limit=) and flag it — same zoom-in hint.
-      compHint(r && r.truncated ? "partial — zoom in" : "");
+      compHint(compositionTruncated ? "partial — zoom in" : "");
     } catch (e) { /* leave the last good render */ }
     finally { compositionBusy = false; }
     maybeFetchWaterMask();   // async: clips when the water arrives; reused per region
@@ -1143,6 +1172,7 @@
     } else {
       if (map.hasLayer(compositionLayer)) map.removeLayer(compositionLayer);
       compositionLayer.setData([]);
+      compositionBBox = null;   // force a fresh fetch when re-enabled
     }
     compositionSyncing = true;
     if (compositionShow && !map.hasLayer(compositionProxy)) compositionProxy.addTo(map);


### PR DESCRIPTION
Interim fix for the two composition-overlay problems reported: it looked worse than the cmapper reference, and it was extremely slow in the browser. (A server-rendered raster **tile** cache is the planned follow-up — see below.)

## Look — borderless + blended edges

- **Edgeless fills.** Removed the per-polygon darkened stroke. The chart is thousands of small polygons, so stroking each one drew a dark boundary mesh that muddied the map and competed with the depth isobaths.
- **Blend at edges.** Fill opacity 0.5 → 0.6 + a small CSS `blur(COMPOSITION_BLUR_PX)` on the whole composition canvas, so the pct bands blend into gradients instead of hard seams. Contours live on a separate crisp canvas above, so they read cleanly on top — matching the cmapper reference.

Verified with a same-data / same-Esri-tiles A/B/C render (current vs edgeless vs edgeless+blur) and live in the app at z16.

## Performance — panning

- **Region-cached fetch.** The composition payload is ~5 MB / ~200k vertices per region and doesn't change with pan/zoom, yet it was refetched + re-parsed (~400 ms on desktop localhost, multiseconds on a phone→Pi) on **every** meaningful move. Now, while the viewport stays inside the last fully-loaded extent, it's redrawn — not refetched. A truncated (`?limit=`-capped) fetch is partial, so it's never cached (always refetched as the view changes).

## Scope / follow-up

This is the agreed **interim** step. The proper fix for the static composition + contour layers is a **server-rendered Pillow raster tile cache** (lazy render → persist to SD once, hash-keyed invalidation, RAM-LRU in front), which removes the live-vector cost entirely and gives a shared/offline tile cache. That's a separate, larger PR.

## Tests

Frontend-only change (`map-depth.js` + docs). `node --check` clean; `e2e_smoke.py` 29/29 with **no console errors**; `pytest -m e2e tests/test_e2e_playwright.py` 11 passed. Rendering/perf is verified visually (screenshots) rather than unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)