### PR TITLE
feat(depth): depth-contour raster tiles (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Depth-contour raster tiles (#118, part of #116).** The **"fast tiles (beta)"**
+  toggle now also renders the depth contours as server-side tiles, stacked above
+  the composition tiles: thin dark isobath lines (the nautical "composition +
+  contours" chart look) via `GET /api/depth/tiles/contours/{z}/{x}/{y}.png`. Like
+  composition tiles they render at any zoom, are cached RAM-LRU → write-once on
+  disk under their own `<data_dir>/tiles/contours/<version>/`, and share the chart
+  `version`. `/api/depth/tiles/info` now reports `has_contours`. The live-vector
+  contour overlay (including its marching-squares fallback) remains the default.
+
 - **Composition raster tiles — keystone (#117, part of #116).** The static
   bottom-composition overlay can now render as **server-side raster tiles**
   instead of live vector polygons: a Pillow renderer (`nav/depth_tiles.py`)

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -321,21 +321,25 @@ the decompressed leading byte; `open_depth_text` gunzips the spilled file
 lazily, so the bounded streaming import stays bounded on a gzipped chart too).
 A `.geojsonl` compresses ~10× (a 300 MB cmapper export → ~50 MB upload).
 
-**Composition raster tiles (#117).** `nav/depth_tiles.py` is a pure Pillow
+**Static-chart raster tiles (#116).** `nav/depth_tiles.py` is a pure Pillow
 renderer + XYZ tile math (`tile_bounds`, `padded_query_bbox`,
-`render_composition_tile`, `transparent_tile`) — no runtime coupling, so it's
-unit-testable headless. `DepthService.composition_tile(z, x, y)` wraps it with a
-**RAM-LRU → write-once disk** cache under `<data_dir>/tiles/composition/<version>/`:
-each non-empty tile is rendered + written **once** (SD-friendly), empty tiles
-return a shared transparent PNG cached in RAM only (never written). `version` is
-a short hash of the persisted `.npz` (mtime+size), so a re-import re-renders.
-Fills are drawn **opaque** (the client `L.TileLayer` applies 0.6 opacity, so
-overlapping polys never double-darken), edges blended with a Gaussian blur, and a
-render margin pulls in neighbour-tile polygons so there's no tile seam. Endpoints:
-`GET /api/depth/tiles/info` (`{has_composition, version, tile_size, min_zoom}`)
-and `GET /api/depth/tiles/composition/{z}/{x}/{y}.png`. Opt-in on the client via
-the "fast tiles (beta)" toggle; the live-vector overlay is the default/fallback.
-Design + roadmap: [`../depth-tiles.md`](../depth-tiles.md) (epic #116).
+`render_composition_tile`, `render_contours_tile`, `transparent_tile`) — no
+runtime coupling, so it's unit-testable headless. Two tiled layers share the
+machinery: **composition (#117)** — opaque YlOrBr fills (client `L.TileLayer`
+applies 0.6 opacity so overlaps never double-darken), Gaussian edge-blend; and
+**contours (#118)** — thin dark isobath lines, no blur, that read cleanly over
+the fill (the cmapper chart look). Both use a render margin so features are
+continuous across tile seams. `DepthService.{composition,contours}_tile(z, x, y)`
+wrap `_layer_tile()` with a **RAM-LRU → write-once disk** cache under
+`<data_dir>/tiles/<layer>/<version>/`: each non-empty tile is rendered + written
+**once** (SD-friendly), empty tiles are a shared transparent PNG kept in RAM only.
+`version` is a short hash of the persisted `.npz` (mtime+size, shared by both
+layers), so a re-import re-renders. Endpoints: `GET /api/depth/tiles/info`
+(`{has_composition, has_contours, version, tile_size, min_zoom}`),
+`/tiles/composition/{z}/{x}/{y}.png`, `/tiles/contours/{z}/{x}/{y}.png`. Opt-in on
+the client via the "fast tiles (beta)" toggle (drives both layers); the
+live-vector overlays are the default/fallback. Design + roadmap:
+[`../depth-tiles.md`](../depth-tiles.md) (epic #116).
 
 ### `Runtime` depth methods (`runtime/depth.py`)
 

--- a/docs/llms/frontend.md
+++ b/docs/llms/frontend.md
@@ -206,7 +206,11 @@ module (Catches, heatmap, no-go).
   PNGs (`/api/depth/tiles/composition/{z}/{x}/{y}.png?v=<version>`, opacity 0.6, in
   the `composition` pane). Tiles render at any zoom (no 8000-poly truncation) and the
   browser caches them; the vector path stays the default/fallback. `applyCompositionMode`
-  keeps exactly one of the two mounted.
+  keeps exactly one of the two mounted. The **same toggle** also swaps the **depth
+  contours** to tiles (#118): a contour `L.TileLayer` (thin dark isobaths, in the
+  `contourTiles` pane above composition) via `applyContourMode`; tile mode renders
+  imported isobaths only (the marching-squares grid fallback is vector-only, and the
+  grid poll stops for tiled contours).
 
 ### `CanvasOverlayMixin` — two load-bearing invariants (do not regress)
 

--- a/src/vanchor/nav/depth_tiles.py
+++ b/src/vanchor/nav/depth_tiles.py
@@ -119,6 +119,54 @@ def render_composition_tile(features, z: int, x: int, y: int, *,
     return buf.getvalue()
 
 
+def render_contours_tile(features, z: int, x: int, y: int, *,
+                         tile_px: int = TILE_PX, supersample: int = 2,
+                         pad_px: int = 4) -> bytes | None:
+    """Render depth-contour ``features`` (isobaths) -> a ``tile_px`` PNG, or
+    ``None`` when nothing is drawn.
+
+    Thin dark semi-transparent lines (the nautical "composition + contours" chart
+    look) that read cleanly over the soft composition fill -- major isobaths
+    (every 5 m) a touch stronger. ``features`` is ``{"d": depth, "pts": [[lat,
+    lon], ...]}`` (``DepthMap.contours_in(bbox)``). Rendered at ``supersample``x
+    then downsampled for crisp antialiased lines; a render margin keeps lines
+    continuous across tile seams. No blur (lines stay sharp)."""
+    from PIL import Image, ImageDraw
+
+    n = 1 << z
+    ss = max(1, int(supersample))
+    S = tile_px * ss
+    P = pad_px * ss
+
+    def to_px(lat: float, lon: float) -> tuple[float, float]:
+        px = ((lon + 180.0) / 360.0 * n - x) * S + P
+        py = (_merc_y01(lat) * n - y) * S + P
+        return (px, py)
+
+    img = Image.new("RGBA", (S + 2 * P, S + 2 * P), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    drew = False
+    for feat in features:
+        ll = feat.get("pts") or []
+        if len(ll) < 2:
+            continue
+        major = round(float(feat.get("d", 0.0))) % 5 == 0
+        colour = (28, 28, 28, 210 if major else 150)     # #1c1c1c, darker for major
+        width = int(round((1.5 if major else 1.0) * ss))
+        draw.line([to_px(float(p[0]), float(p[1])) for p in ll],
+                  fill=colour, width=width, joint="curve")
+        drew = True
+    if not drew:
+        return None
+
+    img = img.crop((P, P, P + S, P + S))
+    if ss != 1:
+        img = img.resize((tile_px, tile_px), Image.LANCZOS)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def transparent_tile(tile_px: int = TILE_PX) -> bytes:
     """A fully-transparent ``tile_px`` PNG -- served for empty tiles (and cached
     in RAM, never written to disk)."""

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -401,14 +401,21 @@ class DepthService:
                 "contours": len(cont), "composition": len(comp), "total": len(dm.points)}
 
     # ------------------------------------------------------------------ #
-    # Composition raster tiles (#117) -- server-rendered, write-once cached
+    # Static-chart raster tiles (#116) -- server-rendered, write-once cached.
+    # Composition (#117) + contours (#118) share the cache + version machinery.
     # ------------------------------------------------------------------ #
 
-    def _composition_version(self) -> str:
-        """Short cache-busting token for the current composition chart. Changes
-        only when a new chart is imported -- derived from the persisted ``.npz``
-        (mtime + size), so tiles are re-rendered after a real re-import, not on
-        every request. Doubles as the on-disk cache subdir + the client ``?v=``."""
+    def _transparent(self) -> bytes:
+        if self._transparent_tile is None:
+            self._transparent_tile = depth_tiles.transparent_tile()
+        return self._transparent_tile
+
+    def _chart_tiles_version(self) -> str:
+        """Short cache-busting token for the current chart. Changes only when a
+        new chart is imported -- derived from the persisted ``.npz`` (mtime +
+        size), so tiles re-render after a real re-import, not on every request.
+        Shared by both tiled layers (they come from the same ``.npz``); doubles
+        as the on-disk cache subdir + the client ``?v=``."""
         from ..nav.depth import DepthMap
 
         npz = DepthMap._npz_path(self._rt._depth_chart_path)
@@ -416,41 +423,40 @@ class DepthService:
             st = os.stat(npz)
             sig = f"{st.st_mtime_ns}-{st.st_size}"
         except OSError:
-            # No persisted chart on disk: key off the in-memory layer size.
-            sig = f"mem-{len(getattr(self._rt.depth_map, 'composition', ()) or ())}"
+            dm = self._rt.depth_map
+            sig = (f"mem-{len(getattr(dm, 'composition', ()) or ())}"
+                   f"-{len(getattr(dm, 'contours', ()) or ())}")
         return hashlib.sha1(sig.encode()).hexdigest()[:12]
 
-    def composition_tiles_info(self) -> dict:
-        """Metadata the client needs to mount the tile layer: whether any
-        composition exists, the cache-busting version, tile size, and the
-        server's minimum render zoom."""
-        has = bool(getattr(self._rt.depth_map, "composition", None))
-        return {"ok": True, "has_composition": has,
-                "version": self._composition_version(),
+    def tiles_info(self) -> dict:
+        """Metadata the client needs to mount the tile layers: which static
+        layers exist, the cache-busting version, tile size, min render zoom."""
+        dm = self._rt.depth_map
+        return {"ok": True,
+                "has_composition": bool(getattr(dm, "composition", None)),
+                "has_contours": bool(getattr(dm, "contours", None)),
+                "version": self._chart_tiles_version(),
                 "tile_size": depth_tiles.TILE_PX, "min_zoom": _TILE_MIN_ZOOM}
 
-    def composition_tile(self, z: int, x: int, y: int) -> bytes:
-        """A composition raster-tile PNG for slippy tile ``z/x/y``.
-
-        RAM-LRU -> disk (write-once) -> render. Empty tiles return a shared
-        transparent PNG cached in RAM only (never written, to spare SD writes).
-        Out-of-range or too-far-out (< min zoom) tiles are transparent."""
+    def _layer_tile(self, layer: str, z: int, x: int, y: int,
+                    features_fn, render_fn) -> bytes:
+        """Shared tile path for a static layer: RAM-LRU -> disk (write-once) ->
+        render. Empty tiles return a shared transparent PNG cached in RAM only
+        (never written, to spare SD writes). Out-of-range / too-far-out (< min
+        zoom) tiles are transparent."""
         rt = self._rt
-        if self._transparent_tile is None:
-            self._transparent_tile = depth_tiles.transparent_tile()
+        transparent = self._transparent()
         n = (1 << z) if 0 <= z <= 24 else 0
         if z < _TILE_MIN_ZOOM or n == 0 or not (0 <= x < n and 0 <= y < n):
-            return self._transparent_tile
-        if not getattr(rt.depth_map, "composition", None):
-            return self._transparent_tile
+            return transparent
 
-        version = self._composition_version()
-        key = (version, z, x, y)
+        version = self._chart_tiles_version()
+        key = (layer, version, z, x, y)
         hit = self._tile_lru_get(key)
         if hit is not None:
             return hit
 
-        path = os.path.join(rt.config.data_dir, "tiles", "composition",
+        path = os.path.join(rt.config.data_dir, "tiles", layer,
                             version, str(z), str(x), f"{y}.png")
         try:
             with open(path, "rb") as fh:
@@ -460,15 +466,32 @@ class DepthService:
         except OSError:
             pass   # not cached on disk yet -> render below
 
-        bbox = depth_tiles.padded_query_bbox(z, x, y)
-        feats = rt.depth_map.composition_in(bbox, limit=200000)
-        png = depth_tiles.render_composition_tile(feats, z, x, y)
+        feats = features_fn(depth_tiles.padded_query_bbox(z, x, y))
+        png = render_fn(feats, z, x, y)
         if png is None:                       # empty tile: RAM-cache, no SD write
-            self._tile_lru_put(key, self._transparent_tile)
-            return self._transparent_tile
+            self._tile_lru_put(key, transparent)
+            return transparent
         self._write_tile_atomic(path, png)    # write-once
         self._tile_lru_put(key, png)
         return png
+
+    def composition_tile(self, z: int, x: int, y: int) -> bytes:
+        """A bottom-composition raster-tile PNG for slippy tile ``z/x/y`` (#117)."""
+        if not getattr(self._rt.depth_map, "composition", None):
+            return self._transparent()
+        return self._layer_tile(
+            "composition", z, x, y,
+            lambda bbox: self._rt.depth_map.composition_in(bbox, limit=200000),
+            depth_tiles.render_composition_tile)
+
+    def contours_tile(self, z: int, x: int, y: int) -> bytes:
+        """A depth-contour (isobath) raster-tile PNG for slippy tile ``z/x/y`` (#118)."""
+        if not getattr(self._rt.depth_map, "contours", None):
+            return self._transparent()
+        return self._layer_tile(
+            "contours", z, x, y,
+            lambda bbox: self._rt.depth_map.contours_in(bbox, limit=200000),
+            depth_tiles.render_contours_tile)
 
     def _tile_lru_get(self, key: tuple) -> bytes | None:
         with self._tile_lru_lock:

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1450,9 +1450,13 @@ class Runtime:
         """Shim → DepthService: a composition raster-tile PNG (#117)."""
         return self._depth.composition_tile(z, x, y)
 
-    def composition_tiles_info(self) -> dict:
-        """Shim → DepthService: composition tile-layer metadata (#117)."""
-        return self._depth.composition_tiles_info()
+    def contours_tile(self, z: int, x: int, y: int) -> bytes:
+        """Shim → DepthService: a depth-contour raster-tile PNG (#118)."""
+        return self._depth.contours_tile(z, x, y)
+
+    def tiles_info(self) -> dict:
+        """Shim → DepthService: static-chart tile-layer metadata (#116)."""
+        return self._depth.tiles_info()
 
     def water_polygon(self, bbox) -> dict:
         """OSM water polygon(s) for a (west, south, east, north) bbox, used to

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -924,11 +924,11 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
 
     @app.get("/api/depth/tiles/info")
     async def depth_tiles_info() -> dict:
-        """Metadata for the composition raster-tile layer (#117): whether any
-        composition is loaded, the cache-busting ``version`` (send as ``?v=``),
-        the tile size, and the server's minimum render zoom."""
+        """Metadata for the static-chart raster-tile layers (#116): which layers
+        are loaded (``has_composition`` / ``has_contours``), the cache-busting
+        ``version`` (send as ``?v=``), the tile size, and the min render zoom."""
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, runtime.composition_tiles_info)
+        return await loop.run_in_executor(None, runtime.tiles_info)
 
     @app.get("/api/depth/tiles/composition/{z}/{x}/{y}.png")
     async def depth_tile_composition(z: int, x: int, y: int) -> Response:
@@ -938,6 +938,16 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
         loop = asyncio.get_event_loop()
         png = await loop.run_in_executor(
             None, lambda: runtime.composition_tile(z, x, y))
+        return Response(content=png, media_type="image/png",
+                        headers={"Cache-Control": "public, max-age=86400"})
+
+    @app.get("/api/depth/tiles/contours/{z}/{x}/{y}.png")
+    async def depth_tile_contours(z: int, x: int, y: int) -> Response:
+        """A server-rendered depth-contour (isobath) raster tile (#118). Stacks
+        above the composition tile; thin dark lines. Transparent when empty."""
+        loop = asyncio.get_event_loop()
+        png = await loop.run_in_executor(
+            None, lambda: runtime.contours_tile(z, x, y))
         return Response(content=png, media_type="image/png",
                         headers={"Cache-Control": "public, max-age=86400"})
 

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -961,12 +961,20 @@
     return a[1].map((ch, i) => Math.round(ch + (b[1][i] - ch) * tt));
   }
   // Render composition UNDER the contour lines: its own pane below overlayPane
-  // (tilePane 200 < composition 350 < overlayPane 400 where contours live).
+  // (tilePane 200 < composition 350 < contourTiles 360 < overlayPane 400 where
+  // the vector contours live).
   if (!map.getPane("composition")) {
     map.createPane("composition");
     const cp = map.getPane("composition");
     cp.style.zIndex = "350";
     cp.style.pointerEvents = "none";
+  }
+  // Contour raster tiles (#118) sit just above the composition tiles.
+  if (!map.getPane("contourTiles")) {
+    map.createPane("contourTiles");
+    const ctp = map.getPane("contourTiles");
+    ctp.style.zIndex = "360";
+    ctp.style.pointerEvents = "none";
   }
   const CompositionLayer = L.Layer.extend(Object.assign({}, CanvasOverlayMixin, {
     onAdd(m) {
@@ -1213,12 +1221,47 @@
     compositionSyncing = false;
   }
   VA.setCompositionShow = setCompositionShow;
+  // Contour raster tiles (#118): the SAME "fast tiles" toggle swaps the
+  // imported-isobath overlay to server tiles, stacked ABOVE the composition
+  // tiles (thin dark lines over the soft fill). Tile mode renders imported
+  // isobaths only -- the marching-squares grid fallback is a vector-mode feature.
+  let contourTileLayer = null;
+  function unmountContourTiles() {
+    if (contourTileLayer) { map.removeLayer(contourTileLayer); contourTileLayer = null; }
+  }
+  function unmountContourVector() {
+    if (map.hasLayer(contourLayer)) map.removeLayer(contourLayer);
+    contourLayer.setExplicit(null);
+    hasExplicitContours = false;
+  }
+  async function mountContourTiles() {
+    let info = null;
+    try { info = await VA.getJSON("/api/depth/tiles/info"); } catch (e) { /* leave */ }
+    if (!contourShow || !compositionUseTiles) return;   // toggled off while awaiting
+    unmountContourTiles();
+    if (!info || !info.has_contours) { contourHint(""); return; }
+    const v = encodeURIComponent(info.version || "0");
+    contourTileLayer = L.tileLayer(
+      "/api/depth/tiles/contours/{z}/{x}/{y}.png?v=" + v,
+      { pane: "contourTiles", opacity: 0.9, tileSize: info.tile_size || 256,
+        minZoom: info.min_zoom || 9, maxNativeZoom: 18, updateWhenZooming: false,
+        className: "leaflet-depth-contours-tiles" });
+    contourTileLayer.addTo(map);
+    contourHint("");
+  }
+  function applyContourMode() {
+    if (!contourShow) { unmountContourTiles(); unmountContourVector(); stopGridPoll(); return; }
+    if (compositionUseTiles) { unmountContourVector(); stopGridPoll(); mountContourTiles(); }
+    else { unmountContourTiles(); fetchContours(); startGridPoll(); if (gridOk) fetchDepthGrid(); }
+  }
+
   function setCompositionTiles(on) {
     compositionUseTiles = !!on;
     try { localStorage.setItem("va-composition-tiles", compositionUseTiles ? "1" : "0"); } catch (e) { /* private mode */ }
     const cb = document.getElementById("composition-tiles");
     if (cb) cb.checked = compositionUseTiles;
-    applyCompositionMode();   // swap vector <-> tiles live if composition is on
+    applyCompositionMode();   // composition: swap vector <-> tiles
+    applyContourMode();       // contours ride the same toggle (#118)
   }
   VA.setCompositionTiles = setCompositionTiles;
 
@@ -1305,6 +1348,7 @@
   let contoursBusy = false;
   async function fetchContours() {
     if (!contourShow || contoursBusy) return;
+    if (compositionUseTiles) return;        // tile mode draws no vector isobaths (#118)
     if (map.getZoom() < DEPTH_MIN_ZOOM) {   // zoom gate (perf): clear + hint
       contourLayer.setExplicit(null);       // drop imported isobaths
       contourLayer.setData([]);             // drop the marching-squares field
@@ -1355,8 +1399,10 @@
     gridTimer = setInterval(pollGridTick, 4000); // depth map changes slowly
   }
   function stopGridPoll() {
-    // Keep polling while either consumer (heatmap or contours) is still on.
-    if (depthShow || contourShow) return;
+    // Keep polling while a consumer still needs the grid: the heatmap, or the
+    // VECTOR contour overlay (its marching-squares fallback). Tiled contours
+    // (#118) render server-side and don't use the grid.
+    if (depthShow || (contourShow && !compositionUseTiles)) return;
     if (gridTimer) { clearInterval(gridTimer); gridTimer = null; }
   }
 
@@ -1451,16 +1497,9 @@
   function setContourShow(on) {
     on = !!on;
     contourShow = on;
-    if (on) {
-      fetchContours();   // prefer explicit imported isobaths (windowed)
-      startGridPoll();   // shared with the heatmap; safe to call when running
-      if (gridOk) fetchDepthGrid();
-    } else {
-      if (map.hasLayer(contourLayer)) map.removeLayer(contourLayer);
-      contourLayer.setExplicit(null);
-      hasExplicitContours = false;
-      stopGridPoll();    // no-op while the heatmap is still on
-    }
+    // applyContourMode mounts exactly one of: contour tiles (#118) / vector
+    // isobaths + marching-squares fallback, or unmounts everything when off.
+    applyContourMode();
     // Mirror into the control proxy (suppressing its own add/remove handler).
     contourSyncing = true;
     if (on && !map.hasLayer(contourProxy)) contourProxy.addTo(map);

--- a/tests/test_depth_tiles.py
+++ b/tests/test_depth_tiles.py
@@ -112,7 +112,7 @@ def test_tile_written_once_then_read_from_disk(tmp_path, monkeypatch):
     assert calls["n"] == 1
 
     # persisted to <data_dir>/tiles/composition/<ver>/<z>/<x>/<y>.png
-    ver = rt._depth.composition_tiles_info()["version"]
+    ver = rt._depth.tiles_info()["version"]
     tile_path = tmp_path / "tiles" / "composition" / ver / str(z) / str(x) / f"{y}.png"
     assert tile_path.exists()
 
@@ -131,7 +131,7 @@ def test_empty_tile_is_transparent_and_not_written(tmp_path):
     x, y = _deg2tile(40.0, -100.0, z)
     png = rt.composition_tile(z, x, y)
     assert png == depth_tiles.transparent_tile()
-    ver = rt._depth.composition_tiles_info()["version"]
+    ver = rt._depth.tiles_info()["version"]
     assert not (tmp_path / "tiles" / "composition" / ver / str(z)).exists()
 
 
@@ -146,15 +146,72 @@ def test_below_min_zoom_and_out_of_range_are_transparent(tmp_path):
 
 def test_no_composition_tile_is_transparent(tmp_path):
     rt = _rt(tmp_path)                                # nothing imported
-    info = rt.composition_tiles_info()
-    assert info["has_composition"] is False and info["tile_size"] == 256
+    info = rt.tiles_info()
+    assert info["has_composition"] is False and info["has_contours"] is False
+    assert info["tile_size"] == 256
     assert rt.composition_tile(13, 4400, 2400) == depth_tiles.transparent_tile()
+    assert rt.contours_tile(13, 4400, 2400) == depth_tiles.transparent_tile()
+
+
+# --- contour tiles (#118) -------------------------------------------------- #
+
+def test_render_contours_returns_png_for_a_line():
+    lat, lon, z = 59.0, 18.0, 13
+    x, y = _deg2tile(lat, lon, z)
+    feats = [{"d": 5.0, "pts": [[lat - 0.004, lon - 0.004], [lat + 0.004, lon + 0.004]]}]
+    png = depth_tiles.render_contours_tile(feats, z, x, y)
+    assert png is not None
+    img = Image.open(io.BytesIO(png))
+    assert img.size == (256, 256) and img.mode == "RGBA"
+    assert img.split()[3].getextrema()[1] > 0        # a line was drawn
+
+
+def test_render_contours_empty_is_none():
+    assert depth_tiles.render_contours_tile([], 13, 4400, 2400) is None
+    assert depth_tiles.render_contours_tile(
+        [{"d": 5, "pts": [[59.0, 18.0]]}], 13, 4400, 2400) is None   # <2 pts skipped
+
+
+_COMP_AND_CONTOURS = json.dumps({"type": "FeatureCollection", "features": [
+    {"geometry": {"type": "Polygon", "coordinates": [[
+        [18.0, 59.0], [18.008, 59.0], [18.008, 59.008], [18.0, 59.008], [18.0, 59.0]]]},
+     "properties": {"composition_pct": 75.0, "kind": "composition"}},
+    {"geometry": {"type": "LineString",
+                  "coordinates": [[18.0, 59.0], [18.004, 59.004], [18.008, 59.008]]},
+     "properties": {"depth_m": 5.0, "kind": "contour"}},
+]}).encode()
+
+
+def test_contour_tile_written_once_then_read_from_disk(tmp_path, monkeypatch):
+    rt = _rt(tmp_path)
+    r = rt.import_depth_map("c.geojson", _COMP_AND_CONTOURS, replace=True)
+    assert r["contours"] == 1 and r["composition"] == 1
+    assert rt.tiles_info()["has_contours"] is True
+    z = 13
+    x, y = _deg2tile(59.004, 18.004, z)
+
+    calls = {"n": 0}
+    real = depth_tiles.render_contours_tile
+    monkeypatch.setattr(depth_tiles, "render_contours_tile",
+                        lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1) or real(*a, **k)))
+
+    png1 = rt.contours_tile(z, x, y)
+    assert png1 and Image.open(io.BytesIO(png1)).split()[3].getextrema()[1] > 0
+    assert calls["n"] == 1
+    ver = rt._depth.tiles_info()["version"]
+    # contours persist under their OWN layer dir (distinct from composition's)
+    assert (tmp_path / "tiles" / "contours" / ver / str(z) / str(x) / f"{y}.png").exists()
+    assert not (tmp_path / "tiles" / "composition").exists()   # not fetched here
+
+    rt._depth._tile_lru.clear()
+    assert rt.contours_tile(z, x, y) == png1
+    assert calls["n"] == 1                            # write-once: no re-render
 
 
 def test_version_changes_when_composition_changes(tmp_path):
     rt = _rt(tmp_path)
     rt.import_depth_map("c.geojson", _COMP, replace=True)
-    v1 = rt.composition_tiles_info()["version"]
+    v1 = rt.tiles_info()["version"]
     bigger = json.dumps({"type": "FeatureCollection", "features": [
         {"geometry": {"type": "Polygon", "coordinates": [[
             [18.0, 59.0], [18.02, 59.0], [18.02, 59.02], [18.0, 59.02], [18.0, 59.0]]]},
@@ -164,4 +221,4 @@ def test_version_changes_when_composition_changes(tmp_path):
          "properties": {"composition_pct": 90.0, "kind": "composition"}},
     ]}).encode()
     rt.import_depth_map("c2.geojson", bigger, replace=True)
-    assert rt.composition_tiles_info()["version"] != v1
+    assert rt.tiles_info()["version"] != v1


### PR DESCRIPTION
Phase 2 of the tiling epic (#116): the **"fast tiles (beta)"** toggle now also renders the depth contours as server tiles, stacked above the composition tiles — completing the cmapper *"composition + contours"* chart look, live and at any zoom. Closes #118.

## What
- **`nav/depth_tiles.py`** — `render_contours_tile()`: thin dark isobath lines (major/every-5 m a touch stronger), supersample → downscale for crisp antialiased lines, render margin for seamless tile borders, no blur.
- **`runtime/depth.py`** — refactored the composition cache into a layer-generic `_layer_tile()` (RAM-LRU → write-once disk under `tiles/<layer>/<version>/`); added `contours_tile()`. `_composition_version` → shared `_chart_tiles_version` (both layers share the `.npz`-derived version). `composition_tiles_info` → `tiles_info()` now reports `has_contours`.
- **`ui/server.py`** — `GET /api/depth/tiles/contours/{z}/{x}/{y}.png`; info reports `has_contours`.
- **`map-depth.js`** — contour `L.TileLayer` in a new `contourTiles` pane (above composition); `applyContourMode()` mounts exactly one of tiles/vector; the same toggle drives **both** layers; `fetchContours` no-ops in tile mode; the grid poll stops for tiled contours (no marching-squares needed).

## Verification
Live at **z14**: smooth composition fill + crisp dark isobaths on top, matching the cmapper reference, no console errors. Contour tile renders (20 KB); write-once disk cache confirmed (own `tiles/contours/<version>/` dir).

## Tests
+3 in `tests/test_depth_tiles.py` (contour render opaque/empty; contour tile write-once + read-from-disk + own layer dir; `has_contours` in info). Full suite **2188 passed**; ruff + `node --check` + e2e smoke (no console errors) + playwright e2e (11) green.

Design: [`docs/depth-tiles.md`](../blob/main/docs/depth-tiles.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)