### PR TITLE
feat(depth): depth tiles offline + client cache integration (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Depth tiles work offline (#120, part of #116).** The composition + contour
+  raster-tile layers now run through the same IndexedDB tile cache as the
+  basemaps (a shared `VA._patchTileCache`), so tiles you've viewed are stored and
+  served offline — one cache key (the same `?v=` URL live and pre-cached). The
+  offline-map download card gained a **"Depth chart tiles"** checkbox that also
+  pre-caches the depth tiles for the selected area, and the existing "Clear tile
+  cache" wipes them too.
+
 - **Depth-tile cache control + invalidation (#119, part of #116).** A re-import
   now bumps the tile `version` **and** garbage-collects the previous chart's tile
   directories (SD hygiene), and the client remounts the tile layers so it picks

--- a/docs/llms/frontend.md
+++ b/docs/llms/frontend.md
@@ -210,7 +210,13 @@ module (Catches, heatmap, no-go).
   contours** to tiles (#118): a contour `L.TileLayer` (thin dark isobaths, in the
   `contourTiles` pane above composition) via `applyContourMode`; tile mode renders
   imported isobaths only (the marching-squares grid fallback is vector-only, and the
-  grid poll stops for tiled contours).
+  grid poll stops for tiled contours). **Offline (#120):** the depth tile layers are
+  run through the shared `VA._patchTileCache` (extracted from the basemap caching in
+  `map-core.js`), so viewed tiles are stored in the same IndexedDB `VA.tileCache` and
+  served offline (one cache key — same `?v=` URL live + pre-cached); the offline-map
+  download card has an **"Depth chart tiles"** checkbox that also pre-caches the
+  composition/contour tiles for the selected area, and "Clear tile cache" wipes them
+  too (URL-keyed).
 
 ### `CanvasOverlayMixin` — two load-bearing invariants (do not regress)
 

--- a/src/vanchor/ui/partials/panel-map.html
+++ b/src/vanchor/ui/partials/panel-map.html
@@ -68,6 +68,10 @@
           <label for="offline-cap">Max tiles</label>
           <input type="number" id="offline-cap" min="1000" max="500000" step="1000" value="50000" />
         </div>
+        <div class="row">
+          <label for="offline-include-depth" title="Also cache the server-rendered depth composition + contour tiles for this area">Depth chart tiles</label>
+          <input type="checkbox" id="offline-include-depth" />
+        </div>
         <div id="offline-est" class="hint"></div>
         <div class="btn-row">
           <button id="offline-download" class="btn-primary" disabled>⬇ Download tiles</button>

--- a/src/vanchor/ui/static/map-core.js
+++ b/src/vanchor/ui/static/map-core.js
@@ -364,8 +364,11 @@
     }
     return obj;
   }
-  Object.keys(base).forEach((name) => {
-    const layer = base[name];
+  // Patch ONE tile layer's createTile to consult VA.tileCache first (and store
+  // fetched tiles). Exposed as VA._patchTileCache so other layers -- the depth
+  // composition/contour raster tiles (#120) -- share the same offline cache +
+  // one-cache-key invariant as the basemaps.
+  function patchTileLayerForCache(layer) {
     const origCreate = layer.createTile;
     layer.createTile = function (coords, done) {
       const img = document.createElement("img");
@@ -417,7 +420,9 @@
       });
       return img;
     };
-  });
+  }
+  Object.keys(base).forEach((name) => patchTileLayerForCache(base[name]));
+  VA._patchTileCache = patchTileLayerForCache;
 
   // ---- follow / zoom state -----------------------------------------------
   // The boat-follow pan lives in map-boat.js (it already resolves the boat

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -1197,6 +1197,7 @@
       { pane: "composition", opacity: 0.6, tileSize: info.tile_size || 256,
         minZoom: info.min_zoom || 9, maxNativeZoom: 18, updateWhenZooming: false,
         className: "leaflet-depth-composition-tiles" });
+    if (VA._patchTileCache) VA._patchTileCache(compositionTileLayer);   // offline cache (#120)
     compositionTileLayer.addTo(map);
     compHint("");
   }
@@ -1246,6 +1247,7 @@
       { pane: "contourTiles", opacity: 0.9, tileSize: info.tile_size || 256,
         minZoom: info.min_zoom || 9, maxNativeZoom: 18, updateWhenZooming: false,
         className: "leaflet-depth-contours-tiles" });
+    if (VA._patchTileCache) VA._patchTileCache(contourTileLayer);       // offline cache (#120)
     contourTileLayer.addTo(map);
     contourHint("");
   }

--- a/src/vanchor/ui/static/offline.js
+++ b/src/vanchor/ui/static/offline.js
@@ -316,13 +316,63 @@
     }
     await Promise.all(Array.from({ length: Math.min(CONC, tiles.length) }, worker));
 
+    // (#120) Optionally also cache the server-rendered depth chart tiles for the
+    // same area, so composition + contours are available offline. Same URL (with
+    // ?v=version) the live layer requests -> one cache key.
+    let depthStored = 0;
+    const includeDepth = $("offline-include-depth");
+    if (!cancelled && includeDepth && includeDepth.checked) {
+      depthStored = await downloadDepthTiles(tiles);
+      stored += depthStored;
+    }
+
     downloading = false;
     if (cancelBtn) cancelBtn.classList.add("hidden");
     if (dlBtn) dlBtn.disabled = false;
     if (cancelled) setStatus("Cancelled at " + done + " / " + tiles.length + ".", "");
-    else setStatus("Done — " + stored + " new tiles cached" + (failed ? ", " + failed + " failed" : "") + ".", "ok");
+    else setStatus("Done — " + stored + " new tiles cached"
+      + (depthStored ? " (incl. " + depthStored + " depth)" : "")
+      + (failed ? ", " + failed + " failed" : "") + ".", "ok");
     VA.logLine("offline tiles: " + stored + " stored, " + failed + " failed, " + name);
     updateUsed();
+  }
+
+  // Cache the depth composition + contour tiles for the enumerated tile coords
+  // (skipping zooms below the server's min render zoom). Returns tiles stored.
+  async function downloadDepthTiles(tiles) {
+    let info = null;
+    try { info = await VA.getJSON("/api/depth/tiles/info"); } catch (e) { return 0; }
+    if (!info || (!info.has_composition && !info.has_contours)) return 0;
+    const v = encodeURIComponent(info.version || "0");
+    const minZ = info.min_zoom || 9;
+    const layers = [];
+    if (info.has_composition) layers.push("composition");
+    if (info.has_contours) layers.push("contours");
+    const urls = [];
+    for (const t of tiles) {
+      if (t.z < minZ) continue;                 // server returns transparent below this
+      for (const layer of layers) {
+        urls.push("/api/depth/tiles/" + layer + "/" + t.z + "/" + t.x + "/" + t.y + ".png?v=" + v);
+      }
+    }
+    let stored = 0, done2 = 0;
+    let i = 0;
+    async function w() {
+      while (i < urls.length && !cancelled) {
+        const url = urls[i++];
+        try {
+          if (!(await tileCache.get(url))) {
+            const r = await fetch(url);
+            if (r.ok) { await tileCache.put(url, await r.blob()); stored++; }
+          }
+        } catch (e) { /* skip */ }
+        if ((++done2 % 10) === 0 || done2 === urls.length) {
+          setStatus("Depth tiles… " + done2 + " / " + urls.length + " (" + stored + " new)", "busy");
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: Math.min(6, urls.length) }, w));
+    return stored;
   }
   if (dlBtn) dlBtn.addEventListener("click", download);
   if (cancelBtn) cancelBtn.addEventListener("click", () => { cancelled = true; });


### PR DESCRIPTION
Phase 4 of the tiling epic (#116): the composition + contour raster tiles now use the same offline tile cache as the basemaps. Closes #120.

## What
- **`map-core.js`** — extracted the per-basemap `createTile` cache patch into a reusable `patchTileLayerForCache()`, exposed as `VA._patchTileCache` (one-cache-key invariant preserved).
- **`map-depth.js`** — patch the composition + contour `L.TileLayer`s with it before `addTo`, so viewed tiles are stored in `VA.tileCache` (IndexedDB) and served offline.
- **`offline.js` + `panel-map.html`** — a **"Depth chart tiles"** checkbox on the offline-download card; `downloadDepthTiles()` pre-caches the composition/contour tiles (same `?v=` URL) for the selected area/zoom (≥ server min zoom). The existing **"Clear tile cache"** already wipes them (URL-keyed).

## Verification (live)
- `VA._patchTileCache` is a function; `VA.tileCache` installed; the `#offline-include-depth` checkbox exists.
- After enabling fast tiles and viewing the lake, a composition tile in view is stored in `VA.tileCache` (42 KB blob) → available offline; one cache key (same `?v=` URL live + pre-cached).
- No console errors.

## Tests
JS-only. Full suite **2191 passed**; ruff + `node --check` (map-core/map-depth/offline) + e2e smoke (no console errors) + playwright e2e (11) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)