### PR TITLE
feat(depth): tile cache control + invalidation (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Depth-tile cache control + invalidation (#119, part of #116).** A re-import
+  now bumps the tile `version` **and** garbage-collects the previous chart's tile
+  directories (SD hygiene), and the client remounts the tile layers so it picks
+  up the fresh tiles. New **auto/static** mode: *auto* re-renders when the chart
+  changes; *static* freezes the current tile set (no re-key / re-render / writes
+  until cleared). The "fast tiles" legend now has an **update: auto/static**
+  selector and a **clear cache** button. Endpoints:
+  `POST /api/depth/tiles/mode?mode=auto|static`, `POST /api/depth/tiles/clear`;
+  `/tiles/info` now reports `mode`.
+
 - **Depth-contour raster tiles (#118, part of #116).** The **"fast tiles (beta)"**
   toggle now also renders the depth contours as server-side tiles, stacked above
   the composition tiles: thin dark isobath lines (the nautical "composition +

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -333,13 +333,18 @@ continuous across tile seams. `DepthService.{composition,contours}_tile(z, x, y)
 wrap `_layer_tile()` with a **RAM-LRU → write-once disk** cache under
 `<data_dir>/tiles/<layer>/<version>/`: each non-empty tile is rendered + written
 **once** (SD-friendly), empty tiles are a shared transparent PNG kept in RAM only.
-`version` is a short hash of the persisted `.npz` (mtime+size, shared by both
-layers), so a re-import re-renders. Endpoints: `GET /api/depth/tiles/info`
-(`{has_composition, has_contours, version, tile_size, min_zoom}`),
-`/tiles/composition/{z}/{x}/{y}.png`, `/tiles/contours/{z}/{x}/{y}.png`. Opt-in on
-the client via the "fast tiles (beta)" toggle (drives both layers); the
-live-vector overlays are the default/fallback. Design + roadmap:
-[`../depth-tiles.md`](../depth-tiles.md) (epic #116).
+`version` is the **effective** token: the short hash of the persisted `.npz`
+(mtime+size) in **auto** mode, or a frozen pin in **static** mode (#119). A
+re-import bumps the auto version and **GCs** the previous version's tile dirs
+(`_gc_stale_tiles`, SD hygiene). Endpoints: `GET /api/depth/tiles/info`
+(`{has_composition, has_contours, version, mode, tile_size, min_zoom}`),
+`/tiles/composition/{z}/{x}/{y}.png`, `/tiles/contours/{z}/{x}/{y}.png`,
+`POST /tiles/mode?mode=auto|static` (`set_tiles_mode` — static writes a `pinned`
+file with the current version so tiles never re-key), `POST /tiles/clear`
+(`clear_tiles` — wipe the whole `tiles/` dir + RAM LRU, reset to auto). Opt-in on
+the client via the "fast tiles (beta)" toggle (drives both layers) with
+auto/static + clear-cache controls; the live-vector overlays are the
+default/fallback. Design + roadmap: [`../depth-tiles.md`](../depth-tiles.md) (epic #116).
 
 ### `Runtime` depth methods (`runtime/depth.py`)
 

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import math
 import os
+import shutil
 import threading
 from collections import OrderedDict
 from typing import TYPE_CHECKING
@@ -395,6 +396,7 @@ class DepthService:
         dm.save(rt._depth_map_path)           # soundings
         dm.save_chart(rt._depth_chart_path)   # static chart (hardness/contours/composition)
         rt._depth_saved_n = len(dm.points)
+        self._gc_stale_tiles()                # drop the previous chart's raster tiles (#119)
         logger.info("imported %d soundings + %d hardness + %d contours + %d composition from %s",
                     len(pts), len(hard), len(cont), len(comp), filename)
         return {"ok": True, "imported": len(pts), "hardness": len(hard),
@@ -410,12 +412,16 @@ class DepthService:
             self._transparent_tile = depth_tiles.transparent_tile()
         return self._transparent_tile
 
-    def _chart_tiles_version(self) -> str:
-        """Short cache-busting token for the current chart. Changes only when a
-        new chart is imported -- derived from the persisted ``.npz`` (mtime +
-        size), so tiles re-render after a real re-import, not on every request.
-        Shared by both tiled layers (they come from the same ``.npz``); doubles
-        as the on-disk cache subdir + the client ``?v=``."""
+    def _tiles_root(self) -> str:
+        return os.path.join(self._rt.config.data_dir, "tiles")
+
+    def _pin_path(self) -> str:
+        return os.path.join(self._tiles_root(), "pinned")
+
+    def _auto_version(self) -> str:
+        """Version derived from the persisted ``.npz`` (mtime + size) -- changes
+        on a real re-import, not on every request. Shared by both tiled layers
+        (same ``.npz``)."""
         from ..nav.depth import DepthMap
 
         npz = DepthMap._npz_path(self._rt._depth_chart_path)
@@ -428,14 +434,88 @@ class DepthService:
                    f"-{len(getattr(dm, 'contours', ()) or ())}")
         return hashlib.sha1(sig.encode()).hexdigest()[:12]
 
+    def _pinned_version(self) -> str | None:
+        """The frozen version in 'static' mode, or ``None`` (auto)."""
+        try:
+            with open(self._pin_path(), "r", encoding="utf-8") as fh:
+                return fh.read().strip() or None
+        except OSError:
+            return None
+
+    def _chart_tiles_version(self) -> str:
+        """The EFFECTIVE tile version: the pinned value in 'static' mode (tiles
+        never re-key/re-render on a chart change), else the auto value. Doubles
+        as the on-disk cache subdir + the client ``?v=``."""
+        return self._pinned_version() or self._auto_version()
+
+    def tiles_mode(self) -> str:
+        return "static" if self._pinned_version() else "auto"
+
+    def set_tiles_mode(self, mode: str) -> dict:
+        """``auto`` -> tiles re-render when the chart changes; ``static`` ->
+        freeze the current tile version (no re-key / re-render / writes on a
+        change, until cleared). Prunes now-stale version dirs."""
+        want_static = str(mode).lower() in ("static", "pinned")
+        if want_static:
+            os.makedirs(self._tiles_root(), exist_ok=True)
+            self._write_atomic_text(self._pin_path(), self._auto_version())
+        else:
+            try:
+                os.remove(self._pin_path())
+            except OSError:
+                pass
+        self._gc_stale_tiles()
+        return {"ok": True, "mode": self.tiles_mode(),
+                "version": self._chart_tiles_version()}
+
+    def clear_tiles(self) -> dict:
+        """Wipe the whole server tile cache (all layers + versions) and reset to
+        auto; tiles re-render lazily on demand afterwards."""
+        try:
+            shutil.rmtree(self._tiles_root())
+        except FileNotFoundError:
+            pass
+        except OSError as exc:              # pragma: no cover - disk failure
+            logger.warning("could not clear tile cache: %s", exc)
+        with self._tile_lru_lock:
+            self._tile_lru.clear()
+        return {"ok": True, "message": "Cleared the server tile cache."}
+
+    def _gc_stale_tiles(self) -> None:
+        """Remove tile version dirs that are no longer the effective version --
+        after a re-import the old version's tiles are orphaned (SD hygiene)."""
+        keep = self._chart_tiles_version()
+        for layer in ("composition", "contours"):
+            ldir = os.path.join(self._tiles_root(), layer)
+            try:
+                versions = os.listdir(ldir)
+            except OSError:
+                continue
+            for ver in versions:
+                p = os.path.join(ldir, ver)
+                if ver != keep and os.path.isdir(p):
+                    try:
+                        shutil.rmtree(p)
+                    except OSError as exc:  # pragma: no cover - disk failure
+                        logger.warning("could not GC stale tiles %s: %s", p, exc)
+
+    @staticmethod
+    def _write_atomic_text(path: str, text: str) -> None:
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+
     def tiles_info(self) -> dict:
         """Metadata the client needs to mount the tile layers: which static
-        layers exist, the cache-busting version, tile size, min render zoom."""
+        layers exist, the cache-busting version, tile size, min render zoom,
+        and the invalidation mode (auto/static)."""
         dm = self._rt.depth_map
         return {"ok": True,
                 "has_composition": bool(getattr(dm, "composition", None)),
                 "has_contours": bool(getattr(dm, "contours", None)),
                 "version": self._chart_tiles_version(),
+                "mode": self.tiles_mode(),
                 "tile_size": depth_tiles.TILE_PX, "min_zoom": _TILE_MIN_ZOOM}
 
     def _layer_tile(self, layer: str, z: int, x: int, y: int,

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1458,6 +1458,14 @@ class Runtime:
         """Shim → DepthService: static-chart tile-layer metadata (#116)."""
         return self._depth.tiles_info()
 
+    def set_tiles_mode(self, mode: str) -> dict:
+        """Shim → DepthService: set tile invalidation mode auto/static (#119)."""
+        return self._depth.set_tiles_mode(mode)
+
+    def clear_tiles(self) -> dict:
+        """Shim → DepthService: wipe the server tile cache (#119)."""
+        return self._depth.clear_tiles()
+
     def water_polygon(self, bbox) -> dict:
         """OSM water polygon(s) for a (west, south, east, north) bbox, used to
         CLIP the depth overlays to water (don't draw composition over land). Uses

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -951,6 +951,19 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
         return Response(content=png, media_type="image/png",
                         headers={"Cache-Control": "public, max-age=86400"})
 
+    @app.post("/api/depth/tiles/mode")
+    async def depth_tiles_mode(mode: str) -> dict:
+        """Set the tile invalidation mode (#119): ``auto`` (re-render when the
+        chart changes) or ``static`` (freeze the current tile set)."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: runtime.set_tiles_mode(mode))
+
+    @app.post("/api/depth/tiles/clear")
+    async def depth_tiles_clear() -> dict:
+        """Wipe the server tile cache (#119); tiles re-render lazily afterwards."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, runtime.clear_tiles)
+
     @app.get("/api/depth/water")
     async def depth_water(
         west: float, south: float, east: float, north: float,

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -280,9 +280,19 @@
     <div class="depth-legend-labels"><span>0</span><span>100</span></div>
     <div class="depth-legend-cap">composition (0–100%, uncalibrated)</div>
     <!-- #117: opt-in server-rendered raster tiles (fast, cached) vs live vectors. -->
-    <label class="comp-tiles-toggle" title="Render the composition as fast server tiles instead of live polygons">
+    <label class="comp-tiles-toggle" title="Render the composition + contours as fast server tiles instead of live polygons">
       <input type="checkbox" id="composition-tiles"> fast tiles (beta)
     </label>
+    <!-- #119: tile-cache controls, shown only when fast tiles is on. -->
+    <div id="composition-tiles-controls" class="comp-tiles-controls hidden">
+      <label title="auto = re-render tiles when the chart changes; static = freeze the current tiles">update
+        <select id="composition-tiles-mode">
+          <option value="auto">auto</option>
+          <option value="static">static</option>
+        </select>
+      </label>
+      <button type="button" id="composition-tiles-clear" title="Wipe the server tile cache; tiles re-render on demand">clear cache</button>
+    </div>
   </div>
 
   <!-- Drop-marker FAB: arms marker placement; tap the map to drop (or long-press

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -1260,6 +1260,8 @@
     try { localStorage.setItem("va-composition-tiles", compositionUseTiles ? "1" : "0"); } catch (e) { /* private mode */ }
     const cb = document.getElementById("composition-tiles");
     if (cb) cb.checked = compositionUseTiles;
+    const controls = document.getElementById("composition-tiles-controls");
+    if (controls) controls.classList.toggle("hidden", !compositionUseTiles);  // #119
     applyCompositionMode();   // composition: swap vector <-> tiles
     applyContourMode();       // contours ride the same toggle (#118)
   }
@@ -1728,6 +1730,9 @@
           const cnt = document.getElementById("depth-count");
           if (cnt && Number.isFinite(r.total)) cnt.textContent = r.total;
           if (typeof fetchDepthGrid === "function") fetchDepthGrid();   // refresh the overlay now
+          // A re-import bumps the tile version -> remount the tile layers so the
+          // client picks up the fresh tiles (new ?v=), not the stale cache. (#119)
+          if (compositionUseTiles) { applyCompositionMode(); applyContourMode(); }
         }
       } catch (e) {
         setStatus("Import failed: " + e, "err");
@@ -1742,12 +1747,34 @@
     wireDepthImport();
   }
 
-  // Wire the "fast tiles (beta)" checkbox in the composition legend (#117).
+  // Wire the "fast tiles (beta)" checkbox + its cache controls (#117/#119).
   function wireCompositionTiles() {
     const cb = document.getElementById("composition-tiles");
     if (!cb) return;
+    const controls = document.getElementById("composition-tiles-controls");
+    const modeSel = document.getElementById("composition-tiles-mode");
+    const clearBtn = document.getElementById("composition-tiles-clear");
     cb.checked = compositionUseTiles;
-    cb.addEventListener("change", () => setCompositionTiles(cb.checked));
+    if (controls) controls.classList.toggle("hidden", !compositionUseTiles);
+    cb.addEventListener("change", () => setCompositionTiles(cb.checked));   // toggles controls too
+    // Reflect the server's current mode (auto/static) into the select.
+    if (modeSel) {
+      VA.getJSON("/api/depth/tiles/info").then((i) => {
+        if (i && i.mode) modeSel.value = i.mode;
+      }).catch(() => {});
+      modeSel.addEventListener("change", async () => {
+        try { await fetch("/api/depth/tiles/mode?mode=" + encodeURIComponent(modeSel.value), { method: "POST" }); } catch (e) { /* keep UI */ }
+        if (compositionUseTiles) { applyCompositionMode(); applyContourMode(); }   // version may change
+      });
+    }
+    if (clearBtn) {
+      clearBtn.addEventListener("click", async () => {
+        clearBtn.disabled = true;
+        try { await fetch("/api/depth/tiles/clear", { method: "POST" }); } catch (e) { /* ignore */ }
+        clearBtn.disabled = false;
+        if (compositionUseTiles) { applyCompositionMode(); applyContourMode(); }   // re-render on demand
+      });
+    }
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", wireCompositionTiles);

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -546,6 +546,17 @@ body.hud-fade-text .catch-fab::after {
   margin-top: 4px; font-size: 11px; color: var(--muted); cursor: pointer;
 }
 .comp-tiles-toggle input { margin: 0; cursor: pointer; }
+/* #119: tile-cache controls (auto/static + clear), under the fast-tiles toggle. */
+.comp-tiles-controls {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 3px; font-size: 11px; color: var(--muted);
+}
+.comp-tiles-controls select,
+.comp-tiles-controls button {
+  font-size: 11px; color: var(--fg); background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.14); border-radius: 4px;
+  padding: 1px 5px; cursor: pointer;
+}
 
 /* ============================ SAFETY BANNER ============================ */
 /* #banner retired — #safety-banners is the ONLY alarm surface. */

--- a/tests/test_depth_tiles.py
+++ b/tests/test_depth_tiles.py
@@ -208,6 +208,64 @@ def test_contour_tile_written_once_then_read_from_disk(tmp_path, monkeypatch):
     assert calls["n"] == 1                            # write-once: no re-render
 
 
+# --- invalidation + cache control (#119) ----------------------------------- #
+
+def test_reimport_gcs_stale_tiles_and_rekeys(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    z = 13
+    x, y = _deg2tile(59.004, 18.004, z)
+    rt.composition_tile(z, x, y)                      # render + persist under v1
+    v1 = rt.tiles_info()["version"]
+    assert (tmp_path / "tiles" / "composition" / v1).exists()
+
+    # A re-import with different data bumps the version AND GCs the old dir.
+    bigger = json.dumps({"type": "FeatureCollection", "features": [
+        {"geometry": {"type": "Polygon", "coordinates": [[
+            [18.0, 59.0], [18.03, 59.0], [18.03, 59.03], [18.0, 59.03], [18.0, 59.0]]]},
+         "properties": {"composition_pct": 40.0, "kind": "composition"}},
+    ]}).encode()
+    rt.import_depth_map("c2.geojson", bigger, replace=True)
+    v2 = rt.tiles_info()["version"]
+    assert v2 != v1
+    assert not (tmp_path / "tiles" / "composition" / v1).exists()   # stale GC'd
+
+
+def test_static_mode_freezes_version(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    assert rt.tiles_info()["mode"] == "auto"
+    pinned = rt.set_tiles_mode("static")
+    assert pinned["mode"] == "static"
+    v = rt.tiles_info()["version"]
+    # a re-import no longer changes the effective (pinned) version
+    bigger = json.dumps({"type": "FeatureCollection", "features": [
+        {"geometry": {"type": "Polygon", "coordinates": [[
+            [18.0, 59.0], [18.05, 59.0], [18.05, 59.05], [18.0, 59.05], [18.0, 59.0]]]},
+         "properties": {"composition_pct": 60.0, "kind": "composition"}},
+    ]}).encode()
+    rt.import_depth_map("c2.geojson", bigger, replace=True)
+    assert rt.tiles_info()["version"] == v and rt.tiles_info()["mode"] == "static"
+    # back to auto -> version tracks the chart again
+    assert rt.set_tiles_mode("auto")["mode"] == "auto"
+    assert rt.tiles_info()["version"] != v
+
+
+def test_clear_tiles_wipes_cache(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    z = 13
+    x, y = _deg2tile(59.004, 18.004, z)
+    rt.composition_tile(z, x, y)
+    assert (tmp_path / "tiles" / "composition").exists()
+    r = rt.clear_tiles()
+    assert r["ok"] and not (tmp_path / "tiles").exists()
+    assert len(rt._depth._tile_lru) == 0
+    # tiles re-render on demand afterwards
+    assert rt.composition_tile(z, x, y)
+    assert (tmp_path / "tiles" / "composition").exists()
+
+
 def test_version_changes_when_composition_changes(tmp_path):
     rt = _rt(tmp_path)
     rt.import_depth_map("c.geojson", _COMP, replace=True)


### PR DESCRIPTION
Phase 3 of the tiling epic (#116): make the raster-tile cache manageable and self-invalidating. Closes #119.

## What
- **`runtime/depth.py`**
  - `_gc_stale_tiles()` — a re-import drops the previous chart's tile version dirs (SD hygiene); called from `import_depth_map` after `save_chart`.
  - **auto/static** mode: `_auto_version()` (npz mtime+size) vs a `pinned` file. `_chart_tiles_version()` returns the pin in *static* mode so tiles never re-key/re-render/write on a change. `set_tiles_mode()` pins/unpins + GCs.
  - `clear_tiles()` — wipe the whole `tiles/` dir + RAM LRU, reset to auto.
  - `tiles_info()` now reports `mode`.
- **`ui/server.py`** — `POST /api/depth/tiles/mode?mode=auto|static`, `POST /api/depth/tiles/clear`.
- **`map-depth.js`** — a re-import remounts the tile layers (fresh `?v=`); the "fast tiles" legend gains an **auto/static** selector + **clear cache** button, wired to the endpoints and re-applying the layers after.

## Verification (live)
- `mode` flips auto ↔ static; under static the `version` freezes across a re-import; back to auto tracks the chart again.
- `clear` wipes `vanchor_data/tiles/`; tiles re-render on demand afterwards.
- GUI controls show only when fast tiles is on; select POSTs and flips the server; no console errors.
- Re-import GC confirmed (old version dir removed).

## Tests
+3 in `tests/test_depth_tiles.py` (reimport GC + re-key; static freezes version; clear wipes cache + re-renders on demand). Full suite **2191 passed**; ruff + `node --check` + e2e smoke (no console errors) + playwright e2e (11) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)