### PR TITLE
feat(depth): pre-generate depth tiles + polish (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Pre-generate depth tiles (#121, part of #116).** A **pre-generate** button
+  (in the "fast tiles" controls) batch-renders and persists the whole chart's
+  tile pyramid over its data bbox — from the min zoom up to the current zoom — in
+  one bounded burst, so the cache is warm and offline-ready without lazy first-pan
+  misses (empty tiles are still skipped, so writes stay bounded). Endpoint:
+  `POST /api/depth/tiles/pregenerate?zmax=`. On the Värmland chart this cached
+  ~3,300 tiles (composition + contours, z9–14) in ~2 min.
+
 - **Depth tiles work offline (#120, part of #116).** The composition + contour
   raster-tile layers now run through the same IndexedDB tile cache as the
   basemaps (a shared `VA._patchTileCache`), so tiles you've viewed are stored and

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -341,10 +341,14 @@ re-import bumps the auto version and **GCs** the previous version's tile dirs
 `/tiles/composition/{z}/{x}/{y}.png`, `/tiles/contours/{z}/{x}/{y}.png`,
 `POST /tiles/mode?mode=auto|static` (`set_tiles_mode` — static writes a `pinned`
 file with the current version so tiles never re-key), `POST /tiles/clear`
-(`clear_tiles` — wipe the whole `tiles/` dir + RAM LRU, reset to auto). Opt-in on
-the client via the "fast tiles (beta)" toggle (drives both layers) with
-auto/static + clear-cache controls; the live-vector overlays are the
-default/fallback. Design + roadmap: [`../depth-tiles.md`](../depth-tiles.md) (epic #116).
+(`clear_tiles` — wipe the whole `tiles/` dir + RAM LRU, reset to auto), and
+`POST /tiles/pregenerate?zmax=` (#121 — `pregenerate_tiles`: batch-render + persist
+every tile over the chart's data bbox from the min zoom up to `zmax`, capped at
+`_TILE_PREGEN_MAX`, so the cache is warm/offline-ready without lazy first-pan
+misses; empties are still skipped). Opt-in on the client via the "fast tiles (beta)"
+toggle (drives both layers) with auto/static + clear + pre-generate controls; the
+live-vector overlays are the default/fallback. Design + roadmap:
+[`../depth-tiles.md`](../depth-tiles.md) (epic #116).
 
 ### `Runtime` depth methods (`runtime/depth.py`)
 

--- a/src/vanchor/nav/depth_tiles.py
+++ b/src/vanchor/nav/depth_tiles.py
@@ -56,6 +56,38 @@ def tile_bounds(z: int, x: int, y: int) -> tuple[float, float, float, float]:
     return (lon(x), lat(y + 1), lon(x + 1), lat(y))
 
 
+def lonlat_to_tile(lat: float, lon: float, z: int) -> tuple[int, int]:
+    """The (x, y) slippy tile containing (lat, lon) at zoom ``z`` (clamped)."""
+    n = 1 << z
+    xt = int((lon + 180.0) / 360.0 * n)
+    lat = max(-_MERC_LAT_LIMIT, min(_MERC_LAT_LIMIT, lat))
+    r = math.radians(lat)
+    yt = int((1.0 - math.log(math.tan(r) + 1.0 / math.cos(r)) / math.pi) / 2.0 * n)
+    return (max(0, min(n - 1, xt)), max(0, min(n - 1, yt)))
+
+
+def tiles_covering(bbox: tuple[float, float, float, float], z: int):
+    """Yield ``(x, y)`` tiles covering the (west, south, east, north) bbox at ``z``."""
+    w, s, e, n = bbox
+    x0, y0 = lonlat_to_tile(n, w, z)   # NW corner (north -> smaller y)
+    x1, y1 = lonlat_to_tile(s, e, z)   # SE corner
+    for x in range(min(x0, x1), max(x0, x1) + 1):
+        for y in range(min(y0, y1), max(y0, y1) + 1):
+            yield x, y
+
+
+def count_tiles_covering(bbox: tuple[float, float, float, float],
+                         zmin: int, zmax: int) -> int:
+    """Number of tiles covering ``bbox`` over ``zmin..zmax`` (no materialisation)."""
+    w, s, e, n = bbox
+    total = 0
+    for z in range(zmin, zmax + 1):
+        x0, y0 = lonlat_to_tile(n, w, z)
+        x1, y1 = lonlat_to_tile(s, e, z)
+        total += (abs(x1 - x0) + 1) * (abs(y1 - y0) + 1)
+    return total
+
+
 def _merc_y01(lat_deg: float) -> float:
     """Normalised web-mercator Y in [0, 1] (0 at the north edge of the world)."""
     lat = math.radians(max(-_MERC_LAT_LIMIT, min(_MERC_LAT_LIMIT, lat_deg)))

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -32,6 +32,7 @@ logger = logging.getLogger("vanchor.app")
 # serves hot tiles with no disk read and bounds RAM.
 _TILE_LRU_MAX = 256          # ~a few MB of PNG bytes
 _TILE_MIN_ZOOM = 9           # below this a tile spans too much data to render
+_TILE_PREGEN_MAX = 40000     # safety cap on tiles rendered by one pre-generate
 
 
 class DepthService:
@@ -572,6 +573,47 @@ class DepthService:
             "contours", z, x, y,
             lambda bbox: self._rt.depth_map.contours_in(bbox, limit=200000),
             depth_tiles.render_contours_tile)
+
+    def _chart_bbox(self) -> tuple[float, float, float, float] | None:
+        """The (west, south, east, north) covering both tiled layers, or None."""
+        dm = self._rt.depth_map
+        boxes = []
+        for layer in (getattr(dm, "composition", None), getattr(dm, "contours", None)):
+            coords = getattr(layer, "coords", None)
+            if coords is not None and getattr(coords, "shape", (0,))[0]:
+                boxes.append((float(coords[:, 1].min()), float(coords[:, 0].min()),
+                              float(coords[:, 1].max()), float(coords[:, 0].max())))
+        if not boxes:
+            return None
+        return (min(b[0] for b in boxes), min(b[1] for b in boxes),
+                max(b[2] for b in boxes), max(b[3] for b in boxes))
+
+    def pregenerate_tiles(self, zmax: int = 16) -> dict:
+        """Eagerly render + persist every composition/contour tile over the
+        chart's data bbox from the min zoom up to ``zmax`` (write-once) -- one
+        bounded burst instead of lazy misses on first pan. Capped for safety."""
+        dm = self._rt.depth_map
+        bbox = self._chart_bbox()
+        if bbox is None:
+            return {"ok": True, "rendered": 0, "message": "No chart loaded."}
+        zmax = max(_TILE_MIN_ZOOM, min(int(zmax), 18))
+        layers = []
+        if getattr(dm, "composition", None):
+            layers.append(self.composition_tile)
+        if getattr(dm, "contours", None):
+            layers.append(self.contours_tile)
+        total = depth_tiles.count_tiles_covering(bbox, _TILE_MIN_ZOOM, zmax) * max(1, len(layers))
+        if total > _TILE_PREGEN_MAX:
+            return {"ok": False, "tiles": total,
+                    "error": f"too many tiles ({total:,}) — lower the max zoom."}
+        rendered = 0
+        for z in range(_TILE_MIN_ZOOM, zmax + 1):
+            for (x, y) in depth_tiles.tiles_covering(bbox, z):
+                for fn in layers:
+                    fn(z, x, y)      # renders + write-once caches (empties skipped)
+                    rendered += 1
+        logger.info("pre-generated %d depth tiles up to z%d", rendered, zmax)
+        return {"ok": True, "rendered": rendered, "zmax": zmax, "tiles": total}
 
     def _tile_lru_get(self, key: tuple) -> bytes | None:
         with self._tile_lru_lock:

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1466,6 +1466,10 @@ class Runtime:
         """Shim → DepthService: wipe the server tile cache (#119)."""
         return self._depth.clear_tiles()
 
+    def pregenerate_tiles(self, zmax: int = 16) -> dict:
+        """Shim → DepthService: batch-render the chart's tile pyramid (#121)."""
+        return self._depth.pregenerate_tiles(zmax)
+
     def water_polygon(self, bbox) -> dict:
         """OSM water polygon(s) for a (west, south, east, north) bbox, used to
         CLIP the depth overlays to water (don't draw composition over land). Uses

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -964,6 +964,13 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, runtime.clear_tiles)
 
+    @app.post("/api/depth/tiles/pregenerate")
+    async def depth_tiles_pregenerate(zmax: int = 16) -> dict:
+        """Batch-render + persist the chart's tile pyramid up to ``zmax`` (#121)
+        so the cache is warm (and offline-ready) without lazy first-pan misses."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: runtime.pregenerate_tiles(zmax))
+
     @app.get("/api/depth/water")
     async def depth_water(
         west: float, south: float, east: float, north: float,

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -291,6 +291,7 @@
           <option value="static">static</option>
         </select>
       </label>
+      <button type="button" id="composition-tiles-pregen" title="Render + cache all tiles for this chart now (warms the cache, offline-ready)">pre-generate</button>
       <button type="button" id="composition-tiles-clear" title="Wipe the server tile cache; tiles re-render on demand">clear cache</button>
     </div>
   </div>

--- a/src/vanchor/ui/static/map-depth.js
+++ b/src/vanchor/ui/static/map-depth.js
@@ -1777,6 +1777,21 @@
         if (compositionUseTiles) { applyCompositionMode(); applyContourMode(); }   // re-render on demand
       });
     }
+    const pregenBtn = document.getElementById("composition-tiles-pregen");
+    if (pregenBtn) {
+      pregenBtn.addEventListener("click", async () => {
+        pregenBtn.disabled = true;
+        const zmax = Math.min(18, Math.max(9, Math.round(map.getZoom())));   // up to the current zoom
+        compHint("pre-generating tiles…");
+        try {
+          const r = await (await fetch("/api/depth/tiles/pregenerate?zmax=" + zmax, { method: "POST" })).json();
+          compHint(r && r.ok ? ("cached " + (r.rendered || 0) + " tiles ≤ z" + (r.zmax || zmax))
+                             : ((r && r.error) || "pre-generate failed"));
+        } catch (e) { compHint("pre-generate failed"); }
+        pregenBtn.disabled = false;
+        if (compositionUseTiles) { applyCompositionMode(); applyContourMode(); }
+      });
+    }
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", wireCompositionTiles);

--- a/tests/test_depth_tiles.py
+++ b/tests/test_depth_tiles.py
@@ -77,6 +77,16 @@ def test_transparent_tile_is_fully_transparent():
     assert img.split()[3].getextrema() == (0, 0)
 
 
+def test_tiles_covering_round_trips_the_containing_tile():
+    lat, lon, z = 59.0, 18.0, 13
+    x, y = depth_tiles.lonlat_to_tile(lat, lon, z)
+    covering = set(depth_tiles.tiles_covering((lon - 1e-6, lat - 1e-6, lon + 1e-6, lat + 1e-6), z))
+    assert (x, y) in covering
+    # count matches enumeration
+    bbox = (17.9, 58.9, 18.1, 59.1)
+    assert depth_tiles.count_tiles_covering(bbox, z, z) == len(list(depth_tiles.tiles_covering(bbox, z)))
+
+
 # --- runtime cache (write-once disk + RAM-LRU) ----------------------------- #
 
 def _rt(tmp_path):
@@ -264,6 +274,38 @@ def test_clear_tiles_wipes_cache(tmp_path):
     # tiles re-render on demand afterwards
     assert rt.composition_tile(z, x, y)
     assert (tmp_path / "tiles" / "composition").exists()
+
+
+def test_pregenerate_fills_the_disk_cache(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP_AND_CONTOURS, replace=True)
+    r = rt.pregenerate_tiles(zmax=14)
+    assert r["ok"] and r["rendered"] > 0 and r["zmax"] == 14
+    ver = rt.tiles_info()["version"]
+    pngs = list((tmp_path / "tiles").rglob("*.png"))
+    assert pngs, "pre-generate wrote no tiles"
+    # both layers were pre-generated under the current version
+    assert (tmp_path / "tiles" / "composition" / ver).exists()
+    assert (tmp_path / "tiles" / "contours" / ver).exists()
+
+
+def test_pregenerate_no_chart_is_noop(tmp_path):
+    r = _rt(tmp_path).pregenerate_tiles(zmax=12)
+    assert r["ok"] and r["rendered"] == 0
+
+
+def test_pregenerate_caps_excessive_tiles(tmp_path):
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)
+    # zmax 18 over even a small bbox * the cap -> refuse without rendering
+    from vanchor.runtime import depth as depth_mod
+    orig = depth_mod._TILE_PREGEN_MAX
+    depth_mod._TILE_PREGEN_MAX = 1                 # force the cap to trip
+    try:
+        r = rt.pregenerate_tiles(zmax=18)
+    finally:
+        depth_mod._TILE_PREGEN_MAX = orig
+    assert r["ok"] is False and "too many tiles" in r["error"]
 
 
 def test_version_changes_when_composition_changes(tmp_path):


### PR DESCRIPTION
Final phase of the tiling epic (#116): a **pre-generate** button that warms the tile cache in one bounded burst. Closes #121.

## What
- **`nav/depth_tiles.py`** — `lonlat_to_tile` / `tiles_covering` / `count_tiles_covering` (Python XYZ enumeration, mirrors `offline.js`).
- **`runtime/depth.py`** — `_chart_bbox()` (overall data bbox from the columnar coords) + `pregenerate_tiles(zmax)`: renders both layers over the bbox from the min zoom up to `zmax`, write-once (empties skipped), capped at `_TILE_PREGEN_MAX`.
- **`ui/server.py`** — `POST /api/depth/tiles/pregenerate?zmax=`.
- **`map-depth.js` + `index.html`** — a **pre-generate** button in the fast-tiles controls (`zmax` = current zoom) with a result hint.

## Verification (live)
On the Värmland chart, `pregenerate?zmax=14` processed **11,074 tiles → 3,342 non-empty PNGs written (~63 MB)** in ~2 min; empty tiles skipped (writes stay bounded). Cache is warm → instant panning + offline-ready.

## Tests
+4 in `tests/test_depth_tiles.py` (tiles_covering round-trip + count; pregenerate fills disk under both layer dirs; no-chart no-op; excessive-tiles cap). Full suite **2195 passed**; ruff + `node --check` + e2e smoke (no console errors) + playwright e2e (11) green.

## Note — epic follow-up
The **water-mask clip** for tiles (soft fill can bleed past the shoreline) is intentionally split into its own follow-up rather than folded here: it needs an offline-water-availability design and would add clipping to the render path, and the soft fade is arguably fine. Tracking separately so the pipeline (#117–#121) lands clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)