### PR TITLE
feat(compass): autodetecting I2C magnetometer compass (BN-880/BE-880) + device UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,30 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
   **spin-to-calibrate** action (turn the boat through a circle) that fits and
   persists the hard/soft-iron correction. Emits `HDT`; `smbus2` is an optional
   dep (`vanchor[i2c]`); fully unit-tested with a fake bus. Adding another chip is
-  one entry in `nav/magnetometer.py`'s `CHIP_TABLE`. BENCH-VERIFY: the register
-  maps + I2C timing are not yet verified on hardware.
+  one entry in `nav/magnetometer.py`'s `CHIP_TABLE`. For remote troubleshooting
+  there's a **"Dump raw I2C"** device action that reads the raw registers (id +
+  data window, live samples) and returns a copy-pasteable hex block — works even
+  when a chip won't autodetect, so a wrong id / swapped bytes can be diagnosed
+  without the hardware. The device panel also shows a **first-run nudge** until
+  the compass is calibrated (and if nothing is detected). Heading assumes a
+  roughly level mount (no tilt compensation without an accelerometer — use the
+  HWT901B AHRS if the sensor tilts). BENCH-VERIFY: the register maps + I2C timing
+  are not yet verified on hardware.
+
+- **Device settings: connection fields now match the source.** Selecting a device
+  source only shows the connection fields that source actually uses — a serial
+  source shows its port + baud, an **I2C** source (the magnetometer) shows a
+  single **I2C bus** field (defaulting to `i2c:1`, never auto-picking a
+  `/dev/ttyUSB*`), and sim / NMEA-bridge / none / phone show nothing. Each
+  registered driver declares its `transport` (`serial` / `i2c` / `none`), exposed
+  as `source_transports` in `/api/config/devices`, so pluggable drivers classify
+  themselves. Previously every device's serial fields appeared whenever any source
+  was wired.
+
+- **Guided setup: I2C probe degrades gracefully.** Probing an I2C address when the
+  `i2c` extra (smbus2) isn't installed, or when the bus can't be opened, now
+  returns a clear message ("install `vanchor[i2c]`" / "enable I2C") instead of a
+  500 — so the wizard stays usable while troubleshooting a compass/battery.
 
 - **Composition tiles clipped to the shoreline (#128).** The server-rendered
   composition tiles are now masked to the OSM water polygon, so the fill no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **I2C magnetometer compass driver (autodetecting).** A new `compass_source:
+  magnetometer` reads the 3-axis magnetometer on combo GNSS boards (Beitian
+  BN-880 / BE-880) and standalone parts, and **autodetects** which chip is fitted
+  — HMC5883L, QMC5883L, or IST8310 — by its identity register, so the user only
+  picks "magnetometer" and points it at an I2C bus (`compass_port:
+  i2c:<bus>[:<addr>]`; address optional). The setup wizard probes the known
+  magnetometer addresses (0x0D / 0x1E / 0x0E) and suggests the config. It learns
+  declination + mount offset from the GPS course (like the HWT901B), and has a
+  **spin-to-calibrate** action (turn the boat through a circle) that fits and
+  persists the hard/soft-iron correction. Emits `HDT`; `smbus2` is an optional
+  dep (`vanchor[i2c]`); fully unit-tested with a fake bus. Adding another chip is
+  one entry in `nav/magnetometer.py`'s `CHIP_TABLE`. BENCH-VERIFY: the register
+  maps + I2C timing are not yet verified on hardware.
+
 - **Composition tiles clipped to the shoreline (#128).** The server-rendered
   composition tiles are now masked to the OSM water polygon, so the fill no
   longer bleeds onto land past the shoreline (the one rough edge left from the

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,9 @@ The interfaces the front end and integrations build against.
   the registry.
 - **[custom-hardware.md](custom-hardware.md)** — split steering + thrust channels,
   off-centre mounts.
+- **[compass-magnetometer.md](compass-magnetometer.md)** — the I2C magnetometer
+  compass (BN-880 / BE-880 & standalone): autodetect, calibration, the **tilt
+  limitation**, and the raw-dump troubleshooter.
 - **[firmware.md](firmware.md)** — the Pi ↔ Arduino software contract.
 - **[ublox-m9n-fusion.md](ublox-m9n-fusion.md)** — GNSS/INS fusion (M9N + HWT901B).
 - **[push-notifications.md](push-notifications.md)** — Web Push alarms to a locked

--- a/docs/compass-magnetometer.md
+++ b/docs/compass-magnetometer.md
@@ -1,0 +1,118 @@
+# I2C magnetometer compass
+
+Vanchor can use the small 3-axis **magnetometer** found on combo GNSS boards
+(Beitian **BN-880 / BE-880** and many drone/rover modules) or a standalone
+magnetometer breakout, as a heading source. It **autodetects** which chip is
+fitted, so you only pick "magnetometer" and point it at the I2C bus.
+
+| | |
+|---|---|
+| **Source** | `compass_source: magnetometer` |
+| **Chips** | HMC5883L, QMC5883L, IST8310 (autodetected by id register) |
+| **Bus** | `compass_port: i2c:<bus>[:<addr>]` — address optional (autodetect) |
+| **Output** | true heading (`HDT`), declination applied |
+| **Needs** | the `i2c` extra: `pip install 'vanchor[i2c]'` |
+
+> ⚠️ **Read the [tilt limitation](#tilt-a-bare-magnetometer-assumes-its-level)
+> below before you rely on it.** A bare magnetometer is only accurate when it
+> sits level.
+
+## Wiring
+
+The magnetometer is a **separate device from the GPS** even on a combo board: the
+GNSS is serial (UART), the magnetometer is I2C. Wire its four I2C pins to the
+Raspberry Pi:
+
+| Module pin | Pi pin |
+|---|---|
+| GND | GND |
+| VCC / 3V3 | 3V3 (check your board — many are 3.3 V only) |
+| SDA | GPIO 2 (SDA1) |
+| SCL | GPIO 3 (SCL1) |
+
+Enable I2C on the Pi once: `sudo raspi-config` → **Interface Options → I2C →
+Yes**, then reboot. The bus is then `/dev/i2c-1`.
+
+## Enable it
+
+**Easiest — the wizard.** **Settings → Devices & hardware → Guided hardware
+setup…**, scan, and the wizard probes the known magnetometer addresses (0x0D /
+0x1E / 0x0E). A detected chip is offered as a one-click compass; **Save &
+restart**.
+
+**Manual.** In **Settings → Devices**, set the compass source to
+**magnetometer**. Leave the port as `i2c:1` to autodetect the address, or pin it
+with `i2c:1:0x0d`. Save and restart.
+
+## Calibrate it (do this — it won't read right otherwise)
+
+A magnetometer is distorted by the metal and magnets around it (hard/soft iron).
+Until you correct for that, the heading is simply wrong. The panel nudges you
+until it's calibrated. It takes a minute:
+
+1. **Settings → Devices → Compass**.
+2. Press **Start calibration**.
+3. **Turn the boat slowly through at least one full circle** (on the water, or
+   spin the whole boat on land — the sensor must rotate with the hull).
+4. Press **Finish calibration**. The fit is saved and survives restarts.
+
+Re-calibrate if you move the sensor, or add/remove metal or electronics near it.
+
+## Tilt: a bare magnetometer assumes it's level
+
+**This is the one real limitation, so it's worth being clear about.** A plain
+magnetometer measures the Earth's magnetic field but has **no way to sense
+gravity**, so it cannot tell heading from tilt. Vanchor computes the heading from
+the horizontal field **assuming the sensor is roughly level**.
+
+The consequences:
+
+- On a boat that **heels or pitches** (chop, a lean under way, weight to one
+  side) the reported heading will **swing with the tilt** — sometimes by tens of
+  degrees. It is steadiest on flat water with the sensor mounted level.
+- There is **no tilt compensation** in this driver, because that requires an
+  **accelerometer** to know "down". Adding one is not a setting — it's a
+  different class of sensor.
+
+What to do about it:
+
+- **Mount the sensor level and low** (near the waterline, away from the motor,
+  battery, and steel), and it's fine for anchor-hold and gentle trolling on
+  reasonable water.
+- **If your boat tilts a lot**, or you want heading you can trust while heeled,
+  use a **fused AHRS** instead: the WitMotion **HWT901B**
+  (`compass_source: hwt901b`) combines a magnetometer with an accelerometer and
+  gyro and does the tilt compensation for you. The trade-off is a second device
+  and a serial port; the bare magnetometer's advantage is that it's already on
+  your GPS board.
+
+## Options
+
+Set these in **Settings → Devices → Compass**:
+
+| Setting | What it does |
+|---|---|
+| **Declination** | `auto` learns declination + mount offset from GPS course (drive straight a while); `manual` = type your local declination; `off` = magnetic heading. |
+| **Update rate** | Reads per second (default 5 Hz). |
+| **Bow / Starboard axis** | Which sensor axis points forward / right, for how the board is mounted. Only needed if the heading is rotated or runs backwards; the `auto` declination corrects a constant offset on its own. |
+| **Mirror correction** | Flip if the heading turns the *wrong way* as you turn. |
+
+## Troubleshooting — "Dump raw I2C"
+
+If it won't detect, or the heading looks wrong, use **Settings → Devices →
+Compass → Dump raw I2C**. It reads the raw registers (the identity register and a
+window of data registers, sampled a few times) at the known addresses and shows a
+hex block you can **copy and paste into a GitHub issue**. That's usually enough to
+tell apart a wrong chip-id, swapped bytes, or a dead / miswired sensor — without
+anyone needing the board in hand. It works even when autodetection is failing.
+
+Common fixes: enable I2C (`raspi-config`); check 3V3 (not 5 V) and SDA/SCL aren't
+swapped; run `i2cdetect -y 1` to confirm the chip acknowledges at an address.
+
+## Adding another chip
+
+Support is table-driven. A new magnetometer is one `ChipSpec` entry in
+`src/vanchor/nav/magnetometer.py`'s `CHIP_TABLE` (address, id register + expected
+id, init writes, byte order, axis order); the driver **and** the setup-wizard
+probe both read that table. See
+[the developer guide](llms/device-drivers.md#second-worked-example-an-i2c-sensor-with-autodetection-magnetometerpy).

--- a/docs/llms/device-drivers.md
+++ b/docs/llms/device-drivers.md
@@ -202,6 +202,21 @@ The `magnetometer` compass driver is the template for an **I2C** device and for
 - **Config** reuses `compass_port` as an `i2c:<bus>[:<addr>]` target (address
   optional → autodetect). **Wizard**: `probe.py` `_probe_magnetometer` +
   `hwscan.py` `known_i2c` list detect it and suggest `compass_source: magnetometer`.
+- **Calibration** (hard/soft-iron) is mandatory for a usable heading: the
+  `calibrate_start`/`calibrate_stop` device actions fit `min/max` over a spin
+  (`CalibrationCollector`; needs ≥2 moving axes so a vertical-axis boat turn
+  works) and persist it via a `persist_cal` callback. A **`dump_raw` action**
+  reads the raw registers (id + a data window, sampled) into a copy-pasteable hex
+  block for remote debugging — it opens its own short-lived bus handle so it works
+  even when autodetect is failing and the read loop has no device.
+- **Tilt (important, and a hard limit):** a bare magnetometer has **no
+  accelerometer**, so it cannot separate heading from tilt. `heading_deg` computes
+  the bearing from the horizontal (X/Y) field **assuming the sensor is level**; on
+  a heeling/pitching boat the heading swings with the tilt. There is **no tilt
+  compensation** here and adding it isn't a knob — it needs an accel/IMU. If a
+  build tilts, point the user at the fused **HWT901B** AHRS
+  (`compass_source: hwt901b`) instead. Keep this caveat visible in any UI/docs.
+- **User guide:** [`../compass-magnetometer.md`](../compass-magnetometer.md).
 
 ## Device-specific settings menu (`device_menu`)
 

--- a/docs/llms/device-drivers.md
+++ b/docs/llms/device-drivers.md
@@ -182,6 +182,27 @@ A driver for exotic hardware must not force its dependency on everyone:
 - Declare an **extra** in `pyproject.toml` (`[project.optional-dependencies]`),
   e.g. `mycompass = ["mylib>=1.0"]`. The core install and the simulator never pull it.
 
+## Second worked example: an I2C sensor with autodetection (`magnetometer.py`)
+
+The `magnetometer` compass driver is the template for an **I2C** device and for
+**autodetecting** one of several interchangeable chips:
+
+- **Pure chip layer** (`nav/magnetometer.py`) talks to an injected `I2CBus`
+  (`write_byte_data`/`read_byte_data`/`read_block_data`) — so every register map,
+  the `detect()` autodetection, the heading math and the hard/soft-iron
+  calibration are unit-tested with a **fake bus** (no smbus2, no hardware). Add a
+  chip = one `ChipSpec` in `CHIP_TABLE` (address, id register, init writes, byte
+  order, axis order); the driver **and** the wizard probe both read that table, so
+  support lives in one place.
+- **Driver layer** (`hardware/drivers/magnetometer.py`) wraps it: a `SmbusBus`
+  (lazy `smbus2`), autodetect-on-start with reconnect, reuse of
+  `HeadingOffsetEstimator` for GPS-learned declination, and a `device_menu` with a
+  **spin-to-calibrate** action that fits + persists the calibration (via a
+  `persist_cal` callback the legacy `_build` wires from `save_device_overrides`).
+- **Config** reuses `compass_port` as an `i2c:<bus>[:<addr>]` target (address
+  optional → autodetect). **Wizard**: `probe.py` `_probe_magnetometer` +
+  `hwscan.py` `known_i2c` list detect it and suggest `compass_source: magnetometer`.
+
 ## Device-specific settings menu (`device_menu`)
 
 A driver can expose its own settings + actions that the UI renders generically —

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -95,12 +95,22 @@ request while one is in progress also returns 409.
 
 ## I²C probing
 
-Only two named addresses are probed, never a bus-wide sweep:
+Only named addresses are probed, never a bus-wide sweep:
 
 | Address | Kind | What is checked |
 |---|---|---|
 | 0x42 | helm-Pico | WHOAMI register returns 0x42 |
 | 0x40–0x4F | INA226 | Manufacturer ID register (0xFE = 0x5449 = "TI") |
+| 0x0D | QMC5883L compass | chip-ID register (0x0D = 0xFF) |
+| 0x1E | HMC5883L compass | identity registers 0x0A–0x0C = "H43" |
+| 0x0E | IST8310 compass | WHO_AM_I register (0x00 = 0x10) |
+
+The compass rows cover the magnetometer on combo GNSS boards (Beitian
+BN-880 / BE-880) and standalone parts. A detected magnetometer suggests
+`compass_source: magnetometer` with `compass_port: i2c:<bus>:0x<addr>`; the driver
+**autodetects** which chip is fitted at run time. Calibrate it after setup in
+**Settings → Devices** (Start calibration → turn the boat through a full slow
+circle → Finish) — a magnetometer needs a hard/soft-iron fit to read true.
 
 ## Offline / demo mode
 

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -110,7 +110,18 @@ BN-880 / BE-880) and standalone parts. A detected magnetometer suggests
 `compass_source: magnetometer` with `compass_port: i2c:<bus>:0x<addr>`; the driver
 **autodetects** which chip is fitted at run time. Calibrate it after setup in
 **Settings → Devices** (Start calibration → turn the boat through a full slow
-circle → Finish) — a magnetometer needs a hard/soft-iron fit to read true.
+circle → Finish) — a magnetometer needs a hard/soft-iron fit to read true, and
+the device panel nudges you until it's done.
+
+**Won't detect?** With `compass_source: magnetometer` selected, use the **Dump
+raw I2C** action in **Settings → Devices**. It reads the raw registers (identity
++ data) at the known addresses and shows a hex block you can copy into an issue —
+enough to tell a wrong chip-id, swapped bytes, or a dead/miswired sensor apart
+without the board in hand.
+
+See **[compass-magnetometer.md](compass-magnetometer.md)** for the full guide —
+wiring, calibration, options, and the **tilt limitation** (a bare magnetometer is
+only accurate when it's level; use the HWT901B AHRS if your boat tilts).
 
 ## Offline / demo mode
 

--- a/src/vanchor/hardware/drivers/battery.py
+++ b/src/vanchor/hardware/drivers/battery.py
@@ -368,4 +368,5 @@ register_context_driver(
     "battery", "ina226", build_ina226,
     api_version=DRIVER_API_VERSION,
     label="INA226 / shunt battery monitor",
+    transport="i2c",
 )

--- a/src/vanchor/hardware/drivers/magnetometer.py
+++ b/src/vanchor/hardware/drivers/magnetometer.py
@@ -16,6 +16,14 @@ that fits and persists the hard/soft-iron correction a magnetometer needs.
 never need it; the driver is fully testable with a fake I2C bus (no smbus2, no
 hardware).
 
+**Tilt / level-mount assumption.** A bare 3-axis magnetometer has no way to sense
+gravity, so the heading is computed from the horizontal (X/Y) field assuming the
+sensor sits roughly level. On a small boat that heels or pitches under way the
+heading will swing with the tilt -- there is no tilt compensation here because
+that needs an accelerometer. If your mount tilts significantly, use a fused AHRS
+instead (the WitMotion HWT901B driver, ``compass_source='hwt901b'``, does the
+accel+gyro fusion). Mounting the magnetometer level and low is the cheap fix.
+
 BENCH-VERIFY: the chip register maps + I2C timing have not yet been checked on
 real hardware; the logic is unit-tested with a fake bus.
 """
@@ -96,13 +104,25 @@ def parse_i2c_target(port: str | None, *, default_bus: int = _DEFAULT_BUS
 # --------------------------------------------------------------------------- #
 def _menu_schema(declination_mode: str, manual_declination_deg: float, hz: float,
                  forward_axis: str, right_axis: str, invert: bool,
-                 detected: str | None) -> dict:
+                 detected: str | None, calibrated: bool = False) -> dict:
     title = "Compass — magnetometer"
     if detected:
         title += f" ({detected})"
+    # First-run nudge: a magnetometer must be calibrated to read true, so surface
+    # it right in the settings panel until it's done (or if nothing is detected).
+    if detected is None:
+        notice = ("No magnetometer detected on the I2C bus yet. Check the wiring "
+                  "(SDA/SCL/3V3/GND), then use \"Dump raw I2C\" to troubleshoot.")
+    elif not calibrated:
+        notice = ("⚠ Not calibrated. Heading will be wrong until you calibrate: "
+                  "press \"Start calibration\", turn the boat slowly through a "
+                  "full circle, then \"Finish calibration\".")
+    else:
+        notice = ""
     return {
         "device": "compass",
         "title": title,
+        "notice": notice,
         "settings": [
             {"key": "declination_mode", "label": "Declination", "type": "select",
              "options": ["auto", "manual", "off"], "value": declination_mode,
@@ -118,7 +138,7 @@ def _menu_schema(declination_mode: str, manual_declination_deg: float, hz: float
              "help": "Which sensor axis points toward the bow (for the mount)."},
             {"key": "right_axis", "label": "Starboard axis", "type": "select",
              "options": ["y", "-y", "x", "-x"], "value": right_axis},
-            {"key": "invert", "label": "Mirror correction", "type": "bool",
+            {"key": "invert", "label": "Mirror correction", "type": "toggle",
              "value": invert, "help": "Enable if the heading turns the wrong way."},
         ],
         "actions": [
@@ -128,6 +148,8 @@ def _menu_schema(declination_mode: str, manual_declination_deg: float, hz: float
              "help": "Then slowly turn the boat through a full circle."},
             {"name": "calibrate_stop", "label": "Finish calibration",
              "help": "Fit + save the hard/soft-iron correction from the spin."},
+            {"name": "dump_raw", "label": "Dump raw I2C",
+             "help": "Read the raw registers to share for troubleshooting."},
             {"name": "redetect", "label": "Re-scan I2C",
              "help": "Probe the bus again for the magnetometer."},
         ],
@@ -153,6 +175,7 @@ class MagnetometerCompass(Sensor):
     def __init__(
         self, open_bus: Callable[[], Any], *,
         addr: int | None = None,
+        bus_num: int | None = None,
         bus: EventBus | None = None,
         hz: float = 5.0,
         motion_provider: MotionProvider | None = None,
@@ -164,6 +187,7 @@ class MagnetometerCompass(Sensor):
     ) -> None:
         self._open_bus = open_bus
         self._addr = addr
+        self._bus_num = bus_num
         self.bus = bus
         self.hz = max(0.5, hz)
         self.motion_provider = motion_provider
@@ -311,9 +335,10 @@ class MagnetometerCompass(Sensor):
 
     # -- device menu -------------------------------------------------------- #
     def device_menu(self) -> dict:
+        calibrated = self.calibration.offset != (0.0, 0.0, 0.0)
         return _menu_schema(self.declination_mode, self.manual_declination_deg,
                             self.hz, self.forward_axis, self.right_axis,
-                            self.invert, self.detected)
+                            self.invert, self.detected, calibrated)
 
     def apply_setting(self, key: str, value: Any) -> dict:
         if key == "declination_mode" and value in ("auto", "manual", "off"):
@@ -370,10 +395,36 @@ class MagnetometerCompass(Sensor):
                             "calibration": result.to_dict()}
             return {"ok": True, "message": "Calibration saved.",
                     "calibration": result.to_dict()}
+        if name == "dump_raw":
+            return self._dump_raw()
         if name == "redetect":
             self._close_bus()   # loop reopens + re-detects on the next tick
             return {"ok": True, "message": "Re-scanning the I2C bus…"}
         return {"ok": False, "message": f"unknown action {name!r}"}
+
+    def _dump_raw(self) -> dict:
+        """Read the raw magnetometer registers and return a hex dump the operator
+        can copy into a report. Opens its OWN short-lived bus handle (so it works
+        even when autodetection is failing and the read loop has no device), and
+        never disturbs the running loop."""
+        try:
+            probe_bus = self._open_bus()
+        except Exception as exc:  # noqa: BLE001 - no bus / no smbus2
+            return {"ok": False, "message": f"Could not open the I2C bus: {exc}"}
+        try:
+            addrs = (self._addr,) if self._addr is not None else None
+            text = mag.dump_i2c(probe_bus, addresses=addrs, bus_num=self._bus_num)
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "message": f"Dump failed: {exc}"}
+        finally:
+            close = getattr(probe_bus, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # pragma: no cover
+                    pass
+        return {"ok": True, "message": "Raw I2C dump — copy the block below and "
+                "share it for troubleshooting.", "dump": text}
 
 
 def open_magnetometer_compass(
@@ -387,7 +438,7 @@ def open_magnetometer_compass(
     """Build the driver for the I2C target in ``port`` (``i2c:<bus>[:<addr>]``)."""
     bus_num, addr = parse_i2c_target(port)
     return MagnetometerCompass(
-        lambda: SmbusBus(bus_num), addr=addr, bus=bus, hz=hz,
+        lambda: SmbusBus(bus_num), addr=addr, bus_num=bus_num, bus=bus, hz=hz,
         motion_provider=motion_provider, declination_mode=declination_mode,
         manual_declination_deg=manual_declination_deg, calibration=calibration,
         forward_axis=forward_axis, right_axis=right_axis, invert=invert,
@@ -429,4 +480,4 @@ def _build(runtime: Any, cfg: Any) -> MagnetometerCompass:
 
 register_driver("compass", "magnetometer", _build,
                 label="I2C magnetometer (HMC5883L / QMC5883L / IST8310)",
-                menu=default_menu())
+                menu=default_menu(), transport="i2c")

--- a/src/vanchor/hardware/drivers/magnetometer.py
+++ b/src/vanchor/hardware/drivers/magnetometer.py
@@ -1,0 +1,432 @@
+"""Pluggable compass driver for a bare I2C 3-axis magnetometer.
+
+Targets the magnetometer found on combo GNSS boards (Beitian BN-880 / BE-880 and
+many drone/rover modules) and any standalone HMC5883L / QMC5883L / IST8310. The
+chip is **autodetected** by its identity register, so the user only picks
+"magnetometer" and points it at an I2C bus -- no need to know which part is
+fitted (see :mod:`vanchor.nav.magnetometer`).
+
+Like the HWT901B driver it is a :class:`~vanchor.hardware.interfaces.Sensor` that
+emits ``HDT`` NMEA onto the bus, learns declination + mount offset from the GPS
+course (reusing :class:`~vanchor.hardware.drivers.hwt901b.HeadingOffsetEstimator`),
+and offers a device menu -- including an interactive **spin-to-calibrate** action
+that fits and persists the hard/soft-iron correction a magnetometer needs.
+
+``smbus2`` is optional and imported lazily, so the core install and the simulator
+never need it; the driver is fully testable with a fake I2C bus (no smbus2, no
+hardware).
+
+BENCH-VERIFY: the chip register maps + I2C timing have not yet been checked on
+real hardware; the logic is unit-tested with a fake bus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Optional
+
+from ...core import events
+from ...core.events import EventBus
+from ...core.geo import normalize_deg
+from ...nav import magnetometer as mag
+from ...nav import nmea
+from ..interfaces import Sensor
+from ..registry import register_driver
+from .hwt901b import HeadingOffsetEstimator, MotionProvider
+
+logger = logging.getLogger("vanchor.hardware.magnetometer")
+
+_DEFAULT_BUS = 1
+_REOPEN_BACKOFF_S = 3.0
+_READ_ERR_LIMIT = 5
+
+
+# --------------------------------------------------------------------------- #
+# Real I2C bus (lazy smbus2). A fake with the same 3 methods is used in tests.
+# --------------------------------------------------------------------------- #
+class SmbusBus:
+    """Thin :class:`~vanchor.nav.magnetometer.I2CBus` over ``smbus2.SMBus``."""
+
+    def __init__(self, bus_num: int) -> None:
+        try:
+            from smbus2 import SMBus  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise RuntimeError(
+                "compass_source='magnetometer' needs the i2c extra: "
+                "pip install 'vanchor[i2c]'"
+            ) from exc
+        self._smbus = SMBus(bus_num)
+
+    def write_byte_data(self, addr: int, reg: int, value: int) -> None:
+        self._smbus.write_byte_data(addr, reg, value)
+
+    def read_byte_data(self, addr: int, reg: int) -> int:
+        return self._smbus.read_byte_data(addr, reg)
+
+    def read_block_data(self, addr: int, reg: int, length: int) -> bytes:
+        return bytes(self._smbus.read_i2c_block_data(addr, reg, length))
+
+    def close(self) -> None:
+        try:
+            self._smbus.close()
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+def parse_i2c_target(port: str | None, *, default_bus: int = _DEFAULT_BUS
+                     ) -> tuple[int, int | None]:
+    """Parse a compass ``port`` into ``(bus, addr|None)`` for the I2C compass.
+
+    Accepts ``i2c:<bus>``, ``i2c:<bus>:<addr>`` (addr hex ``0x0d`` or decimal), a
+    bare bus number, or anything else (-> default bus, autodetect address)."""
+    s = (port or "").strip()
+    if s.lower().startswith("i2c:"):
+        parts = s[4:].split(":")
+        bus = int(parts[0]) if parts and parts[0] else default_bus
+        addr = int(parts[1], 0) if len(parts) > 1 and parts[1] else None
+        return bus, addr
+    if s.isdigit():
+        return int(s), None
+    return default_bus, None
+
+
+# --------------------------------------------------------------------------- #
+# Device menu schema
+# --------------------------------------------------------------------------- #
+def _menu_schema(declination_mode: str, manual_declination_deg: float, hz: float,
+                 forward_axis: str, right_axis: str, invert: bool,
+                 detected: str | None) -> dict:
+    title = "Compass — magnetometer"
+    if detected:
+        title += f" ({detected})"
+    return {
+        "device": "compass",
+        "title": title,
+        "settings": [
+            {"key": "declination_mode", "label": "Declination", "type": "select",
+             "options": ["auto", "manual", "off"], "value": declination_mode,
+             "help": "auto = learn declination + mount offset from GPS course."},
+            {"key": "manual_declination_deg", "label": "Manual declination",
+             "type": "number", "min": -30, "max": 30, "step": 0.1, "unit": "°",
+             "value": round(manual_declination_deg, 1),
+             "shown_when": {"declination_mode": "manual"}},
+            {"key": "hz", "label": "Update rate", "type": "number",
+             "min": 1, "max": 50, "step": 1, "unit": "Hz", "value": hz},
+            {"key": "forward_axis", "label": "Bow axis", "type": "select",
+             "options": ["x", "-x", "y", "-y"], "value": forward_axis,
+             "help": "Which sensor axis points toward the bow (for the mount)."},
+            {"key": "right_axis", "label": "Starboard axis", "type": "select",
+             "options": ["y", "-y", "x", "-x"], "value": right_axis},
+            {"key": "invert", "label": "Mirror correction", "type": "bool",
+             "value": invert, "help": "Enable if the heading turns the wrong way."},
+        ],
+        "actions": [
+            {"name": "status", "label": "Sensor status",
+             "help": "Show the detected chip, live heading, learned offset."},
+            {"name": "calibrate_start", "label": "Start calibration",
+             "help": "Then slowly turn the boat through a full circle."},
+            {"name": "calibrate_stop", "label": "Finish calibration",
+             "help": "Fit + save the hard/soft-iron correction from the spin."},
+            {"name": "redetect", "label": "Re-scan I2C",
+             "help": "Probe the bus again for the magnetometer."},
+        ],
+    }
+
+
+def default_menu() -> dict:
+    return _menu_schema("auto", 0.0, 5.0, "x", "y", False, None)
+
+
+# --------------------------------------------------------------------------- #
+# The driver
+# --------------------------------------------------------------------------- #
+class MagnetometerCompass(Sensor):
+    """An I2C magnetometer presented as a vanchor NMEA compass.
+
+    ``open_bus`` is a zero-arg callable returning an object with
+    ``write_byte_data`` / ``read_byte_data`` / ``read_block_data`` (+ optional
+    ``close``) -- the real :class:`SmbusBus` or a fake in tests. Detection,
+    configuration and reconnection happen inside the loop, so a not-yet-ready bus
+    or wrong wiring never crashes startup and recovers on its own."""
+
+    def __init__(
+        self, open_bus: Callable[[], Any], *,
+        addr: int | None = None,
+        bus: EventBus | None = None,
+        hz: float = 5.0,
+        motion_provider: MotionProvider | None = None,
+        declination_mode: str = "auto",
+        manual_declination_deg: float = 0.0,
+        calibration: mag.Calibration | None = None,
+        forward_axis: str = "x", right_axis: str = "y", invert: bool = False,
+        persist_cal: Optional[Callable[[dict], None]] = None,
+    ) -> None:
+        self._open_bus = open_bus
+        self._addr = addr
+        self.bus = bus
+        self.hz = max(0.5, hz)
+        self.motion_provider = motion_provider
+        self.declination_mode = declination_mode
+        self.manual_declination_deg = manual_declination_deg
+        self.calibration = calibration or mag.Calibration()
+        self.forward_axis = forward_axis
+        self.right_axis = right_axis
+        self.invert = invert
+        self._persist_cal = persist_cal
+        self.estimator = HeadingOffsetEstimator()
+
+        self._task: asyncio.Task | None = None
+        self._i2c: Any = None
+        self._mag: mag.Magnetometer | None = None
+        self.detected: str | None = None
+        # Calibration state.
+        self._collector: mag.CalibrationCollector | None = None
+        # Latest values for the Debug view.
+        self.last_heading_deg: float | None = None
+        self._last_magnetic_deg: float | None = None
+        self._last_declination_deg: float = 0.0
+        self._last_raw: tuple[int, int, int] | None = None
+
+    async def start(self) -> None:
+        self._task = asyncio.ensure_future(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        self._close_bus()
+
+    def _close_bus(self) -> None:
+        close = getattr(self._i2c, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # pragma: no cover
+                pass
+        self._i2c = None
+        self._mag = None
+
+    def _open_and_detect(self) -> bool:
+        """Open the bus and detect + configure the chip. Blocking (run in a
+        thread). Returns True on success."""
+        self._i2c = self._open_bus()
+        addrs = (self._addr,) if self._addr is not None else None
+        found = mag.detect(self._i2c, addresses=addrs)
+        if found is None:
+            self._close_bus()
+            return False
+        spec, addr = found
+        self._mag = mag.Magnetometer(self._i2c, spec, addr)
+        self._mag.configure()
+        self.detected = spec.name
+        logger.info("magnetometer: detected %s at 0x%02x on the I2C bus",
+                    spec.name, addr)
+        return True
+
+    def _current_declination(self, magnetic_heading: float, dt: float) -> float:
+        if self.declination_mode == "manual":
+            return self.manual_declination_deg
+        if self.declination_mode == "off":
+            return 0.0
+        cog = sog = None
+        if self.motion_provider is not None:
+            mv = self.motion_provider()
+            if mv is not None:
+                cog, sog = mv
+        return self.estimator.update(magnetic_heading, cog, sog, dt)
+
+    def _heading_from_raw(self, raw: tuple[int, int, int], dt: float) -> str:
+        """Raw counts -> calibrated -> magnetic heading -> declination -> HDT."""
+        if self._collector is not None:                       # feed calibration
+            self._collector.add(tuple(float(v) for v in raw))
+        corrected = self.calibration.apply(tuple(float(v) for v in raw))
+        magnetic = mag.heading_deg(corrected, forward_axis=self.forward_axis,
+                                   right_axis=self.right_axis, invert=self.invert)
+        declination = self._current_declination(magnetic, dt)
+        heading = normalize_deg(magnetic + declination)
+        self.last_heading_deg = heading
+        self._last_magnetic_deg = magnetic
+        self._last_declination_deg = declination
+        self._last_raw = raw
+        return nmea.encode_hdt(heading)
+
+    async def sample_once(self, dt: float) -> str | None:
+        """Read one vector and return the HDT sentence, or None (not ready)."""
+        if self._mag is None:
+            return None
+        loop = asyncio.get_event_loop()
+        raw = await loop.run_in_executor(None, self._mag.read_raw)
+        return self._heading_from_raw(raw, dt)
+
+    async def _loop(self) -> None:
+        loop = asyncio.get_event_loop()
+        errors = 0
+        while True:
+            try:
+                if self._mag is None:
+                    ok = await loop.run_in_executor(None, self._open_and_detect)
+                    if not ok:
+                        await asyncio.sleep(_REOPEN_BACKOFF_S)
+                        continue
+                    errors = 0
+                period = 1.0 / self.hz
+                sentence = await self.sample_once(period)
+                if sentence and self.bus is not None:
+                    await self.bus.publish(events.NMEA_IN, sentence)
+                errors = 0
+                await asyncio.sleep(period)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - keep the loop alive; reopen on repeats
+                errors += 1
+                logger.debug("magnetometer read error (%d): %s", errors, exc)
+                if errors >= _READ_ERR_LIMIT:
+                    logger.warning("magnetometer: too many read errors; reopening")
+                    self._close_bus()
+                    errors = 0
+                await asyncio.sleep(min(_REOPEN_BACKOFF_S, 1.0))
+
+    def debug(self) -> str:
+        if self.detected is None:
+            return f"{type(self).__name__}: scanning I2C for a magnetometer…"
+        if self.last_heading_deg is None:
+            return f"{type(self).__name__}: {self.detected} found, waiting for data…"
+        try:
+            r = self._last_raw or (0, 0, 0)
+            cal = "on" if self.calibration.offset != (0.0, 0.0, 0.0) else "off"
+            return (
+                f"{type(self).__name__}\n"
+                f"  chip      : {self.detected}\n"
+                f"  heading   : {self.last_heading_deg:.1f} ° true "
+                f"({self._last_magnetic_deg:.1f} ° magnetic)\n"
+                f"  declin.   : {self._last_declination_deg:+.1f} ° "
+                f"(mode {self.declination_mode})\n"
+                f"  raw x/y/z : {r[0]} / {r[1]} / {r[2]}  (cal {cal})\n"
+                f"  offset    : {self.estimator.offset_deg:+.1f} ° "
+                f"(settled {self.estimator.settled})"
+            )
+        except Exception as exc:  # noqa: BLE001 - debug must never raise
+            return f"{type(self).__name__}: debug error ({exc})"
+
+    # -- device menu -------------------------------------------------------- #
+    def device_menu(self) -> dict:
+        return _menu_schema(self.declination_mode, self.manual_declination_deg,
+                            self.hz, self.forward_axis, self.right_axis,
+                            self.invert, self.detected)
+
+    def apply_setting(self, key: str, value: Any) -> dict:
+        if key == "declination_mode" and value in ("auto", "manual", "off"):
+            self.declination_mode = value
+        elif key == "manual_declination_deg":
+            self.manual_declination_deg = float(value)
+        elif key == "hz":
+            self.hz = max(0.5, float(value))
+        elif key == "forward_axis":
+            self.forward_axis = str(value)
+        elif key == "right_axis":
+            self.right_axis = str(value)
+        elif key == "invert":
+            self.invert = bool(value)
+        elif key == "calibration":
+            self.calibration = mag.Calibration.from_dict(value)
+        else:
+            return {"ok": False, "message": f"unknown setting {key!r}"}
+        return {"ok": True}
+
+    def run_action(self, name: str, params: dict | None = None) -> dict:
+        if name == "status":
+            hdg = self.last_heading_deg
+            return {"ok": True, "message": f"Magnetometer: {self.detected or 'not detected'}.",
+                    "status": {
+                        "chip": self.detected,
+                        "heading_deg": round(hdg, 1) if hdg is not None else None,
+                        "declination_mode": self.declination_mode,
+                        "offset_deg": round(self.estimator.offset_deg, 1),
+                        "offset_settled": self.estimator.settled,
+                        "calibrated": self.calibration.offset != (0.0, 0.0, 0.0),
+                    }}
+        if name == "calibrate_start":
+            if self._mag is None:
+                return {"ok": False, "message": "No magnetometer detected yet."}
+            self._collector = mag.CalibrationCollector()
+            return {"ok": True, "message": "Calibrating. Slowly turn the boat "
+                    "through a full circle, then press Finish."}
+        if name == "calibrate_stop":
+            col = self._collector
+            self._collector = None
+            if col is None:
+                return {"ok": False, "message": "Calibration was not started."}
+            result = col.result()
+            if result is None:
+                return {"ok": False, "message": "Not enough rotation to calibrate. "
+                        "Turn the boat through a full slow circle and retry."}
+            self.calibration = result
+            if self._persist_cal is not None:
+                try:
+                    self._persist_cal(result.to_dict())
+                except Exception as exc:  # noqa: BLE001
+                    return {"ok": True, "message": f"Calibrated (not saved: {exc}).",
+                            "calibration": result.to_dict()}
+            return {"ok": True, "message": "Calibration saved.",
+                    "calibration": result.to_dict()}
+        if name == "redetect":
+            self._close_bus()   # loop reopens + re-detects on the next tick
+            return {"ok": True, "message": "Re-scanning the I2C bus…"}
+        return {"ok": False, "message": f"unknown action {name!r}"}
+
+
+def open_magnetometer_compass(
+    port: str, bus: EventBus | None, *,
+    hz: float = 5.0, motion_provider: MotionProvider | None = None,
+    declination_mode: str = "auto", manual_declination_deg: float = 0.0,
+    calibration: mag.Calibration | None = None,
+    forward_axis: str = "x", right_axis: str = "y", invert: bool = False,
+    persist_cal: Optional[Callable[[dict], None]] = None,
+) -> MagnetometerCompass:
+    """Build the driver for the I2C target in ``port`` (``i2c:<bus>[:<addr>]``)."""
+    bus_num, addr = parse_i2c_target(port)
+    return MagnetometerCompass(
+        lambda: SmbusBus(bus_num), addr=addr, bus=bus, hz=hz,
+        motion_provider=motion_provider, declination_mode=declination_mode,
+        manual_declination_deg=manual_declination_deg, calibration=calibration,
+        forward_axis=forward_axis, right_axis=right_axis, invert=invert,
+        persist_cal=persist_cal,
+    )
+
+
+def _build(runtime: Any, cfg: Any) -> MagnetometerCompass:
+    """Registry build hook: wire the driver to the runtime GPS motion (for
+    auto-declination) + bus, applying persisted device-menu settings, and give it
+    a callback that persists a fitted calibration to the config."""
+    hw = cfg.hardware
+
+    def motion():
+        st = getattr(runtime, "state", None)
+        if st is None or st.fix is None:
+            return None
+        return (st.fix.cog_deg, st.sog_knots * 0.514444)  # knots -> m/s
+
+    def persist_cal(cal_dict: dict) -> None:
+        from ...core.config import save_device_overrides  # local: avoid import cycle
+        hw.device_settings.setdefault("compass", {})["calibration"] = cal_dict
+        save_device_overrides(cfg.data_dir, hw, cfg.nmea_tcp, cfg.sim_motor)
+
+    saved = (getattr(hw, "device_settings", None) or {}).get("compass", {})
+    return open_magnetometer_compass(
+        hw.compass_port, runtime.bus,
+        hz=float(saved.get("hz", cfg.sensors.compass_hz)),
+        motion_provider=motion,
+        declination_mode=str(saved.get("declination_mode", "auto")),
+        manual_declination_deg=float(saved.get("manual_declination_deg", 0.0)),
+        calibration=mag.Calibration.from_dict(saved.get("calibration")),
+        forward_axis=str(saved.get("forward_axis", "x")),
+        right_axis=str(saved.get("right_axis", "y")),
+        invert=bool(saved.get("invert", False)),
+        persist_cal=persist_cal,
+    )
+
+
+register_driver("compass", "magnetometer", _build,
+                label="I2C magnetometer (HMC5883L / QMC5883L / IST8310)",
+                menu=default_menu())

--- a/src/vanchor/hardware/drivers/phone.py
+++ b/src/vanchor/hardware/drivers/phone.py
@@ -246,5 +246,5 @@ def _build_compass(runtime: Any, cfg: Any) -> PhoneCompass:
     return PhoneCompass(ensure_hub(runtime), runtime.bus)
 
 
-register_driver("gps", "phone", _build_gps, label="Phone (this device)")
-register_driver("compass", "phone", _build_compass, label="Phone (this device)")
+register_driver("gps", "phone", _build_gps, label="Phone (this device)", transport="none")
+register_driver("compass", "phone", _build_compass, label="Phone (this device)", transport="none")

--- a/src/vanchor/hardware/probe.py
+++ b/src/vanchor/hardware/probe.py
@@ -622,6 +622,12 @@ def probe_i2c(bus_num: int, addr: int, kind: str = "auto", *,
             except OSError:
                 pass
 
+        if kind in ("magnetometer", "auto"):
+            try:
+                return _probe_magnetometer(bus, addr, write_fn, read_fn)
+            except OSError:
+                pass
+
         return {"ok": True, "detected": "unknown"}
     finally:
         try:
@@ -670,3 +676,27 @@ def _probe_ina226(bus, addr: int, write_fn, read_fn) -> dict:
         "detected": "ina226",
         "sample": {"mfr_id": "0x5449", "die_id": "0x2260"},
     }
+
+
+def _probe_magnetometer(bus, addr: int, write_fn, read_fn) -> dict:
+    """Probe for a known I2C magnetometer at addr (BN-880/BE-880 compass and
+    friends). Reads the chip's identity register only -- reuses the same chip
+    table the driver autodetects with, so support stays in one place. Raises
+    OSError if nothing known matches."""
+    from ..nav import magnetometer as mag
+
+    for spec in mag.CHIP_TABLE:
+        if addr not in spec.addresses:
+            continue
+        w = write_fn(bytes([spec.id_reg]))
+        r = read_fn(spec.id_len)
+        bus.i2c_rdwr(w, r)
+        got = bytes(r)
+        if got == spec.id_expected:
+            return {"ok": True, "detected": "magnetometer",
+                    "sample": {"chip": spec.name, "id": "0x" + got.hex()}}
+        raise OSError(
+            f"{spec.name} id=0x{got.hex()} (expected 0x{spec.id_expected.hex()}) "
+            f"at addr=0x{addr:02X}"
+        )
+    raise OSError(f"no known magnetometer at addr 0x{addr:02X}")

--- a/src/vanchor/hardware/registry.py
+++ b/src/vanchor/hardware/registry.py
@@ -70,6 +70,10 @@ class DriverSpec:
     source: str        # the *_source value that selects it, e.g. "hwt901b" / "ina226"
     build: BuildFn | None = None     # legacy (runtime, cfg) -> device
     label: str = ""    # human label for the UI
+    # How the device connects, so the UI shows the RIGHT connection fields (a
+    # serial port + baud, an I2C target, or nothing) instead of always the serial
+    # ones. "serial" | "i2c" | "none".
+    transport: str = "serial"
     menu: dict | None = None  # static device_menu() schema (defaults), so the UI
                               # can render settings/actions on selection
     # Versioned capability API (roadmap #43): when set, the driver is built via
@@ -197,21 +201,25 @@ _REGISTRY: dict[tuple[str, str], DriverSpec] = {}
 
 
 def register_driver(kind: str, source: str, build: BuildFn, *,
-                    label: str = "", menu: dict | None = None) -> None:
+                    label: str = "", menu: dict | None = None,
+                    transport: str = "serial") -> None:
     """Register a **legacy** driver (``build(runtime, cfg)``) as a selectable
     ``{kind}_source`` value. Optional ``menu`` is the driver's default
     device_menu() schema, so the UI can render its settings/actions the moment
-    the source is selected. Idempotent.
+    the source is selected. ``transport`` ("serial" | "i2c" | "none") tells the
+    UI which connection fields to show. Idempotent.
 
     New drivers — and every community pack — should prefer
     :func:`register_context_driver`, which hands the driver a NARROW, versioned
     capability object instead of the whole runtime."""
-    _REGISTRY[(kind, source)] = DriverSpec(kind, source, build=build, label=label, menu=menu)
+    _REGISTRY[(kind, source)] = DriverSpec(kind, source, build=build, label=label,
+                                           menu=menu, transport=transport)
 
 
 def register_context_driver(
     kind: str, source: str, build: ContextBuildFn, *,
     api_version: int = DRIVER_API_VERSION, label: str = "", menu: dict | None = None,
+    transport: str = "serial",
 ) -> None:
     """Register a driver against the **versioned capability API** (roadmap #43).
 
@@ -227,8 +235,19 @@ def register_context_driver(
             kind, source, api_version, DRIVER_API_VERSION,
         )
     _REGISTRY[(kind, source)] = DriverSpec(
-        kind, source, label=label, menu=menu, ctx_build=build, api_version=api_version,
+        kind, source, label=label, menu=menu, ctx_build=build,
+        api_version=api_version, transport=transport,
     )
+
+
+def transports() -> dict:
+    """``{kind: {source: transport}}`` for registered drivers -- so the UI can
+    show the right connection fields (serial port / I2C target / none) for the
+    selected source instead of always the serial ones."""
+    out: dict = {}
+    for s in _REGISTRY.values():
+        out.setdefault(s.kind, {})[s.source] = s.transport
+    return out
 
 
 def menus(kind: str) -> dict:

--- a/src/vanchor/nav/magnetometer.py
+++ b/src/vanchor/nav/magnetometer.py
@@ -164,6 +164,60 @@ class Magnetometer:
 
 
 # --------------------------------------------------------------------------- #
+# Raw register dump (remote troubleshooting)
+# --------------------------------------------------------------------------- #
+def dump_i2c(bus: I2CBus, *, addresses: tuple[int, ...] | None = None,
+             samples: int = 3, window: int = 16, delay_s: float = 0.1,
+             bus_num: int | None = None) -> str:
+    """A human-readable hex dump of the known magnetometer addresses -- so a
+    remote user can copy it into an issue when a chip won't autodetect and we
+    diagnose it (wrong id? swapped bytes? dead sensor?) without the hardware.
+
+    Reads ONLY the named magnetometer addresses (no bus-wide sweep). For each: an
+    explicit identity-register check per candidate chip, plus ``samples``
+    snapshots of a ``window``-byte register block from 0x00 (which spans the data
+    AND id registers of every supported chip), so changing bytes = live data. All
+    reads are guarded, so an absent address just reports 'NO RESPONSE'."""
+    addrs = addresses if addresses is not None else tuple(
+        sorted({a for s in CHIP_TABLE for a in s.addresses}))
+    hdr = "I2C magnetometer raw dump"
+    if bus_num is not None:
+        hdr += f" (bus /dev/i2c-{bus_num})"
+    lines = [hdr + ":", f"probing {', '.join(f'0x{a:02x}' for a in addrs)}"]
+    for addr in addrs:
+        id_notes = []
+        for s in CHIP_TABLE:
+            if addr not in s.addresses:
+                continue
+            try:
+                got = bytes(bus.read_block_data(addr, s.id_reg, s.id_len))
+                verdict = "MATCH" if got == s.id_expected else "differs"
+                id_notes.append(f"{s.name}: id@0x{s.id_reg:02x}=0x{got.hex()} "
+                                f"(expect 0x{s.id_expected.hex()} -> {verdict})")
+            except Exception:
+                id_notes.append(f"{s.name}: id@0x{s.id_reg:02x} no response")
+        snaps: list[str] = []
+        responded = False
+        n = max(1, samples)
+        for j in range(n):
+            try:
+                w = bytes(bus.read_block_data(addr, 0x00, window))
+                snaps.append(w.hex())
+                responded = True
+            except Exception:
+                snaps.append("(no response)")
+                break                       # dead address -> don't retry
+            if delay_s > 0 and j < n - 1:
+                time.sleep(delay_s)         # spacing between live samples only
+        lines.append(f"0x{addr:02x}: {'responds' if responded else 'NO RESPONSE'}")
+        lines += [f"    {n}" for n in id_notes]
+        if responded:
+            lines.append(f"    regs 0x00..0x{window - 1:02x} x{len(snaps)}:")
+            lines += [f"      {i}: {s}" for i, s in enumerate(snaps)]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
 # Calibration (hard- + soft-iron) and heading
 # --------------------------------------------------------------------------- #
 @dataclass

--- a/src/vanchor/nav/magnetometer.py
+++ b/src/vanchor/nav/magnetometer.py
@@ -1,0 +1,270 @@
+"""I2C magnetometer support: multi-chip autodetection, raw reads, heading, and
+hard/soft-iron calibration.
+
+This module is **pure** with respect to the hardware layer: it talks to an
+injected ``bus`` object (any object exposing ``write_byte_data(addr, reg, val)``,
+``read_byte_data(addr, reg) -> int`` and ``read_block_data(addr, reg, n) ->
+bytes``), so every chip's register map, the autodetection, the heading math and
+the calibration are unit-testable with a fake bus and no ``smbus2`` installed.
+The real smbus2 wrapper lives in ``hardware/drivers/magnetometer.py``.
+
+Combo GPS modules (Beitian BN-880 / BE-880, and many drone/rover boards) carry a
+3-axis magnetometer on I2C next to the GNSS. There is no single part: the same
+board may ship an **HMC5883L**, a **QMC5883L** clone, or an **IST8310**, at
+different addresses and with different register maps and byte orders. So we key
+support off the chip's identity register and autodetect which one is present,
+rather than making the user know. Adding another chip is one entry in
+``CHIP_TABLE``.
+
+BENCH-VERIFY: the register maps below are transcribed from the datasheets; the
+logic (detection, decode, heading, calibration) is unit-tested with a fake bus,
+but the real chip timing/config has NOT yet been verified on hardware.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Protocol
+
+
+class I2CBus(Protocol):
+    """The tiny I2C surface the chips need (smbus2 provides all three)."""
+
+    def write_byte_data(self, addr: int, reg: int, value: int) -> None: ...
+    def read_byte_data(self, addr: int, reg: int) -> int: ...
+    def read_block_data(self, addr: int, reg: int, length: int) -> bytes: ...
+
+
+def _s16(lo: int, hi: int) -> int:
+    """Combine low/high bytes into a signed 16-bit int (hi is the MSB)."""
+    v = (hi << 8) | lo
+    return v - 0x10000 if v & 0x8000 else v
+
+
+# --------------------------------------------------------------------------- #
+# Chip definitions
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ChipSpec:
+    """One magnetometer's register map + identity.
+
+    ``id_reg``/``id_expected`` identify the part (``id_len`` bytes read from
+    ``id_reg`` must equal ``id_expected``). ``init`` is the list of
+    ``(register, value)`` writes that put it in a usable measuring mode.
+    ``data_reg``/``data_len`` locate the 6 output bytes; ``little_endian`` and
+    ``axis_pairs`` decode them into ``(x, y, z)`` -- ``axis_pairs`` is the index
+    of the 16-bit pair (0,1,2 within the block) that holds X, Y and Z
+    respectively (chips differ: HMC5883L streams X,Z,Y; QMC5883L streams X,Y,Z).
+    ``single_shot`` chips have no continuous mode: re-run ``init`` and wait
+    ``settle_s`` before each read."""
+
+    name: str
+    label: str
+    addresses: tuple[int, ...]
+    id_reg: int
+    id_expected: bytes
+    init: tuple[tuple[int, int], ...]
+    data_reg: int
+    little_endian: bool
+    axis_pairs: tuple[int, int, int] = (0, 1, 2)   # block-pair index for (X, Y, Z)
+    id_len: int = 1
+    single_shot: bool = False
+    settle_s: float = 0.008
+    ut_per_lsb: float = 0.0     # microtesla per LSB (reporting only; 0 = unknown)
+
+
+# HMC5883L (Honeywell): addr 0x1E. Identity regs 0x0A-0x0C read ASCII "H43".
+# Config A 0x00=0x70 (8-avg, 15 Hz), Config B 0x01=0x20 (gain ±1.3 Ga), Mode
+# 0x02=0x00 (continuous). Data 0x03..0x08 big-endian in X, Z, Y order.
+HMC5883L = ChipSpec(
+    name="HMC5883L", label="Honeywell HMC5883L",
+    addresses=(0x1E,), id_reg=0x0A, id_expected=b"H43", id_len=3,
+    init=((0x00, 0x70), (0x01, 0x20), (0x02, 0x00)),
+    data_reg=0x03, little_endian=False, axis_pairs=(0, 2, 1),
+    ut_per_lsb=100.0 / 1090.0,
+)
+
+# QMC5883L (QST): addr 0x0D. Chip-ID reg 0x0D = 0xFF. SET/RESET period reg
+# 0x0B=0x01 (required), Control 1 0x09=0x1D (continuous, 200 Hz, ±8 G, OSR 512).
+# Data 0x00..0x05 little-endian in X, Y, Z order.
+QMC5883L = ChipSpec(
+    name="QMC5883L", label="QST QMC5883L",
+    addresses=(0x0D,), id_reg=0x0D, id_expected=b"\xff",
+    init=((0x0B, 0x01), (0x09, 0x1D)),
+    data_reg=0x00, little_endian=True, axis_pairs=(0, 1, 2),
+    ut_per_lsb=100.0 / 3000.0,   # ±8 G range -> 3000 LSB/G
+)
+
+# IST8310 (iSentek): addr 0x0E. WHO_AM_I reg 0x00 = 0x10. No continuous mode:
+# write CNTL1 0x0A=0x01 to trigger a single measurement, wait, then read
+# 0x03..0x08 little-endian X, Y, Z.
+IST8310 = ChipSpec(
+    name="IST8310", label="iSentek IST8310",
+    addresses=(0x0E,), id_reg=0x00, id_expected=b"\x10",
+    init=((0x0A, 0x01),),
+    data_reg=0x03, little_endian=True, axis_pairs=(0, 1, 2),
+    single_shot=True, settle_s=0.008, ut_per_lsb=1.0 / 3.0,
+)
+
+# Order matters for autodetect: distinct addresses, so no conflict, but keep the
+# common combo-GPS chips first. Add a new chip by appending its ChipSpec here.
+CHIP_TABLE: tuple[ChipSpec, ...] = (QMC5883L, HMC5883L, IST8310)
+
+
+def detect(bus: I2CBus, *, addresses: tuple[int, ...] | None = None
+           ) -> tuple[ChipSpec, int] | None:
+    """Probe known magnetometer addresses and return ``(spec, addr)`` for the
+    first chip whose identity register matches, else ``None``.
+
+    Register READS only (plus, implicitly, none of the init writes) at explicitly
+    named addresses -- never a bus-wide sweep. ``addresses`` optionally restricts
+    the probe (e.g. to a single configured address)."""
+    for spec in CHIP_TABLE:
+        for addr in spec.addresses:
+            if addresses is not None and addr not in addresses:
+                continue
+            try:
+                got = bytes(bus.read_block_data(addr, spec.id_reg, spec.id_len))
+            except Exception:
+                continue          # NAK / no device at this address
+            if got == spec.id_expected:
+                return spec, addr
+    return None
+
+
+class Magnetometer:
+    """A configured magnetometer on a bus: ``configure()`` once, then
+    ``read_raw()`` returns the signed ``(x, y, z)`` counts."""
+
+    def __init__(self, bus: I2CBus, spec: ChipSpec, addr: int) -> None:
+        self.bus = bus
+        self.spec = spec
+        self.addr = addr
+
+    def configure(self) -> None:
+        for reg, val in self.spec.init:
+            self.bus.write_byte_data(self.addr, reg, val)
+
+    def read_raw(self) -> tuple[int, int, int]:
+        spec = self.spec
+        if spec.single_shot:
+            # No continuous mode: re-trigger and let the measurement settle.
+            for reg, val in spec.init:
+                self.bus.write_byte_data(self.addr, reg, val)
+            time.sleep(spec.settle_s)
+        raw = bytes(self.bus.read_block_data(self.addr, spec.data_reg, 6))
+        pairs = []
+        for i in range(3):
+            lo, hi = raw[2 * i], raw[2 * i + 1]
+            pairs.append(_s16(lo, hi) if spec.little_endian else _s16(hi, lo))
+        px, py, pz = spec.axis_pairs
+        return pairs[px], pairs[py], pairs[pz]
+
+
+# --------------------------------------------------------------------------- #
+# Calibration (hard- + soft-iron) and heading
+# --------------------------------------------------------------------------- #
+@dataclass
+class Calibration:
+    """Per-axis hard-iron offset + soft-iron scale. ``corrected = (raw - offset)
+    * scale``. Identity by default (raw passed through)."""
+
+    offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+
+    def apply(self, xyz: tuple[float, float, float]) -> tuple[float, float, float]:
+        return tuple((xyz[i] - self.offset[i]) * self.scale[i] for i in range(3))
+
+    def to_dict(self) -> dict:
+        return {"offset": list(self.offset), "scale": list(self.scale)}
+
+    @classmethod
+    def from_dict(cls, d: dict | None) -> "Calibration":
+        if not d:
+            return cls()
+        o = d.get("offset") or [0.0, 0.0, 0.0]
+        s = d.get("scale") or [1.0, 1.0, 1.0]
+        return cls(offset=(float(o[0]), float(o[1]), float(o[2])),
+                   scale=(float(s[0]), float(s[1]), float(s[2])))
+
+
+class CalibrationCollector:
+    """Accumulate samples during a full rotation and fit a hard/soft-iron
+    correction (min/max per axis). ``spin the boat slowly through 360 deg``:
+
+        offset[i] = (max[i] + min[i]) / 2          # hard-iron centre
+        scale[i]  = avg_radius / ((max[i]-min[i])/2)  # soft-iron -> unit sphere
+    """
+
+    def __init__(self) -> None:
+        self.n = 0
+        self._min = [math.inf, math.inf, math.inf]
+        self._max = [-math.inf, -math.inf, -math.inf]
+
+    def add(self, xyz: tuple[float, float, float]) -> None:
+        for i in range(3):
+            self._min[i] = min(self._min[i], xyz[i])
+            self._max[i] = max(self._max[i], xyz[i])
+        self.n += 1
+
+    def spread(self) -> float:
+        """Largest axis range so far -- a readiness signal (needs real rotation)."""
+        if self.n == 0:
+            return 0.0
+        return max(self._max[i] - self._min[i] for i in range(3))
+
+    def result(self) -> Calibration | None:
+        """The fitted Calibration, or None if not enough motion to trust it.
+
+        A boat turns about the VERTICAL axis, so only the two horizontal axes
+        trace a circle -- the third (vertical) stays ~flat. We therefore require
+        at least TWO axes to have real spread (not all three), size the unit
+        sphere from the moving axes, and leave a flat axis at scale 1.0. The
+        offset (hard-iron centre) is still taken on all three."""
+        if self.n < 20:
+            return None
+        deltas = [(self._max[i] - self._min[i]) / 2.0 for i in range(3)]
+        big = max(deltas)
+        if big <= 1e-6:
+            return None
+        thresh = big * 0.15
+        moved = [d for d in deltas if d >= thresh]
+        if len(moved) < 2:                 # need a real rotation, not jitter
+            return None
+        target = sum(moved) / len(moved)   # mean radius of the moving axes
+        offset = tuple((self._max[i] + self._min[i]) / 2.0 for i in range(3))
+        scale = tuple(target / deltas[i] if deltas[i] >= thresh else 1.0
+                      for i in range(3))
+        return Calibration(offset=offset, scale=scale)
+
+
+# Axis mapping: which corrected sensor axis points to the boat's bow / starboard,
+# and its sign. Default: X = bow (forward), Y = starboard (right). A magnetometer
+# mounted at any yaw is handled by the GPS-learned offset downstream; these knobs
+# exist for a mirrored/rotated mount the offset alone can't fix.
+_AXIS_INDEX = {"x": 0, "y": 1, "z": 2}
+
+
+def heading_deg(corrected: tuple[float, float, float], *,
+                forward_axis: str = "x", right_axis: str = "y",
+                invert: bool = False) -> float:
+    """Magnetic heading (0..360, CW from magnetic north) from a corrected vector,
+    assuming the sensor is roughly level (no tilt compensation without an accel).
+
+    ``forward_axis``/``right_axis`` (e.g. ``"x"``/``"y"``, optionally signed like
+    ``"-y"``) select and orient the horizontal axes for the mount; ``invert``
+    flips the rotation sense for a mirrored board."""
+    def axis(name: str) -> float:
+        sign = -1.0 if name.startswith("-") else 1.0
+        return sign * corrected[_AXIS_INDEX[name.lstrip("+-")]]
+
+    fwd = axis(forward_axis)
+    right = axis(right_axis)
+    ang = math.degrees(math.atan2(-right if not invert else right, fwd))
+    return ang % 360.0
+
+
+# () -> (course_over_ground_deg, speed_over_ground_mps) | None
+MotionProvider = Callable[[], "tuple | None"]

--- a/src/vanchor/runtime/devices.py
+++ b/src/vanchor/runtime/devices.py
@@ -12,6 +12,26 @@ import logging
 
 logger = logging.getLogger("vanchor.app")
 
+# Built-in (non-driver) sources -> how they connect: "serial" needs a port+baud,
+# "i2c" needs a bus/address, "none" needs no connection field. Registered drivers
+# carry their own transport (registry.transports()).
+_BUILTIN_TRANSPORT = {"sim": "none", "serial": "serial", "nmea": "none",
+                      "none": "none", "both": "serial"}
+# option-key -> registry device kind (only where they differ; depth uses "sensor").
+_OPTION_REG_KIND = {"sensor": "depth"}
+
+
+def _source_transports(options: dict, reg_transports: dict) -> dict:
+    """``{option_key: {source: transport}}`` merging the built-in sources with the
+    registry's per-driver transport, so the UI can show serial / I2C / no
+    connection fields to match the selected source (not always serial)."""
+    out: dict = {}
+    for opt_key, sources in options.items():
+        reg = reg_transports.get(_OPTION_REG_KIND.get(opt_key, opt_key), {})
+        out[opt_key] = {s: reg.get(s, _BUILTIN_TRANSPORT.get(s, "serial"))
+                        for s in sources}
+    return out
+
 
 class DeviceManager:
     """Device config, construction, status, health, debug -- split out of Runtime."""
@@ -30,22 +50,28 @@ class DeviceManager:
         plain read; a POST returns ``True`` because devices are rebuilt only on
         restart, not hot-swapped)."""
         from dataclasses import asdict
+
+        from ..hardware import registry
         rt = self._rt
+        options = {
+            "sensor": list(rt._SENSOR_SOURCES),
+            "gps": list(rt._gps_sources()),
+            "compass": list(rt._compass_sources()),
+            "motor": list(rt._MOTOR_SOURCES),
+            "battery": list(rt._battery_sources()),
+            # Per-channel split sources ("both" is a combined concept, not a
+            # per-channel one; split channels use sim | serial | none).
+            "steering": list(rt._CHANNEL_SOURCES),
+            "thrust": list(rt._CHANNEL_SOURCES),
+        }
         return {
             "hardware": asdict(rt.config.hardware),
             "nmea_tcp": asdict(rt.config.nmea_tcp),
             "sim_motor": asdict(rt.config.sim_motor),  # actuation shaping (#36)
-            "options": {
-                "sensor": list(rt._SENSOR_SOURCES),
-                "gps": list(rt._gps_sources()),
-                "compass": list(rt._compass_sources()),
-                "motor": list(rt._MOTOR_SOURCES),
-                "battery": list(rt._battery_sources()),
-                # Per-channel split sources ("both" is a combined concept, not a
-                # per-channel one; split channels use sim | serial | none).
-                "steering": list(rt._CHANNEL_SOURCES),
-                "thrust": list(rt._CHANNEL_SOURCES),
-            },
+            "options": options,
+            # How each source connects, so the UI shows the RIGHT connection
+            # fields (serial port + baud / I2C target / none) per selected source.
+            "source_transports": _source_transports(options, registry.transports()),
             "menus": self._device_menus(),
             "driver_menus": rt._driver_menus(),
             "restart_required": False,

--- a/src/vanchor/runtime/hwscan.py
+++ b/src/vanchor/runtime/hwscan.py
@@ -168,6 +168,14 @@ class HardwareScan:
             {"kind": "ina226", "addr": f"0x{_ina_addr:02x}",
              "label": "INA226 battery shunt"},
         ]
+        # Magnetometer compass chips (BN-880/BE-880 & standalone). Addresses come
+        # from the driver's chip table so the wizard offers exactly what it can
+        # autodetect.
+        from ..nav import magnetometer as _mag
+        for _spec in _mag.CHIP_TABLE:
+            for _a in _spec.addresses:
+                known_i2c.append({"kind": "magnetometer", "addr": f"0x{_a:02x}",
+                                  "label": f"{_spec.label} compass"})
 
         # Demo mode: return sim posture without scanning real hardware
         if getattr(rt.config, "demo", None) and rt.config.demo.enabled:
@@ -367,7 +375,7 @@ class HardwareScan:
         if not (0x03 <= _addr <= 0x77):
             raise ValueError(f"i2c addr 0x{_addr:02X} out of range 0x03..0x77")
 
-        if _kind not in ("auto", "helm-pico", "ina226"):
+        if _kind not in ("auto", "helm-pico", "ina226", "magnetometer"):
             raise ValueError(f"unknown i2c kind {_kind!r}")
 
         # Ownership check
@@ -404,6 +412,15 @@ class HardwareScan:
                     "set battery.i2c_bus/i2c_addr in vanchor.yaml if not 1/0x40"
                 )
             _resp["suggest"] = _sug
+        elif _detected == "magnetometer":
+            _chip = _raw.get("sample", {}).get("chip", "magnetometer")
+            _resp["suggest"] = {
+                "kind": "compass", "source": "magnetometer",
+                "fields": {"compass_source": "magnetometer",
+                           "compass_port": f"i2c:{_bus}:0x{_addr:02x}"},
+                "note": f"{_chip} compass on I2C. Calibrate it in "
+                        "Settings -> Devices after setup.",
+            }
         else:
             _resp["suggest"] = None
         return _resp

--- a/src/vanchor/runtime/hwscan.py
+++ b/src/vanchor/runtime/hwscan.py
@@ -389,7 +389,16 @@ class HardwareScan:
                 ),
             }
 
-        _raw = await asyncio.to_thread(probe_mod.probe_i2c, _bus, _addr, _kind)
+        try:
+            _raw = await asyncio.to_thread(probe_mod.probe_i2c, _bus, _addr, _kind)
+        except RuntimeError as exc:
+            # smbus2 (the 'i2c' extra) not installed -> a clean message, not a 500.
+            return {"ok": False, "error": str(exc)}
+        except OSError as exc:
+            # bus device missing / not permitted (e.g. I2C not enabled on the Pi).
+            return {"ok": False,
+                    "error": f"could not open /dev/i2c-{_bus}: {exc}. "
+                             "Enable I2C (raspi-config) and check permissions."}
 
         # Build response inline
         _detected = _raw.get("detected", "unknown")

--- a/src/vanchor/ui/partials/panel-devices.html
+++ b/src/vanchor/ui/partials/panel-devices.html
@@ -134,8 +134,8 @@
             only when the feeder disconnects (taking the helm never switches it).</div>
 
           <div id="dev-serial" class="hidden">
-            <div class="ctx-sub">Serial ports</div>
-            <div class="hint">Pick a detected port. Prefer a "stable" entry (<code>/dev/serial/by-id/…</code> or an on-board <code>/dev/serial0</code>) — it survives reboots &amp; replugging; a raw <code>/dev/ttyUSB0</code> can get renumbered. Set each port's baud to match its device.</div>
+            <div class="ctx-sub">Connections</div>
+            <div class="hint">Only the connection fields for the sources you picked are shown. For a serial device, prefer a "stable" port (<code>/dev/serial/by-id/…</code> or an on-board <code>/dev/serial0</code>) — it survives reboots &amp; replugging; a raw <code>/dev/ttyUSB0</code> can get renumbered. For an I2C device, enter <code>i2c:&lt;bus&gt;</code> (address optional).</div>
             <datalist id="dev-serial-ports"></datalist>
 
             <label class="dev-srcrow">

--- a/src/vanchor/ui/static/devices.js
+++ b/src/vanchor/ui/static/devices.js
@@ -84,6 +84,7 @@
 
   let loaded = false;
   let options = DEFAULT_OPTS;
+  let sourceTransports = {};   // { optKey: { source: "serial"|"i2c"|"none" } }
   let driverMenus = {};   // { source: menu-schema } — shown on selection
   let activeMenus = [];   // menus from the running devices (live values)
   let lastRestartRequired = false;
@@ -137,20 +138,80 @@
     sel.value = has ? want : "";
   }
 
-  // Reveal serial settings (ports + baud) when any source is WIRED -- i.e. not
-  // Auto/sim/nmea. Covers "serial", motor "both", and pluggable serial drivers
-  // like "hwt901b" (which needs its port set), without hardcoding driver names.
-  const _WIRELESS = { "": 1, sim: 1, nmea: 1 };
-  function anySerial() {
-    return SRC_FIELDS.some((f) => {
-      const sel = $(f.id);
-      return sel && !(sel.value in _WIRELESS);
-    });
+  // Show each device's connection fields to match the SELECTED source's
+  // transport: a serial source -> port + baud; an I2C source (e.g. the
+  // magnetometer) -> a single I2C target field (no serial port auto-picked);
+  // sim / nmea / none / phone -> no connection field at all. Driven by the
+  // backend's source_transports map, so pluggable drivers classify themselves
+  // and we never show a ttyUSB port for an I2C device.
+  const CONN_KINDS = [
+    { kind: "gps", sel: "dev-src-gps", opt: "gps" },
+    { kind: "compass", sel: "dev-src-compass", opt: "compass" },
+    { kind: "motor", sel: "dev-src-motor", opt: "motor" },
+    { kind: "steering", sel: "dev-src-steering", opt: "steering" },
+    { kind: "thrust", sel: "dev-src-thrust", opt: "thrust" },
+  ];
+  function transportFor(opt, val) {
+    const m = sourceTransports[opt] || {};
+    if (val && Object.prototype.hasOwnProperty.call(m, val)) return m[val];
+    return val ? "serial" : "none";   // unknown wired source -> serial fields
   }
-
-  function syncSerial() {
+  function connEls(kind) {
+    const input = $("dev-" + kind + "-port");
+    const pick = $("dev-" + kind + "-port-pick");
+    const baud = $("dev-" + kind + "-baud");
+    const customRow = input && input.closest(".dev-srcrow");
+    return {
+      input, pick,
+      pickRow: pick && pick.closest(".dev-srcrow"),
+      customRow,
+      lineRow: baud && baud.closest(".dev-lineopts"),
+      label: customRow && customRow.querySelector("span"),
+    };
+  }
+  function relabelConn(kind, el, i2c) {
+    // Cache the HTML defaults once so serial mode restores them (motor keeps its
+    // "…or i2c:<bus>:<addr>" hint; only a genuinely-I2C source is relabelled).
+    if (el.input && el.input.dataset.origPh === undefined)
+      el.input.dataset.origPh = el.input.placeholder || "";
+    if (el.label && el.label.dataset.origText === undefined)
+      el.label.dataset.origText = el.label.textContent || "";
+    const nice = kind.charAt(0).toUpperCase() + kind.slice(1);
+    if (i2c) {
+      if (el.label) el.label.textContent = nice + " I2C bus";
+      if (el.input) {
+        el.input.placeholder = "i2c:1  or  i2c:1:0x0d  (bus[:address]; address optional = autodetect)";
+        const v = (el.input.value || "").trim();
+        if (!/^i2c:/i.test(v)) el.input.value = "i2c:1";   // drop a leftover serial port
+      }
+    } else {
+      if (el.label && el.label.dataset.origText !== undefined)
+        el.label.textContent = el.label.dataset.origText;
+      if (el.input && el.input.dataset.origPh !== undefined)
+        el.input.placeholder = el.input.dataset.origPh;
+    }
+  }
+  function syncConnFields() {
+    let anyShown = false;
+    CONN_KINDS.forEach(({ kind, sel, opt }) => {
+      const s = $(sel);
+      if (!s) return;
+      const tr = transportFor(opt, s.value);
+      const el = connEls(kind);
+      const serial = tr === "serial", i2c = tr === "i2c";
+      if (el.pickRow) el.pickRow.classList.toggle("hidden", !serial);   // serial-port picker
+      if (el.lineRow) el.lineRow.classList.toggle("hidden", !serial);   // baud/parity/…
+      if (el.customRow) {
+        // i2c -> always show it (it's the I2C field); serial -> only when the
+        // picker is on "Custom path…"; none -> hide.
+        const showCustom = i2c || (serial && el.pick && el.pick.value === PORT_CUSTOM);
+        el.customRow.classList.toggle("hidden", !showCustom);
+      }
+      relabelConn(kind, el, i2c);
+      if (serial || i2c) anyShown = true;
+    });
     const box = $("dev-serial");
-    if (box) box.classList.toggle("hidden", !anySerial());
+    if (box) box.classList.toggle("hidden", !anyShown);
   }
 
   function syncMode() {
@@ -210,6 +271,8 @@
   function render(cfg) {
     cfg = cfg || {};
     options = cfg.options && typeof cfg.options === "object" ? cfg.options : DEFAULT_OPTS;
+    sourceTransports = (cfg.source_transports && typeof cfg.source_transports === "object")
+      ? cfg.source_transports : {};
     const hw = cfg.hardware && typeof cfg.hardware === "object" ? cfg.hardware : {};
     const nmea = cfg.nmea_tcp && typeof cfg.nmea_tcp === "object" ? cfg.nmea_tcp : {};
     lastRestartRequired = !!cfg.restart_required;
@@ -275,7 +338,7 @@
     setVal("dev-nmea-port", nmea.port);
 
     syncMode();
-    syncSerial();
+    syncConnFields();
     syncNmea();
     setBadge(hw.enabled ? "● hardware" : "sim");
     driverMenus = (cfg.driver_menus && typeof cfg.driver_menus === "object") ? cfg.driver_menus : {};
@@ -313,6 +376,12 @@
       h.className = "drawer-section";
       h.textContent = menu.title || (menu.device + " settings");
       box.appendChild(h);
+      if (menu.notice) {   // first-run nudge / "not detected" callout (#magnetometer)
+        const n = document.createElement("div");
+        n.className = "hint dev-menu-notice";
+        n.textContent = menu.notice;
+        box.appendChild(n);
+      }
       (menu.settings || []).forEach((s) => box.appendChild(renderSetting(menu.device, s, box)));
       if ((menu.actions || []).length) {
         const row = document.createElement("div");
@@ -403,6 +472,19 @@
         if (r && r.status) msg += "  " + Object.entries(r.status)
           .map(([k, v]) => k + "=" + v).join(", ");
         out.textContent = msg;
+        // A raw dump (e.g. "Dump raw I2C") comes back as multi-line text: show it
+        // in a selectable monospace block so it's easy to copy + share.
+        let pre = box.querySelector(".dev-menu-dump");
+        if (r && r.dump) {
+          if (!pre) {
+            pre = document.createElement("pre");
+            pre.className = "dev-menu-dump";
+            box.appendChild(pre);
+          }
+          pre.textContent = r.dump;
+        } else if (pre) {
+          pre.remove();
+        }
       })
       .catch(() => { if (out) out.textContent = "Action failed."; });
   }
@@ -569,6 +651,7 @@
       inp.value = sel.value;  // the dropdown IS the source; mirror into the input
       if (customRow) customRow.classList.add("hidden");
     }
+    syncConnFields();   // keep the box + custom-row visibility consistent
   }
 
   function loadSerialPorts() {
@@ -661,7 +744,7 @@
   // Source selects → toggle serial disclosure + show the picked driver's menu.
   SRC_FIELDS.forEach((f) => {
     const sel = $(f.id);
-    if (sel) sel.addEventListener("change", () => { syncSerial(); refreshMenus(); });
+    if (sel) sel.addEventListener("change", () => { syncConnFields(); refreshMenus(); });
   });
 
   // Split-channel source selects → toggle per-channel serial rows.

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -2442,6 +2442,19 @@ body.mobile.dock-collapsed .dock { padding-bottom: 0; }
 .dev-menu { margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--line); }
 .dev-menu .btn-row { margin-top: 6px; }
 .dev-menu-out { margin-top: 6px; min-height: 1em; white-space: pre-wrap; }
+/* First-run nudge / not-detected callout under a device menu title. */
+.dev-menu-notice {
+  margin: 4px 0 8px; padding: 6px 8px; border-radius: 6px;
+  background: rgba(255, 200, 80, 0.10); border: 1px solid rgba(255, 200, 80, 0.35);
+  color: var(--fg);
+}
+/* Raw-dump output: selectable monospace block for copy + share. */
+.dev-menu-dump {
+  margin-top: 8px; padding: 8px; max-height: 40vh; overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
+  line-height: 1.35; white-space: pre; user-select: all;
+  background: rgba(0, 0, 0, 0.35); border: 1px solid var(--line); border-radius: 6px;
+}
 
 /* ===================================================================== */
 /* VIEWS (spec §3) — specialised, URL-addressable layouts of the SAME live  */

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -131,7 +131,7 @@ def test_get_returns_config_and_options(client):
     assert data["options"] == {
         "sensor": ["sim", "serial", "nmea", "none"],  # "none" = Not connected
         "gps": ["sim", "serial", "nmea", "none", "phone", "ublox"],  # + registered drivers
-        "compass": ["sim", "serial", "nmea", "none", "hwt901b", "phone"],  # + registered drivers
+        "compass": ["sim", "serial", "nmea", "none", "hwt901b", "magnetometer", "phone"],  # + registered drivers
         "motor": ["sim", "serial", "both", "none"],
         "battery": ["sim", "none", "ina226"],  # sim/none built-in + registered ina226 driver
         # Split-channel sources: "both" is a combined concept, not per-channel.

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -126,8 +126,16 @@ def client(tmp_path):
 def test_get_returns_config_and_options(client):
     data = client.get("/api/config/devices").json()
     assert set(data) == {"hardware", "nmea_tcp", "sim_motor", "options", "menus",
-                         "driver_menus", "restart_required"}
+                         "driver_menus", "source_transports", "restart_required"}
     assert data["restart_required"] is False
+    # Each source's connection transport, so the UI shows the right fields.
+    st = data["source_transports"]
+    assert st["compass"]["magnetometer"] == "i2c"   # I2C -> I2C target field
+    assert st["compass"]["hwt901b"] == "serial"     # serial -> port + baud
+    assert st["compass"]["serial"] == "serial"
+    assert st["compass"]["sim"] == "none" and st["compass"]["nmea"] == "none"
+    assert st["compass"]["phone"] == "none"
+    assert st["battery"]["ina226"] == "i2c"
     assert data["options"] == {
         "sensor": ["sim", "serial", "nmea", "none"],  # "none" = Not connected
         "gps": ["sim", "serial", "nmea", "none", "phone", "ublox"],  # + registered drivers

--- a/tests/test_hw_probe.py
+++ b/tests/test_hw_probe.py
@@ -391,6 +391,33 @@ class TestProbeI2c:
         # OSError from _probe_helm_pico is caught; probe_i2c returns detected=unknown
         assert result.get("detected") == "unknown"
 
+    def test_magnetometer_qmc5883l_detected(self):
+        """QMC5883L at 0x0D: chip-id reg 0x0D reads 0xFF -> detected=magnetometer."""
+
+        def fake_smbus(bus_num):
+            return MagicMock(), (lambda data: MagicMock()), (lambda n: _FakeReadMsg(b"\xff"))
+
+        result = probe_i2c(1, 0x0D, kind="magnetometer", smbus_factory=fake_smbus)
+        assert result.get("detected") == "magnetometer"
+        assert result["sample"]["chip"] == "QMC5883L"
+
+    def test_magnetometer_hmc5883l_detected_via_auto(self):
+        """HMC5883L at 0x1E identifies as 'H43'; the auto path finds it too."""
+
+        def fake_smbus(bus_num):
+            return MagicMock(), (lambda data: MagicMock()), (lambda n: _FakeReadMsg(b"H43"))
+
+        result = probe_i2c(1, 0x1E, kind="auto", smbus_factory=fake_smbus)
+        assert result.get("detected") == "magnetometer"
+        assert result["sample"]["chip"] == "HMC5883L"
+
+    def test_magnetometer_wrong_id_is_unknown(self):
+        def fake_smbus(bus_num):
+            return MagicMock(), (lambda data: MagicMock()), (lambda n: _FakeReadMsg(b"\x00"))
+
+        result = probe_i2c(1, 0x0D, kind="magnetometer", smbus_factory=fake_smbus)
+        assert result.get("detected") == "unknown"
+
 
 # --------------------------------------------------------------------------- #
 # hint_from_metadata — unit tests

--- a/tests/test_hw_scan_api.py
+++ b/tests/test_hw_scan_api.py
@@ -169,6 +169,18 @@ class TestHwProbeEndpoint:
         r = client.post("/api/hw/probe", json={"target": "serial"})
         assert r.status_code == 400
 
+    def test_i2c_without_smbus2_returns_clean_error_not_500(self, client):
+        """Probing an I2C address when the 'i2c' extra (smbus2) is missing must
+        report a clean message, not a 500 -- the guided setup stays usable."""
+        with patch("vanchor.hardware.probe.probe_i2c",
+                   side_effect=RuntimeError("I2C probe requires the 'i2c' extra")):
+            r = client.post("/api/hw/probe",
+                            json={"target": "i2c", "bus": 1, "addr": "0x0d",
+                                  "kind": "magnetometer"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is False and "i2c" in body["error"].lower()
+
     def test_concurrent_probe_returns_409(self, rt, client):
         """When the lock is held a second probe returns 409."""
         lock = rt._hw_probe_lock

--- a/tests/test_magnetometer.py
+++ b/tests/test_magnetometer.py
@@ -1,0 +1,144 @@
+"""The pure I2C-magnetometer support: multi-chip autodetection, register decode
+(byte order + axis order per chip), heading convention, and hard/soft-iron
+calibration. All driven by a fake bus -- no smbus2, no hardware."""
+
+import math
+
+import pytest
+
+from vanchor.nav import magnetometer as m
+
+
+class FakeBus:
+    """Maps (addr, reg) -> bytes for id/data reads; records writes. Unknown
+    (addr, reg) raises OSError, standing in for an I2C NAK (no device)."""
+
+    def __init__(self, reads: dict) -> None:
+        self.reads = reads          # {(addr, reg): bytes}
+        self.writes: list = []
+
+    def write_byte_data(self, addr, reg, value):
+        self.writes.append((addr, reg, value))
+
+    def read_byte_data(self, addr, reg):
+        return self.reads[(addr, reg)][0]
+
+    def read_block_data(self, addr, reg, length):
+        if (addr, reg) not in self.reads:
+            raise OSError("nak")
+        return self.reads[(addr, reg)][:length]
+
+
+def _be16(v):    # signed -> big-endian 2 bytes (MSB first)
+    return bytes([(v >> 8) & 0xFF, v & 0xFF]) if v >= 0 else _be16(v + 0x10000)
+
+
+def _le16(v):    # signed -> little-endian 2 bytes (LSB first)
+    b = _be16(v)
+    return bytes([b[1], b[0]])
+
+
+# --- detection ------------------------------------------------------------- #
+
+def test_detect_qmc5883l():
+    bus = FakeBus({(0x0D, 0x0D): b"\xff", (0x0D, 0x00): b"\x00" * 6})
+    spec, addr = m.detect(bus)
+    assert spec.name == "QMC5883L" and addr == 0x0D
+
+
+def test_detect_hmc5883l():
+    bus = FakeBus({(0x1E, 0x0A): b"H43", (0x1E, 0x03): b"\x00" * 6})
+    spec, addr = m.detect(bus)
+    assert spec.name == "HMC5883L" and addr == 0x1E
+
+
+def test_detect_ist8310():
+    bus = FakeBus({(0x0E, 0x00): b"\x10", (0x0E, 0x03): b"\x00" * 6})
+    spec, addr = m.detect(bus)
+    assert spec.name == "IST8310" and addr == 0x0E
+
+
+def test_detect_none_when_nothing_answers():
+    assert m.detect(FakeBus({})) is None
+
+
+def test_detect_respects_address_filter():
+    # A QMC is present, but we only allow the HMC address -> not found.
+    bus = FakeBus({(0x0D, 0x0D): b"\xff"})
+    assert m.detect(bus, addresses=(0x1E,)) is None
+
+
+# --- register decode (byte order + axis order) ----------------------------- #
+
+def test_qmc_decode_little_endian_xyz():
+    # QMC data at 0x00 is little-endian in X, Y, Z order.
+    data = _le16(100) + _le16(200) + _le16(-50)
+    bus = FakeBus({(0x0D, 0x0D): b"\xff", (0x0D, 0x00): data})
+    spec, addr = m.detect(bus)
+    mag = m.Magnetometer(bus, spec, addr)
+    mag.configure()
+    assert mag.read_raw() == (100, 200, -50)
+    assert (0x0D, 0x09) in [(w[0], w[1]) for w in bus.writes]   # control reg written
+
+
+def test_hmc_decode_big_endian_x_z_y_order():
+    # HMC streams big-endian in X, Z, Y order; read_raw must return (X, Y, Z).
+    data = _be16(100) + _be16(300) + _be16(-200)   # X, Z, Y on the wire
+    bus = FakeBus({(0x1E, 0x0A): b"H43", (0x1E, 0x03): data})
+    spec, addr = m.detect(bus)
+    mag = m.Magnetometer(bus, spec, addr)
+    assert mag.read_raw() == (100, -200, 300)      # -> (X, Y, Z)
+
+
+# --- heading convention (CW from north; X=bow, Y=starboard) ---------------- #
+
+@pytest.mark.parametrize("xyz,expected", [
+    ((100.0, 0.0, 0.0), 0.0),      # field along bow -> north
+    ((0.0, -100.0, 0.0), 90.0),    # -> east
+    ((-100.0, 0.0, 0.0), 180.0),   # -> south
+    ((0.0, 100.0, 0.0), 270.0),    # -> west
+])
+def test_heading_convention(xyz, expected):
+    assert m.heading_deg(xyz) == pytest.approx(expected, abs=0.01)
+
+
+def test_heading_axis_remap_and_invert():
+    # Swap so Y is bow: field along +Y should now read north.
+    assert m.heading_deg((0.0, 100.0, 0.0), forward_axis="y", right_axis="-x") \
+        == pytest.approx(0.0, abs=0.01)
+    # invert flips the rotation sense.
+    base = m.heading_deg((70.0, -70.0, 0.0))
+    inv = m.heading_deg((70.0, -70.0, 0.0), invert=True)
+    assert (base + inv) % 360 == pytest.approx(0.0, abs=0.01)
+
+
+# --- calibration ----------------------------------------------------------- #
+
+def test_calibration_fits_hard_iron_offset():
+    """A boat spinning about vertical traces a circle in X/Y (Z ~flat) with a
+    hard-iron bias; the collector recovers the centre and re-centres the data."""
+    col = m.CalibrationCollector()
+    ox, oy = 30.0, -20.0
+    for k in range(72):                       # a full slow circle
+        t = math.radians(k * 5)
+        col.add((ox + 100 * math.cos(t), oy + 100 * math.sin(t), 5.0))
+    cal = col.result()
+    assert cal is not None
+    assert cal.offset[0] == pytest.approx(ox, abs=1.0)
+    assert cal.offset[1] == pytest.approx(oy, abs=1.0)
+    # Applying the fit centres the ring on the origin.
+    cx, cy, _ = cal.apply((ox + 100, oy, 5.0))
+    assert cx == pytest.approx(100, abs=2) and cy == pytest.approx(0, abs=2)
+
+
+def test_calibration_rejects_insufficient_rotation():
+    col = m.CalibrationCollector()
+    for _ in range(50):                       # lots of samples, but no motion
+        col.add((10.0, 20.0, 5.0))
+    assert col.result() is None
+
+
+def test_calibration_roundtrips_through_dict():
+    cal = m.Calibration(offset=(1.0, 2.0, 3.0), scale=(1.1, 0.9, 1.0))
+    assert m.Calibration.from_dict(cal.to_dict()).offset == (1.0, 2.0, 3.0)
+    assert m.Calibration.from_dict(None).offset == (0.0, 0.0, 0.0)   # identity

--- a/tests/test_magnetometer.py
+++ b/tests/test_magnetometer.py
@@ -138,6 +138,17 @@ def test_calibration_rejects_insufficient_rotation():
     assert col.result() is None
 
 
+def test_dump_i2c_reports_matches_window_and_no_response():
+    window = b"\x64\x00\xc8\x00\xce\xff" + b"\x00" * 10   # 16 bytes from 0x00
+    bus = FakeBus({(0x0D, 0x0D): b"\xff", (0x0D, 0x00): window})   # only QMC present
+    rep = m.dump_i2c(bus, samples=2, delay_s=0, bus_num=1)
+    assert "bus /dev/i2c-1" in rep
+    assert "QMC5883L" in rep and "MATCH" in rep      # id matched
+    assert "0x0d: responds" in rep
+    assert window.hex() in rep                       # raw window shown for decoding
+    assert "0x1e: NO RESPONSE" in rep and "0x0e: NO RESPONSE" in rep
+
+
 def test_calibration_roundtrips_through_dict():
     cal = m.Calibration(offset=(1.0, 2.0, 3.0), scale=(1.1, 0.9, 1.0))
     assert m.Calibration.from_dict(cal.to_dict()).offset == (1.0, 2.0, 3.0)

--- a/tests/test_magnetometer_driver.py
+++ b/tests/test_magnetometer_driver.py
@@ -157,6 +157,37 @@ def test_calibrate_start_requires_a_detected_chip():
     assert d.run_action("calibrate_start")["ok"] is False
 
 
+# --- raw dump (remote troubleshooting) ------------------------------------- #
+
+def test_dump_raw_action_returns_hex_dump():
+    d = MagnetometerCompass(lambda: _qmc_bus(x=100, y=0), bus_num=1)
+    r = d.run_action("dump_raw")
+    assert r["ok"] is True and "dump" in r
+    assert "QMC5883L" in r["dump"] and "bus /dev/i2c-1" in r["dump"]
+
+
+def test_dump_raw_reports_bus_open_failure():
+    def boom():
+        raise RuntimeError("i2c extra not installed")
+    r = MagnetometerCompass(boom).run_action("dump_raw")
+    assert r["ok"] is False and "Could not open" in r["message"]
+
+
+# --- first-run calibration nudge ------------------------------------------- #
+
+def test_menu_notice_nudges_until_calibrated():
+    d = MagnetometerCompass(lambda: _qmc_bus())
+    d._open_and_detect()                                  # detected, not calibrated
+    assert "Not calibrated" in d.device_menu()["notice"]
+    d.apply_setting("calibration", {"offset": [5, 5, 5], "scale": [1, 1, 1]})
+    assert d.device_menu()["notice"] == ""               # cleared once calibrated
+
+
+def test_menu_notice_when_nothing_detected():
+    d = MagnetometerCompass(lambda: FakeBus({}))
+    assert "No magnetometer detected" in d.device_menu()["notice"]
+
+
 # --- device menu ----------------------------------------------------------- #
 
 def test_device_menu_and_apply_setting():

--- a/tests/test_magnetometer_driver.py
+++ b/tests/test_magnetometer_driver.py
@@ -1,0 +1,172 @@
+"""The I2C magnetometer compass DRIVER: registration, i2c target parsing, HDT
+emission, declination modes, the spin-to-calibrate flow (+ persistence), and the
+device menu. Uses a fake bus -- no smbus2, no hardware."""
+
+import math
+
+import pytest
+
+from vanchor.hardware import registry
+from vanchor.hardware.drivers import load_drivers
+from vanchor.hardware.drivers.magnetometer import (MagnetometerCompass,
+                                                   parse_i2c_target)
+from vanchor.nav import magnetometer as m
+from vanchor.nav import nmea
+
+
+class FakeBus:
+    def __init__(self, reads):
+        self.reads = reads
+        self.closed = False
+
+    def write_byte_data(self, addr, reg, value):
+        pass
+
+    def read_byte_data(self, addr, reg):
+        return self.reads[(addr, reg)][0]
+
+    def read_block_data(self, addr, reg, length):
+        if (addr, reg) not in self.reads:
+            raise OSError("nak")
+        return self.reads[(addr, reg)][:length]
+
+    def close(self):
+        self.closed = True
+
+
+def _le16(v):
+    v &= 0xFFFF
+    return bytes([v & 0xFF, (v >> 8) & 0xFF])
+
+
+def _qmc_bus(x=100, y=0, z=0):
+    return FakeBus({(0x0D, 0x0D): b"\xff",
+                    (0x0D, 0x00): _le16(x) + _le16(y) + _le16(z)})
+
+
+class _RecordBus:
+    def __init__(self):
+        self.events = []
+
+    async def publish(self, topic, payload):
+        self.events.append((topic, payload))
+
+
+# --- registration + parsing ------------------------------------------------ #
+
+def test_registers_as_a_compass_source():
+    load_drivers()
+    assert registry.has("compass", "magnetometer")
+    assert "magnetometer" in registry.sources("compass")
+
+
+@pytest.mark.parametrize("port,expected", [
+    ("i2c:1:0x0d", (1, 0x0D)),
+    ("i2c:2:26", (2, 26)),
+    ("i2c:1", (1, None)),
+    ("3", (3, None)),
+    ("/dev/ttyUSB1", (1, None)),   # non-i2c -> default bus, autodetect addr
+    ("", (1, None)),
+])
+def test_parse_i2c_target(port, expected):
+    assert parse_i2c_target(port) == expected
+
+
+# --- detect + emit HDT ----------------------------------------------------- #
+
+def test_open_and_detect_finds_chip():
+    d = MagnetometerCompass(lambda: _qmc_bus())
+    assert d._open_and_detect() is True
+    assert d.detected == "QMC5883L"
+
+
+async def test_sample_once_emits_hdt():
+    # Field along bow (x=100) -> heading 0 -> HDT 000.0, off-mode (no declination).
+    d = MagnetometerCompass(lambda: _qmc_bus(x=100, y=0), declination_mode="off")
+    assert d._open_and_detect() is True
+    assert await d.sample_once(0.2) == nmea.encode_hdt(0.0)
+    # Field to port (y=-100) -> east -> 090.
+    d2 = MagnetometerCompass(lambda: _qmc_bus(x=0, y=-100), declination_mode="off")
+    d2._open_and_detect()
+    assert await d2.sample_once(0.2) == nmea.encode_hdt(90.0)
+
+
+async def test_manual_declination_is_added():
+    d = MagnetometerCompass(lambda: _qmc_bus(x=100, y=0),
+                            declination_mode="manual", manual_declination_deg=7.0)
+    d._open_and_detect()
+    assert await d.sample_once(0.2) == nmea.encode_hdt(7.0)
+
+
+async def test_loop_publishes_nmea_then_stops():
+    bus = _RecordBus()
+    d = MagnetometerCompass(lambda: _qmc_bus(x=100, y=0), bus=bus,
+                            declination_mode="off", hz=50.0)
+    await d.start()
+    try:
+        for _ in range(50):
+            if bus.events:
+                break
+            await _sleep(0.02)
+    finally:
+        await d.stop()
+    topics = {t for t, _ in bus.events}
+    assert "nmea.in" in {str(t) for t in topics} or any(
+        "HDT" in str(p) for _, p in bus.events)
+
+
+async def _sleep(s):
+    import asyncio
+    await asyncio.sleep(s)
+
+
+# --- calibration flow + persistence ---------------------------------------- #
+
+def test_calibrate_flow_fits_and_persists():
+    saved = {}
+    d = MagnetometerCompass(lambda: _qmc_bus(), declination_mode="off",
+                            persist_cal=lambda c: saved.update(c))
+    d._open_and_detect()
+    assert d.run_action("calibrate_start")["ok"] is True
+    # Feed a full circle with a hard-iron bias through the read path.
+    ox, oy = 40.0, -25.0
+    for k in range(72):
+        t = math.radians(k * 5)
+        d._heading_from_raw((int(ox + 100 * math.cos(t)),
+                             int(oy + 100 * math.sin(t)), 5), 0.2)
+    res = d.run_action("calibrate_stop")
+    assert res["ok"] is True and "calibration" in res
+    assert d.calibration.offset[0] == pytest.approx(ox, abs=2.0)
+    assert saved.get("offset")[1] == pytest.approx(oy, abs=2.0)   # persisted
+
+
+def test_calibrate_stop_without_motion_reports_and_does_not_persist():
+    saved = {}
+    d = MagnetometerCompass(lambda: _qmc_bus(),
+                            persist_cal=lambda c: saved.update(c))
+    d._open_and_detect()
+    d.run_action("calibrate_start")
+    for _ in range(30):
+        d._heading_from_raw((10, 20, 5), 0.2)          # no rotation
+    res = d.run_action("calibrate_stop")
+    assert res["ok"] is False and not saved
+
+
+def test_calibrate_start_requires_a_detected_chip():
+    d = MagnetometerCompass(lambda: FakeBus({}))       # nothing on the bus
+    assert d.run_action("calibrate_start")["ok"] is False
+
+
+# --- device menu ----------------------------------------------------------- #
+
+def test_device_menu_and_apply_setting():
+    d = MagnetometerCompass(lambda: _qmc_bus())
+    menu = d.device_menu()
+    assert menu["device"] == "compass"
+    keys = {s["key"] for s in menu["settings"]}
+    assert {"declination_mode", "hz", "forward_axis", "invert"} <= keys
+    assert d.apply_setting("hz", 10)["ok"] is True and d.hz == 10
+    assert d.apply_setting("declination_mode", "manual")["ok"] is True
+    assert d.apply_setting("calibration", {"offset": [1, 2, 3], "scale": [1, 1, 1]})["ok"]
+    assert d.calibration.offset == (1.0, 2.0, 3.0)
+    assert d.apply_setting("bogus", 1)["ok"] is False


### PR DESCRIPTION
Adds an **I2C magnetometer compass** driver for the magnetometer on combo GNSS boards (Beitian **BN-880 / BE-880**) and standalone parts, plus the device-settings UX fixes it surfaced. Built to help a maker in Discussion #114 whose BE-880 compass isn't supported yet.

## Compass driver
- **Autodetects the chip** — HMC5883L / QMC5883L / IST8310 — by its identity register, so the user only picks `compass_source: magnetometer` and points it at a bus (`compass_port: i2c:<bus>[:<addr>]`, address optional). Adding a chip = one `ChipSpec` in `nav/magnetometer.py`'s `CHIP_TABLE` (the driver **and** the wizard probe read it).
- **Setup wizard** probes the known addresses (0x0D / 0x1E / 0x0E) and suggests the config.
- **Learns declination + mount offset** from GPS course (reuses the HWT901B estimator); emits `HDT`.
- **Spin-to-calibrate** device action fits + persists the hard/soft-iron correction; a **first-run nudge** shows in the panel until calibrated.
- **"Dump raw I2C"** action returns a copy-pasteable hex block of the raw registers for remote troubleshooting — works even when autodetect is failing.
- **Tilt** is documented clearly: a bare magnetometer assumes level (no tilt comp without an accel → use the HWT901B AHRS).
- `smbus2` optional (`vanchor[i2c]`); pure chip layer + driver fully unit-tested with a **fake bus** (no hardware).

## Device-settings UX (reported: "messy — all the ports show up")
- Connection fields now **match the selected source's transport**: serial → port + baud; **I2C** (magnetometer) → one **I2C bus** field (default `i2c:1`, never a `/dev/ttyUSB*`); sim/nmea/none/phone → nothing. Each driver declares `transport` in the registry, exposed as `source_transports` in `/api/config/devices` (extensible to packs).

## Guided setup robustness
- Probing an I2C address without `smbus2` (or an unopenable bus) now returns a clean `{ok:false, error}` instead of a **500** — the wizard stays usable. (Pre-existing bug, fixed here since it's on the magnetometer path.)

## Docs
New user guide **`docs/compass-magnetometer.md`** (wiring, autodetect, calibration, a clear **tilt** section, dump troubleshooting), linked from the index; expanded `docs/llms/device-drivers.md`; `setup-wizard.md` updated; CHANGELOG.

## Verification
Live: magnetometer source hides serial fields + shows "Compass I2C bus" = `i2c:1`; sim shows no connection fields; wizard scan lists the 3 magnetometer addresses; the I2C probe degrades gracefully. **Full suite 2236 passed**; e2e smoke 29/29; Playwright e2e 11; ruff + `node --check` clean.

**BENCH-VERIFY:** the chip register maps + I2C timing aren't yet verified on real hardware (logic is fake-bus tested). Ideal to hand to the maker on #114 to confirm — the "Dump raw I2C" action is there precisely for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)