### PR TITLE
feat(depth): clip composition tiles to the water mask (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Composition tiles clipped to the shoreline (#128).** The server-rendered
+  composition tiles are now masked to the OSM water polygon, so the fill no
+  longer bleeds onto land past the shoreline (the one rough edge left from the
+  tiling epic). The water polygon is read **cache-only** — never fetched from
+  Overpass on the render path — and clipped to the chart bbox once + memoised, so
+  per-tile masking is cheap; where no water is cached, tiles render unclipped as
+  before. A new renderer-version token folds into the tile cache key so existing
+  tiles re-render with the clip.
+
 - **Pre-generate depth tiles (#121, part of #116).** A **pre-generate** button
   (in the "fast tiles" controls) batch-renders and persists the whole chart's
   tile pyramid over its data bbox — from the min zoom up to the current zoom — in

--- a/docs/llms/backend.md
+++ b/docs/llms/backend.md
@@ -326,10 +326,16 @@ renderer + XYZ tile math (`tile_bounds`, `padded_query_bbox`,
 `render_composition_tile`, `render_contours_tile`, `transparent_tile`) — no
 runtime coupling, so it's unit-testable headless. Two tiled layers share the
 machinery: **composition (#117)** — opaque YlOrBr fills (client `L.TileLayer`
-applies 0.6 opacity so overlaps never double-darken), Gaussian edge-blend; and
+applies 0.6 opacity so overlaps never double-darken), Gaussian edge-blend, and
+**clipped to the water mask** (#128) so the fill can't bleed onto land; and
 **contours (#118)** — thin dark isobath lines, no blur, that read cleanly over
 the fill (the cmapper chart look). Both use a render margin so features are
-continuous across tile seams. `DepthService.{composition,contours}_tile(z, x, y)`
+continuous across tile seams. The water clip reads the polygon **cache-only**
+(`WaterCache.find_covering` — never Overpass on the render path), clips the
+(possibly region-wide) polygon to the chart bbox once and memoises the reduced
+rings (`_water_rings_for`), so per-tile masking stays cheap; no cached water ->
+rendered unclipped. `depth_tiles.RENDERER_VERSION` folds into the cache version
+so a render-output change (like this clip) rolls old tiles. `DepthService.{composition,contours}_tile(z, x, y)`
 wrap `_layer_tile()` with a **RAM-LRU → write-once disk** cache under
 `<data_dir>/tiles/<layer>/<version>/`: each non-empty tile is rendered + written
 **once** (SD-friendly), empty tiles are a shared transparent PNG kept in RAM only.

--- a/src/vanchor/nav/depth_tiles.py
+++ b/src/vanchor/nav/depth_tiles.py
@@ -28,6 +28,10 @@ _COMPOSITION_STOPS = (
 
 TILE_PX = 256          # tile edge in CSS px (256, per the #117 decision)
 _MERC_LAT_LIMIT = 85.05112878   # web-mercator clamp
+# Bump when the RENDERED OUTPUT changes (style/blur/clip) so the cache version
+# rolls and old tiles re-render instead of being served stale. 1 = #117/#118,
+# 2 = #128 water-mask clip.
+RENDERER_VERSION = 2
 
 
 def composition_rgb(pct: float) -> tuple[int, int, int]:
@@ -108,15 +112,20 @@ def padded_query_bbox(z: int, x: int, y: int, *, tile_px: int = TILE_PX,
 
 def render_composition_tile(features, z: int, x: int, y: int, *,
                             tile_px: int = TILE_PX, supersample: int = 2,
-                            blur_px: float = 2.0, pad_px: int = 8) -> bytes | None:
+                            blur_px: float = 2.0, pad_px: int = 8,
+                            water=None) -> bytes | None:
     """Render composition ``features`` -> a ``tile_px`` PNG (bytes), or ``None``
     when nothing is drawn (an empty tile -- the caller serves a shared
     transparent PNG and does not persist it, to spare SD writes).
 
     ``features`` is an iterable of ``{"pct": float, "ring": [[lat, lon], ...]}``
     (exactly what ``DepthMap.composition_in(bbox)`` yields), for the padded bbox.
+
+    ``water`` (optional, #128) clips the fill to the shoreline: an iterable of
+    ``(exterior, holes)`` polygons in **(lon, lat)** -- the blurred fill's alpha
+    is masked to the water so it does not bleed onto land. ``None`` -> unclipped.
     """
-    from PIL import Image, ImageDraw, ImageFilter   # lazy: keep import off hot paths
+    from PIL import Image, ImageChops, ImageDraw, ImageFilter   # lazy: keep off hot paths
 
     n = 1 << z
     ss = max(1, int(supersample))
@@ -143,6 +152,21 @@ def render_composition_tile(features, z: int, x: int, y: int, *,
 
     if blur_px > 0:
         img = img.filter(ImageFilter.GaussianBlur(blur_px * ss))
+    if water:
+        # Mask the (blurred) fill to the water polygon so it can't bleed onto land
+        # (#128). Exterior rings -> keep (255), island holes -> drop (0).
+        mask = Image.new("L", img.size, 0)
+        md = ImageDraw.Draw(mask)
+        painted = False
+        for exterior, holes in water:
+            if len(exterior) >= 3:
+                md.polygon([to_px(lat, lon) for lon, lat in exterior], fill=255)
+                painted = True
+            for hole in holes or ():
+                if len(hole) >= 3:
+                    md.polygon([to_px(lat, lon) for lon, lat in hole], fill=0)
+        if painted:
+            img.putalpha(ImageChops.multiply(img.getchannel("A"), mask))
     img = img.crop((P, P, P + S, P + S))
     if ss != 1:
         img = img.resize((tile_px, tile_px), Image.LANCZOS)

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -43,6 +43,7 @@ class DepthService:
         self._tile_lru: "OrderedDict[tuple, bytes]" = OrderedDict()
         self._tile_lru_lock = threading.Lock()
         self._transparent_tile: bytes | None = None
+        self._water_memo: dict | None = None   # cached water rings for the tile clip (#128)
 
     # ------------------------------------------------------------------ #
     # Live sounding + divergence
@@ -433,6 +434,8 @@ class DepthService:
             dm = self._rt.depth_map
             sig = (f"mem-{len(getattr(dm, 'composition', ()) or ())}"
                    f"-{len(getattr(dm, 'contours', ()) or ())}")
+        # Fold in the renderer version so a render-output change rolls the cache.
+        sig = f"{sig}-r{depth_tiles.RENDERER_VERSION}"
         return hashlib.sha1(sig.encode()).hexdigest()[:12]
 
     def _pinned_version(self) -> str | None:
@@ -480,6 +483,7 @@ class DepthService:
             logger.warning("could not clear tile cache: %s", exc)
         with self._tile_lru_lock:
             self._tile_lru.clear()
+        self._water_memo = None                  # re-read water on the next render (#128)
         return {"ok": True, "message": "Cleared the server tile cache."}
 
     def _gc_stale_tiles(self) -> None:
@@ -556,14 +560,57 @@ class DepthService:
         self._tile_lru_put(key, png)
         return png
 
+    def _water_rings_for(self, bbox):
+        """Water-polygon rings (lon/lat) for the shoreline clip (#128), covering
+        the (west, south, east, north) ``bbox`` -- CACHE-ONLY (never fetches from
+        Overpass on the render path). The covering polygon can be region-wide
+        (~1M vertices), so it's clipped to the chart's data bbox ONCE and the
+        reduced rings memoised -- one lake entry then serves a whole pan /
+        pre-generate. Returns a list of ``(exterior, holes)``, or None (no water
+        cached, or shapely unavailable -> render unclipped)."""
+        w, s, e, n = bbox
+        m = self._water_memo
+        if m and m["w"] <= w and m["s"] <= s and m["e"] >= e and m["n"] >= n:
+            return m["rings"]
+        try:
+            from shapely.geometry import box as _box
+
+            from ..nav import water as water_mod
+            geom = water_mod.WaterCache(self._rt.config.data_dir).find_covering((s, w, n, e))
+            if geom is None or geom.is_empty:
+                return None
+            rw, rs, re_, rn = self._chart_bbox() or (w, s, e, n)
+            pad = 0.02      # a touch beyond the data so the shoreline just outside still clips
+            region = (rw - pad, rs - pad, re_ + pad, rn + pad)
+            clipped = geom.intersection(_box(*region))
+            if clipped.is_empty:
+                return None
+            rings = []
+            for poly in (getattr(clipped, "geoms", None) or [clipped]):
+                ext = getattr(poly, "exterior", None)
+                if ext is None:
+                    continue
+                rings.append((list(ext.coords), [list(r.coords) for r in poly.interiors]))
+        except Exception as exc:  # shapely missing / corrupt cache -> unclipped
+            logger.debug("water clip unavailable: %s", exc)
+            return None
+        self._water_memo = {"w": region[0], "s": region[1], "e": region[2], "n": region[3],
+                            "rings": rings}
+        return rings
+
+    def _render_composition_clipped(self, feats, z, x, y):
+        water = self._water_rings_for(depth_tiles.padded_query_bbox(z, x, y))
+        return depth_tiles.render_composition_tile(feats, z, x, y, water=water)
+
     def composition_tile(self, z: int, x: int, y: int) -> bytes:
-        """A bottom-composition raster-tile PNG for slippy tile ``z/x/y`` (#117)."""
+        """A bottom-composition raster-tile PNG for slippy tile ``z/x/y`` (#117),
+        clipped to the water mask when it's cached locally (#128)."""
         if not getattr(self._rt.depth_map, "composition", None):
             return self._transparent()
         return self._layer_tile(
             "composition", z, x, y,
             lambda bbox: self._rt.depth_map.composition_in(bbox, limit=200000),
-            depth_tiles.render_composition_tile)
+            self._render_composition_clipped)
 
     def contours_tile(self, z: int, x: int, y: int) -> bytes:
         """A depth-contour (isobath) raster-tile PNG for slippy tile ``z/x/y`` (#118)."""

--- a/tests/test_depth_tiles.py
+++ b/tests/test_depth_tiles.py
@@ -71,6 +71,22 @@ def test_render_empty_features_is_none():
         [{"pct": 50, "ring": [[59.0, 18.0], [59.0, 18.001]]}], 13, 4400, 2400) is None
 
 
+def test_composition_water_clip_masks_land():
+    """#128: with a water polygon, fill outside the water is masked to transparent."""
+    z, lat, lon = 13, 59.0, 18.0
+    x, y = _deg2tile(lat, lon, z)
+    w, s, e, n = depth_tiles.tile_bounds(z, x, y)
+    feats = [{"pct": 75.0, "ring": [[s, w], [s, e], [n, e], [n, w]]}]   # fills the tile
+    mid = (w + e) / 2.0
+    water = [([(w, s), (mid, s), (mid, n), (w, n)], [])]                # LEFT half only (lon,lat)
+    png = depth_tiles.render_composition_tile(feats, z, x, y, blur_px=0, water=water)
+    img = Image.open(io.BytesIO(png))
+    alpha = img.split()[3]
+    left = alpha.getpixel((img.width // 4, img.height // 2))            # water -> kept
+    right = alpha.getpixel((img.width * 3 // 4, img.height // 2))       # land  -> masked
+    assert left > 0 and right == 0
+
+
 def test_transparent_tile_is_fully_transparent():
     img = Image.open(io.BytesIO(depth_tiles.transparent_tile()))
     assert img.size == (256, 256)
@@ -306,6 +322,25 @@ def test_pregenerate_caps_excessive_tiles(tmp_path):
     finally:
         depth_mod._TILE_PREGEN_MAX = orig
     assert r["ok"] is False and "too many tiles" in r["error"]
+
+
+def test_water_rings_cache_only_and_memoised(tmp_path):
+    """#128: _water_rings_for reads the water cache only (no Overpass); None when
+    absent, rings when a covering polygon is stored."""
+    from shapely.geometry import Polygon
+
+    from vanchor.nav import water as water_mod
+    rt = _rt(tmp_path)
+    rt.import_depth_map("c.geojson", _COMP, replace=True)   # chart around (18.0, 59.0)
+    assert rt._depth._water_rings_for((17.9, 58.9, 18.1, 59.1)) is None   # nothing cached
+
+    wc = water_mod.WaterCache(str(tmp_path))                # bbox order = (s, w, n, e)
+    wc.store((58.5, 17.5, 59.5, 18.5),
+             Polygon([(17.5, 58.5), (18.5, 58.5), (18.5, 59.5), (17.5, 59.5)]))
+    rt._depth._water_memo = None
+    rings = rt._depth._water_rings_for((17.9, 58.9, 18.1, 59.1))
+    assert rings and len(rings[0][0]) >= 4                  # an exterior ring came back
+    assert rt._depth._water_memo is not None                # memoised for later tiles
 
 
 def test_version_changes_when_composition_changes(tmp_path):


### PR DESCRIPTION
The follow-up flagged during the tiling epic (#116): the composition raster tiles now mask to the OSM water polygon, so the fill no longer bleeds onto land past the shoreline. Closes #128.

## What
- **`nav/depth_tiles.py`** — `render_composition_tile(water=…)` masks the blurred fill's alpha to the water polygon (exterior rings keep, island holes drop). New `RENDERER_VERSION` (=2) folds into the cache version so old **unclipped** tiles re-render.
- **`runtime/depth.py`** — `_water_rings_for()` reads the water polygon **cache-only** (`WaterCache.find_covering` — never Overpass on the render path). The covering polygon can be region-wide (~1M vertices), so it's clipped to the chart bbox **once** and the reduced rings memoised (measured **929k → 7.6k verts in 6 ms**); per-tile masking is then cheap. No cached water → rendered unclipped, as before. Water memo reset on cache clear.

## Verification (live, z14)
Composition now hugs the waterline — no bleed onto the surrounding fields/forest (vs the pre-fix render). First tile 0.42 s (warms the clip + memo), then cached 11 ms. The cache `version` rolled (`…-r2`) so old unclipped tiles are superseded automatically.

## Tests
+2 in `tests/test_depth_tiles.py` (renderer masks land → transparent; `_water_rings_for` is cache-only, `None` when absent, returns rings + memoises when a covering polygon is stored). Full suite **2197 passed**; ruff + `node --check` + e2e smoke (no console errors) + playwright e2e (11) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)