### PR TITLE
feat(depth): server-rendered composition raster tiles (keystone #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Composition raster tiles — keystone (#117, part of #116).** The static
+  bottom-composition overlay can now render as **server-side raster tiles**
+  instead of live vector polygons: a Pillow renderer (`nav/depth_tiles.py`)
+  rasterises each 256 px XYZ tile from the in-memory chart (edgeless YlOrBr fills,
+  blended edges, seamless across tiles), served at
+  `GET /api/depth/tiles/composition/{z}/{x}/{y}.png` with a
+  `GET /api/depth/tiles/info` metadata endpoint. Tiles are cached **RAM-LRU →
+  write-once on disk** under `<data_dir>/tiles/composition/<version>/` — each tile
+  is rendered and written at most once (SD-friendly), empty tiles are a shared
+  transparent PNG kept in RAM only, and a chart re-import bumps the `version` so
+  tiles refresh. On the client an opt-in **"fast tiles (beta)"** toggle
+  (`VA.setCompositionTiles`, persisted) swaps the vector overlay for an
+  `L.TileLayer`; tiles render at **any** zoom (no 8000-polygon truncation) and the
+  browser caches them, so panning/zooming is smooth. The live-vector overlay
+  remains the default and fallback. Next phases (contour tiles, hash-keyed
+  invalidation + GUI, offline, pre-generate) are tracked under #116.
+
 - **Bottom-composition overlay: cleaner look + much cheaper panning.** The
   composition polygons now render **edgeless** (no per-polygon stroke) at ~0.6
   opacity with a light edge-blur, so the bottom-hardness bands blend into smooth

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -321,6 +321,22 @@ the decompressed leading byte; `open_depth_text` gunzips the spilled file
 lazily, so the bounded streaming import stays bounded on a gzipped chart too).
 A `.geojsonl` compresses ~10× (a 300 MB cmapper export → ~50 MB upload).
 
+**Composition raster tiles (#117).** `nav/depth_tiles.py` is a pure Pillow
+renderer + XYZ tile math (`tile_bounds`, `padded_query_bbox`,
+`render_composition_tile`, `transparent_tile`) — no runtime coupling, so it's
+unit-testable headless. `DepthService.composition_tile(z, x, y)` wraps it with a
+**RAM-LRU → write-once disk** cache under `<data_dir>/tiles/composition/<version>/`:
+each non-empty tile is rendered + written **once** (SD-friendly), empty tiles
+return a shared transparent PNG cached in RAM only (never written). `version` is
+a short hash of the persisted `.npz` (mtime+size), so a re-import re-renders.
+Fills are drawn **opaque** (the client `L.TileLayer` applies 0.6 opacity, so
+overlapping polys never double-darken), edges blended with a Gaussian blur, and a
+render margin pulls in neighbour-tile polygons so there's no tile seam. Endpoints:
+`GET /api/depth/tiles/info` (`{has_composition, version, tile_size, min_zoom}`)
+and `GET /api/depth/tiles/composition/{z}/{x}/{y}.png`. Opt-in on the client via
+the "fast tiles (beta)" toggle; the live-vector overlay is the default/fallback.
+Design + roadmap: [`../depth-tiles.md`](../depth-tiles.md) (epic #116).
+
 ### `Runtime` depth methods (`runtime/depth.py`)
 
 - `import_depth_map(filename, data, replace=False)` — parse → `replace` swaps the

--- a/docs/llms/frontend.md
+++ b/docs/llms/frontend.md
@@ -200,7 +200,13 @@ module (Catches, heatmap, no-go).
   **region-cached** (`compositionBBox`): while the viewport stays inside the last
   fully-loaded extent the ~5 MB payload is **not** refetched — only redrawn — so
   panning within a lake is cheap. A truncated (`?limit=`-capped) fetch is partial,
-  so it's never cached (always refetched as the view changes).
+  so it's never cached (always refetched as the view changes). **Opt-in raster-tile
+  mode (#117):** the "fast tiles (beta)" toggle (`VA.setCompositionTiles`, persisted
+  in `localStorage`) swaps the vector overlay for an `L.TileLayer` of server-rendered
+  PNGs (`/api/depth/tiles/composition/{z}/{x}/{y}.png?v=<version>`, opacity 0.6, in
+  the `composition` pane). Tiles render at any zoom (no 8000-poly truncation) and the
+  browser caches them; the vector path stays the default/fallback. `applyCompositionMode`
+  keeps exactly one of the two mounted.
 
 ### `CanvasOverlayMixin` — two load-bearing invariants (do not regress)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "uvicorn[standard]>=0.27",
     "python-multipart>=0.0.9",  # file uploads (POST /api/restore)
     "numpy>=1.24",        # Fossen 3-DOF boat model (sim model="fossen")
+    "pillow>=10",         # server-rendered depth raster tiles (nav/depth_tiles.py)
     "pyyaml>=6.0",        # YAML config files
     "orjson>=3.9",        # fast depth-chart JSON (de)serialisation (graceful fallback)
     "pygeomag>=1.1",      # full WMM2025 magnetic declination (nav.wmm; degree-2 fallback)

--- a/src/vanchor/nav/depth_tiles.py
+++ b/src/vanchor/nav/depth_tiles.py
@@ -1,0 +1,129 @@
+"""Server-rendered raster tiles for the static bottom-composition overlay (#117).
+
+Pure Pillow renderer + XYZ tile math -- no server / runtime coupling, so it is
+unit-testable headless. The runtime layer (``runtime/depth.py``) wraps this with
+the write-once disk + RAM-LRU cache; the design lives in ``docs/depth-tiles.md``.
+
+Fills are drawn **opaque** and the client ``L.TileLayer`` applies the ~0.6
+opacity, so overlapping polygons never double-darken (matches the vector
+overlay's single-alpha look). Edges are blended with a Gaussian blur; a render
+margin (``pad_px``) pulls in neighbouring-tile polygons so the blur has no seam
+at tile borders. The tile is rendered at ``supersample``x then downsampled for
+antialiased, edgeless bands.
+"""
+from __future__ import annotations
+
+import io
+import math
+
+# YlOrBr ramp -- the SAME stops as the JS COMPOSITION_STOPS / cmapper's YlOrBr,
+# so the tiles match the vector overlay exactly. (fraction, (r, g, b))
+_COMPOSITION_STOPS = (
+    (0.00, (255, 255, 229)),
+    (0.25, (254, 227, 145)),
+    (0.50, (254, 153, 41)),
+    (0.75, (217, 95, 14)),
+    (1.00, (153, 52, 4)),
+)
+
+TILE_PX = 256          # tile edge in CSS px (256, per the #117 decision)
+_MERC_LAT_LIMIT = 85.05112878   # web-mercator clamp
+
+
+def composition_rgb(pct: float) -> tuple[int, int, int]:
+    """Map a composition percentage (0..100) to an (r, g, b) on the YlOrBr ramp."""
+    f = max(0.0, min(1.0, (pct or 0.0) / 100.0))
+    a, b = _COMPOSITION_STOPS[0], _COMPOSITION_STOPS[-1]
+    for i in range(len(_COMPOSITION_STOPS) - 1):
+        if _COMPOSITION_STOPS[i][0] <= f <= _COMPOSITION_STOPS[i + 1][0]:
+            a, b = _COMPOSITION_STOPS[i], _COMPOSITION_STOPS[i + 1]
+            break
+    span = b[0] - a[0]
+    t = 0.0 if span <= 0 else (f - a[0]) / span
+    return tuple(int(round(a[1][k] + (b[1][k] - a[1][k]) * t)) for k in range(3))
+
+
+def tile_bounds(z: int, x: int, y: int) -> tuple[float, float, float, float]:
+    """(west, south, east, north) WGS84 degrees for slippy/XYZ tile ``z/x/y``."""
+    n = 1 << z
+
+    def lon(xt: float) -> float:
+        return xt / n * 360.0 - 180.0
+
+    def lat(yt: float) -> float:
+        return math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * yt / n))))
+
+    return (lon(x), lat(y + 1), lon(x + 1), lat(y))
+
+
+def _merc_y01(lat_deg: float) -> float:
+    """Normalised web-mercator Y in [0, 1] (0 at the north edge of the world)."""
+    lat = math.radians(max(-_MERC_LAT_LIMIT, min(_MERC_LAT_LIMIT, lat_deg)))
+    return (1.0 - math.log(math.tan(lat) + 1.0 / math.cos(lat)) / math.pi) / 2.0
+
+
+def padded_query_bbox(z: int, x: int, y: int, *, tile_px: int = TILE_PX,
+                      pad_px: int = 8) -> tuple[float, float, float, float]:
+    """The (west, south, east, north) to query composition for when rendering
+    tile ``z/x/y`` -- the tile bounds grown by the blur margin so edge blur pulls
+    in neighbouring polygons (no tile-seam)."""
+    w, s, e, n = tile_bounds(z, x, y)
+    fx = pad_px / tile_px
+    dw = (e - w) * fx
+    dn = (n - s) * fx
+    return (w - dw, s - dn, e + dw, n + dn)
+
+
+def render_composition_tile(features, z: int, x: int, y: int, *,
+                            tile_px: int = TILE_PX, supersample: int = 2,
+                            blur_px: float = 2.0, pad_px: int = 8) -> bytes | None:
+    """Render composition ``features`` -> a ``tile_px`` PNG (bytes), or ``None``
+    when nothing is drawn (an empty tile -- the caller serves a shared
+    transparent PNG and does not persist it, to spare SD writes).
+
+    ``features`` is an iterable of ``{"pct": float, "ring": [[lat, lon], ...]}``
+    (exactly what ``DepthMap.composition_in(bbox)`` yields), for the padded bbox.
+    """
+    from PIL import Image, ImageDraw, ImageFilter   # lazy: keep import off hot paths
+
+    n = 1 << z
+    ss = max(1, int(supersample))
+    S = tile_px * ss
+    P = pad_px * ss
+
+    def to_px(lat: float, lon: float) -> tuple[float, float]:
+        px = ((lon + 180.0) / 360.0 * n - x) * S + P
+        py = (_merc_y01(lat) * n - y) * S + P
+        return (px, py)
+
+    img = Image.new("RGBA", (S + 2 * P, S + 2 * P), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    drew = False
+    for feat in features:
+        ring = feat.get("ring") or []
+        if len(ring) < 3:
+            continue
+        pts = [to_px(float(p[0]), float(p[1])) for p in ring]
+        draw.polygon(pts, fill=composition_rgb(feat.get("pct", 0.0)) + (255,))
+        drew = True
+    if not drew:
+        return None
+
+    if blur_px > 0:
+        img = img.filter(ImageFilter.GaussianBlur(blur_px * ss))
+    img = img.crop((P, P, P + S, P + S))
+    if ss != 1:
+        img = img.resize((tile_px, tile_px), Image.LANCZOS)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def transparent_tile(tile_px: int = TILE_PX) -> bytes:
+    """A fully-transparent ``tile_px`` PNG -- served for empty tiles (and cached
+    in RAM, never written to disk)."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGBA", (tile_px, tile_px), (0, 0, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -11,15 +11,26 @@ _depth_chart_path, _depth_saved_n, _depth_save_in_flight, etc.).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import math
 import os
+import threading
+from collections import OrderedDict
 from typing import TYPE_CHECKING
+
+from ..nav import depth_tiles
 
 if TYPE_CHECKING:
     from ..core.models import GeoPoint
 
 logger = logging.getLogger("vanchor.app")
+
+# Composition raster-tile cache (#117): RAM-LRU in front of a write-once disk
+# cache. Static data -> each tile is written at most once (SD-friendly); the LRU
+# serves hot tiles with no disk read and bounds RAM.
+_TILE_LRU_MAX = 256          # ~a few MB of PNG bytes
+_TILE_MIN_ZOOM = 9           # below this a tile spans too much data to render
 
 
 class DepthService:
@@ -27,6 +38,9 @@ class DepthService:
 
     def __init__(self, rt) -> None:
         self._rt = rt   # back-reference to Runtime for shared state
+        self._tile_lru: "OrderedDict[tuple, bytes]" = OrderedDict()
+        self._tile_lru_lock = threading.Lock()
+        self._transparent_tile: bytes | None = None
 
     # ------------------------------------------------------------------ #
     # Live sounding + divergence
@@ -385,3 +399,98 @@ class DepthService:
                     len(pts), len(hard), len(cont), len(comp), filename)
         return {"ok": True, "imported": len(pts), "hardness": len(hard),
                 "contours": len(cont), "composition": len(comp), "total": len(dm.points)}
+
+    # ------------------------------------------------------------------ #
+    # Composition raster tiles (#117) -- server-rendered, write-once cached
+    # ------------------------------------------------------------------ #
+
+    def _composition_version(self) -> str:
+        """Short cache-busting token for the current composition chart. Changes
+        only when a new chart is imported -- derived from the persisted ``.npz``
+        (mtime + size), so tiles are re-rendered after a real re-import, not on
+        every request. Doubles as the on-disk cache subdir + the client ``?v=``."""
+        from ..nav.depth import DepthMap
+
+        npz = DepthMap._npz_path(self._rt._depth_chart_path)
+        try:
+            st = os.stat(npz)
+            sig = f"{st.st_mtime_ns}-{st.st_size}"
+        except OSError:
+            # No persisted chart on disk: key off the in-memory layer size.
+            sig = f"mem-{len(getattr(self._rt.depth_map, 'composition', ()) or ())}"
+        return hashlib.sha1(sig.encode()).hexdigest()[:12]
+
+    def composition_tiles_info(self) -> dict:
+        """Metadata the client needs to mount the tile layer: whether any
+        composition exists, the cache-busting version, tile size, and the
+        server's minimum render zoom."""
+        has = bool(getattr(self._rt.depth_map, "composition", None))
+        return {"ok": True, "has_composition": has,
+                "version": self._composition_version(),
+                "tile_size": depth_tiles.TILE_PX, "min_zoom": _TILE_MIN_ZOOM}
+
+    def composition_tile(self, z: int, x: int, y: int) -> bytes:
+        """A composition raster-tile PNG for slippy tile ``z/x/y``.
+
+        RAM-LRU -> disk (write-once) -> render. Empty tiles return a shared
+        transparent PNG cached in RAM only (never written, to spare SD writes).
+        Out-of-range or too-far-out (< min zoom) tiles are transparent."""
+        rt = self._rt
+        if self._transparent_tile is None:
+            self._transparent_tile = depth_tiles.transparent_tile()
+        n = (1 << z) if 0 <= z <= 24 else 0
+        if z < _TILE_MIN_ZOOM or n == 0 or not (0 <= x < n and 0 <= y < n):
+            return self._transparent_tile
+        if not getattr(rt.depth_map, "composition", None):
+            return self._transparent_tile
+
+        version = self._composition_version()
+        key = (version, z, x, y)
+        hit = self._tile_lru_get(key)
+        if hit is not None:
+            return hit
+
+        path = os.path.join(rt.config.data_dir, "tiles", "composition",
+                            version, str(z), str(x), f"{y}.png")
+        try:
+            with open(path, "rb") as fh:
+                png = fh.read()
+            self._tile_lru_put(key, png)
+            return png
+        except OSError:
+            pass   # not cached on disk yet -> render below
+
+        bbox = depth_tiles.padded_query_bbox(z, x, y)
+        feats = rt.depth_map.composition_in(bbox, limit=200000)
+        png = depth_tiles.render_composition_tile(feats, z, x, y)
+        if png is None:                       # empty tile: RAM-cache, no SD write
+            self._tile_lru_put(key, self._transparent_tile)
+            return self._transparent_tile
+        self._write_tile_atomic(path, png)    # write-once
+        self._tile_lru_put(key, png)
+        return png
+
+    def _tile_lru_get(self, key: tuple) -> bytes | None:
+        with self._tile_lru_lock:
+            png = self._tile_lru.get(key)
+            if png is not None:
+                self._tile_lru.move_to_end(key)
+            return png
+
+    def _tile_lru_put(self, key: tuple, png: bytes) -> None:
+        with self._tile_lru_lock:
+            self._tile_lru[key] = png
+            self._tile_lru.move_to_end(key)
+            while len(self._tile_lru) > _TILE_LRU_MAX:
+                self._tile_lru.popitem(last=False)
+
+    @staticmethod
+    def _write_tile_atomic(path: str, png: bytes) -> None:
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "wb") as fh:
+                fh.write(png)
+            os.replace(tmp, path)             # atomic; matches the chart writers
+        except OSError as exc:                # pragma: no cover - defensive
+            logger.warning("could not persist depth tile %s: %s", path, exc)

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1446,6 +1446,14 @@ class Runtime:
         """Shim → DepthService (issue #71)."""
         return self._depth.depth_composition(bbox, limit)
 
+    def composition_tile(self, z: int, x: int, y: int) -> bytes:
+        """Shim → DepthService: a composition raster-tile PNG (#117)."""
+        return self._depth.composition_tile(z, x, y)
+
+    def composition_tiles_info(self) -> dict:
+        """Shim → DepthService: composition tile-layer metadata (#117)."""
+        return self._depth.composition_tiles_info()
+
     def water_polygon(self, bbox) -> dict:
         """OSM water polygon(s) for a (west, south, east, north) bbox, used to
         CLIP the depth overlays to water (don't draw composition over land). Uses

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -922,6 +922,25 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
             _malloc_trim_if_glibc()
         return result
 
+    @app.get("/api/depth/tiles/info")
+    async def depth_tiles_info() -> dict:
+        """Metadata for the composition raster-tile layer (#117): whether any
+        composition is loaded, the cache-busting ``version`` (send as ``?v=``),
+        the tile size, and the server's minimum render zoom."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, runtime.composition_tiles_info)
+
+    @app.get("/api/depth/tiles/composition/{z}/{x}/{y}.png")
+    async def depth_tile_composition(z: int, x: int, y: int) -> Response:
+        """A server-rendered composition raster tile (#117). Static per chart, so
+        the client sends ``?v=<version>`` and the tile caches long. Empty tiles
+        come back as a transparent PNG."""
+        loop = asyncio.get_event_loop()
+        png = await loop.run_in_executor(
+            None, lambda: runtime.composition_tile(z, x, y))
+        return Response(content=png, media_type="image/png",
+                        headers={"Cache-Control": "public, max-age=86400"})
+
     @app.get("/api/depth/water")
     async def depth_water(
         west: float, south: float, east: float, north: float,

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -279,6 +279,10 @@
     <div class="comp-legend-bar"></div>
     <div class="depth-legend-labels"><span>0</span><span>100</span></div>
     <div class="depth-legend-cap">composition (0–100%, uncalibrated)</div>
+    <!-- #117: opt-in server-rendered raster tiles (fast, cached) vs live vectors. -->
+    <label class="comp-tiles-toggle" title="Render the composition as fast server tiles instead of live polygons">
+      <input type="checkbox" id="composition-tiles"> fast tiles (beta)
+    </label>
   </div>
 
   <!-- Drop-marker FAB: arms marker placement; tap the map to drop (or long-press

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -1128,6 +1128,7 @@
   let compositionTruncated = false;  // last fetch was ?limit=-capped (partial)
   async function fetchComposition() {
     if (!compositionShow || compositionBusy) return;
+    if (compositionUseTiles) return;        // tile mode draws no vectors (#117)
     if (map.getZoom() < DEPTH_MIN_ZOOM) {   // zoom gate (perf): clear + hint
       compositionLayer.setData([]);
       compHint("zoom in for composition");
@@ -1161,25 +1162,65 @@
     finally { compositionBusy = false; }
     maybeFetchWaterMask();   // async: clips when the water arrives; reused per region
   }
+  // ---- server raster-tile mode (#117, opt-in) --------------------------
+  // Instead of fetching + drawing thousands of vector polygons per move, mount
+  // the server-rendered composition as an ordinary L.TileLayer (the browser
+  // caches PNGs; the server renders each tile once). Off by default; persisted.
+  let compositionUseTiles = false;
+  try { compositionUseTiles = localStorage.getItem("va-composition-tiles") === "1"; } catch (e) { /* private mode */ }
+  let compositionTileLayer = null;
+  function unmountCompositionTiles() {
+    if (compositionTileLayer) { map.removeLayer(compositionTileLayer); compositionTileLayer = null; }
+  }
+  function unmountCompositionVector() {
+    if (map.hasLayer(compositionLayer)) map.removeLayer(compositionLayer);
+    compositionLayer.setData([]);
+    compositionBBox = null;
+  }
+  async function mountCompositionTiles() {
+    let info = null;
+    try { info = await VA.getJSON("/api/depth/tiles/info"); } catch (e) { /* leave */ }
+    if (!compositionShow || !compositionUseTiles) return;   // toggled off while awaiting
+    unmountCompositionTiles();
+    if (!info || !info.has_composition) { compHint(""); return; }   // no chart -> nothing
+    const v = encodeURIComponent(info.version || "0");
+    compositionTileLayer = L.tileLayer(
+      "/api/depth/tiles/composition/{z}/{x}/{y}.png?v=" + v,
+      { pane: "composition", opacity: 0.6, tileSize: info.tile_size || 256,
+        minZoom: info.min_zoom || 9, maxNativeZoom: 18, updateWhenZooming: false,
+        className: "leaflet-depth-composition-tiles" });
+    compositionTileLayer.addTo(map);
+    compHint("");
+  }
+  // Apply the current (show, tiles) combination: exactly one of the vector
+  // overlay / the tile layer is mounted, never both.
+  function applyCompositionMode() {
+    if (!compositionShow) { unmountCompositionTiles(); unmountCompositionVector(); return; }
+    if (compositionUseTiles) { unmountCompositionVector(); mountCompositionTiles(); }
+    else { unmountCompositionTiles(); fetchComposition(); }
+  }
+
   const compositionProxy = L.layerGroup();   // fronts the layers-panel checkbox
   let compositionSyncing = false;
   function setCompositionShow(on) {
     compositionShow = !!on;
     const legend = document.getElementById("composition-legend");
     if (legend) legend.classList.toggle("hidden", !compositionShow);
-    if (compositionShow) {
-      fetchComposition();
-    } else {
-      if (map.hasLayer(compositionLayer)) map.removeLayer(compositionLayer);
-      compositionLayer.setData([]);
-      compositionBBox = null;   // force a fresh fetch when re-enabled
-    }
+    applyCompositionMode();
     compositionSyncing = true;
     if (compositionShow && !map.hasLayer(compositionProxy)) compositionProxy.addTo(map);
     else if (!compositionShow && map.hasLayer(compositionProxy)) map.removeLayer(compositionProxy);
     compositionSyncing = false;
   }
   VA.setCompositionShow = setCompositionShow;
+  function setCompositionTiles(on) {
+    compositionUseTiles = !!on;
+    try { localStorage.setItem("va-composition-tiles", compositionUseTiles ? "1" : "0"); } catch (e) { /* private mode */ }
+    const cb = document.getElementById("composition-tiles");
+    if (cb) cb.checked = compositionUseTiles;
+    applyCompositionMode();   // swap vector <-> tiles live if composition is on
+  }
+  VA.setCompositionTiles = setCompositionTiles;
 
   let gridOk = false;            // true once a grid fetch has succeeded
   let gridTimer = null;
@@ -1660,6 +1701,19 @@
     document.addEventListener("DOMContentLoaded", wireDepthImport);
   } else {
     wireDepthImport();
+  }
+
+  // Wire the "fast tiles (beta)" checkbox in the composition legend (#117).
+  function wireCompositionTiles() {
+    const cb = document.getElementById("composition-tiles");
+    if (!cb) return;
+    cb.checked = compositionUseTiles;
+    cb.addEventListener("change", () => setCompositionTiles(cb.checked));
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wireCompositionTiles);
+  } else {
+    wireCompositionTiles();
   }
 
   // ---- per-frame render --------------------------------------------------

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -540,6 +540,12 @@ body.hud-fade-text .catch-fab::after {
   height: 10px; border-radius: 5px;
   background: linear-gradient(to right, #ffffe5, #fee391, #fe9929, #d95f0e, #993404);
 }
+/* #117: opt-in "fast tiles" toggle under the composition legend. */
+.comp-tiles-toggle {
+  display: flex; align-items: center; gap: 5px;
+  margin-top: 4px; font-size: 11px; color: var(--muted); cursor: pointer;
+}
+.comp-tiles-toggle input { margin: 0; cursor: pointer; }
 
 /* ============================ SAFETY BANNER ============================ */
 /* #banner retired — #safety-banners is the ONLY alarm surface. */

--- a/tests/test_depth_tiles.py
+++ b/tests/test_depth_tiles.py
@@ -1,0 +1,167 @@
+"""Composition raster tiles (#117): the pure Pillow renderer + tile math, and
+the runtime's write-once disk + RAM-LRU cache."""
+
+import io
+import json
+import math
+
+from PIL import Image
+
+from vanchor.app import Runtime
+from vanchor.core.config import load
+from vanchor.nav import depth_tiles
+
+
+# --- pure tile math + renderer --------------------------------------------- #
+
+def test_tile_bounds_world_and_ordering():
+    w, s, e, n = depth_tiles.tile_bounds(0, 0, 0)
+    assert (round(w), round(e)) == (-180, 180)
+    assert n > 0 > s and n == -s          # web-mercator is symmetric about 0
+    assert round(n, 2) == 85.05
+    # a child tile is inside its parent and correctly ordered
+    w2, s2, e2, n2 = depth_tiles.tile_bounds(1, 1, 0)   # NE quadrant
+    assert w2 == 0 and round(e2) == 180 and n2 > s2 >= 0
+
+
+def test_padded_bbox_grows_the_tile():
+    z, x, y = 13, 4400, 2400
+    tw, ts, te, tn = depth_tiles.tile_bounds(z, x, y)
+    pw, ps, pe, pn = depth_tiles.padded_query_bbox(z, x, y)
+    assert pw < tw and ps < ts and pe > te and pn > tn
+
+
+def test_composition_rgb_ramp_endpoints():
+    assert depth_tiles.composition_rgb(0) == (255, 255, 229)     # YlOrBr low
+    assert depth_tiles.composition_rgb(100) == (153, 52, 4)      # YlOrBr high
+    mid = depth_tiles.composition_rgb(50)
+    assert mid == (254, 153, 41)
+
+
+def _deg2tile(lat, lon, z):
+    n = 2 ** z
+    xt = int((lon + 180.0) / 360.0 * n)
+    r = math.radians(lat)
+    yt = int((1 - math.log(math.tan(r) + 1 / math.cos(r)) / math.pi) / 2 * n)
+    return xt, yt
+
+
+def _ring(lat, lon, half=0.004):
+    return [[lat - half, lon - half], [lat - half, lon + half],
+            [lat + half, lon + half], [lat + half, lon - half]]
+
+
+def test_render_returns_opaque_png_for_a_polygon():
+    lat, lon, z = 59.0, 18.0, 13
+    x, y = _deg2tile(lat, lon, z)
+    feats = [{"pct": 75.0, "ring": _ring(lat, lon)}]
+    png = depth_tiles.render_composition_tile(feats, z, x, y)
+    assert png is not None
+    img = Image.open(io.BytesIO(png))
+    assert img.size == (256, 256) and img.mode == "RGBA"
+    alpha_max = img.split()[3].getextrema()[1]
+    assert alpha_max > 0                    # something was actually drawn
+
+
+def test_render_empty_features_is_none():
+    assert depth_tiles.render_composition_tile([], 13, 4400, 2400) is None
+    # a polygon entirely outside the tile draws nothing visible but still fills
+    # its (off-tile) pixels; a degenerate <3-vertex ring is skipped -> None
+    assert depth_tiles.render_composition_tile(
+        [{"pct": 50, "ring": [[59.0, 18.0], [59.0, 18.001]]}], 13, 4400, 2400) is None
+
+
+def test_transparent_tile_is_fully_transparent():
+    img = Image.open(io.BytesIO(depth_tiles.transparent_tile()))
+    assert img.size == (256, 256)
+    assert img.split()[3].getextrema() == (0, 0)
+
+
+# --- runtime cache (write-once disk + RAM-LRU) ----------------------------- #
+
+def _rt(tmp_path):
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    return Runtime(cfg)
+
+
+_COMP = json.dumps({"type": "FeatureCollection", "features": [
+    {"geometry": {"type": "Polygon", "coordinates": [[
+        [18.0, 59.0], [18.008, 59.0], [18.008, 59.008], [18.0, 59.008], [18.0, 59.0]]]},
+     "properties": {"composition_pct": 75.0, "kind": "composition"}},
+]}).encode()
+
+
+def test_tile_written_once_then_read_from_disk(tmp_path, monkeypatch):
+    rt = _rt(tmp_path)
+    assert rt.import_depth_map("c.geojson", _COMP, replace=True)["composition"] == 1
+    z = 13
+    x, y = _deg2tile(59.004, 18.004, z)
+
+    calls = {"n": 0}
+    real = depth_tiles.render_composition_tile
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return real(*a, **k)
+
+    monkeypatch.setattr(depth_tiles, "render_composition_tile", counting)
+
+    png1 = rt.composition_tile(z, x, y)
+    assert png1 and Image.open(io.BytesIO(png1)).split()[3].getextrema()[1] > 0
+    assert calls["n"] == 1
+
+    # persisted to <data_dir>/tiles/composition/<ver>/<z>/<x>/<y>.png
+    ver = rt._depth.composition_tiles_info()["version"]
+    tile_path = tmp_path / "tiles" / "composition" / ver / str(z) / str(x) / f"{y}.png"
+    assert tile_path.exists()
+
+    # drop the RAM cache -> a second request must read DISK, not re-render
+    rt._depth._tile_lru.clear()
+    png2 = rt.composition_tile(z, x, y)
+    assert png2 == png1
+    assert calls["n"] == 1                  # write-once: no second render
+
+
+def test_empty_tile_is_transparent_and_not_written(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    z = 13
+    # a tile far from the (59,18) polygon -> empty
+    x, y = _deg2tile(40.0, -100.0, z)
+    png = rt.composition_tile(z, x, y)
+    assert png == depth_tiles.transparent_tile()
+    ver = rt._depth.composition_tiles_info()["version"]
+    assert not (tmp_path / "tiles" / "composition" / ver / str(z)).exists()
+
+
+def test_below_min_zoom_and_out_of_range_are_transparent(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    tp = depth_tiles.transparent_tile()
+    assert rt.composition_tile(3, 4, 2) == tp        # below _TILE_MIN_ZOOM
+    assert rt.composition_tile(13, -1, 0) == tp      # x out of range
+    assert rt.composition_tile(13, 0, 1 << 13) == tp  # y out of range
+
+
+def test_no_composition_tile_is_transparent(tmp_path):
+    rt = _rt(tmp_path)                                # nothing imported
+    info = rt.composition_tiles_info()
+    assert info["has_composition"] is False and info["tile_size"] == 256
+    assert rt.composition_tile(13, 4400, 2400) == depth_tiles.transparent_tile()
+
+
+def test_version_changes_when_composition_changes(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    v1 = rt.composition_tiles_info()["version"]
+    bigger = json.dumps({"type": "FeatureCollection", "features": [
+        {"geometry": {"type": "Polygon", "coordinates": [[
+            [18.0, 59.0], [18.02, 59.0], [18.02, 59.02], [18.0, 59.02], [18.0, 59.0]]]},
+         "properties": {"composition_pct": 40.0, "kind": "composition"}},
+        {"geometry": {"type": "Polygon", "coordinates": [[
+            [18.1, 59.1], [18.12, 59.1], [18.12, 59.12], [18.1, 59.12], [18.1, 59.1]]]},
+         "properties": {"composition_pct": 90.0, "kind": "composition"}},
+    ]}).encode()
+    rt.import_depth_map("c2.geojson", bigger, replace=True)
+    assert rt.composition_tiles_info()["version"] != v1


### PR DESCRIPTION
The keystone of the depth raster-tile epic (#116): render the static **bottom-composition** overlay as server-side raster tiles instead of live vector polygons. Decisions locked earlier — **Pillow renderer**, **lazy render → write-once SD cache**, **256 px tiles**.

Closes #117.

## Server
- **`nav/depth_tiles.py`** — pure Pillow renderer + XYZ tile math (`tile_bounds`, `padded_query_bbox`, `render_composition_tile`, `transparent_tile`); no runtime coupling, unit-testable headless. Fills are **opaque** (the client `TileLayer` applies 0.6 opacity, so overlapping polys never double-darken), edges blended with a Gaussian blur, and a render margin pulls in neighbour-tile polygons so there's **no tile seam**. 256 px, 2× supersample → downscale for antialiased edgeless bands.
- **`runtime/depth.py`** — `DepthService.composition_tile()` wraps it with a **RAM-LRU → write-once disk** cache under `<data_dir>/tiles/composition/<version>/`. Each non-empty tile renders + writes **once** (SD-friendly); empty tiles are a shared transparent PNG kept in RAM only (never written). `version` = short hash of the persisted `.npz` (mtime+size), so a re-import re-renders.
- **`ui/server.py`** — `GET /api/depth/tiles/info` + `GET /api/depth/tiles/composition/{z}/{x}/{y}.png`.

## Client (`map-depth.js`)
- Opt-in **"fast tiles (beta)"** toggle (`VA.setCompositionTiles`, persisted in `localStorage`) swaps the vector overlay for an `L.TileLayer`. Tiles render at **any** zoom (no 8000-polygon truncation) and the browser caches them, so panning/zooming is smooth. `applyCompositionMode()` keeps exactly one of vector/tiles mounted; the live-vector overlay stays the **default + fallback**.

## Verification
- Stitched 5×5 real-data render is **seamless + edgeless** (the padding + blur work).
- Live at **z14** (where the vector path truncated to "partial — zoom in") the tiles render the full lake, no console errors.
- Write-once disk cache confirmed: dense tile persisted, empty land tile absent from disk; second request after clearing the RAM LRU reads disk (renderer not called again).

## Tests
`tests/test_depth_tiles.py` (11): tile math, renderer opaque/empty, transparent tile, write-once + read-from-disk, empty-not-written, min-zoom/out-of-range transparent, version-changes-on-reimport. Full suite **2185 passed**; ruff + `node --check` + e2e smoke (no console errors) + playwright e2e (11) green. Pillow added to core deps.

## Known follow-up (tracked on #116)
Tiles aren't yet **water-mask-clipped** like the vector overlay, so a little soft fill can bleed past the shoreline. Candidate for the polish phase (#121) or a dedicated item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)