### PR TITLE
release: 1.5.0a11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+## [1.5.0a11] — 2026-08-07
+
 - **I2C magnetometer compass driver (autodetecting).** A new `compass_source:
   magnetometer` reads the 3-axis magnetometer on combo GNSS boards (Beitian
   BN-880 / BE-880) and standalone parts, and **autodetects** which chip is fitted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vanchor-ng"
-version = "1.5.0a10"
+version = "1.5.0a11"
 description = "Software-first GPS anchoring / autopilot for cheap trolling motors (modern rewrite)"
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Alpha release **1.5.0a11**: version bump + CHANGELOG dated.

Rolls up everything merged to `main` since a10:
- Gzipped depth-chart imports (#113).
- The depth **raster-tile** epic — composition (#117) + contour (#118) tiles, cache control/invalidation (#119), offline (#120), pre-generate (#121), and the shoreline water-clip (#128).
- The edgeless/blended composition interim (#115).
- The **autodetecting I2C magnetometer compass** (#130) + the device-settings transport-aware UX and wizard-robustness fixes.

No code changes — just `pyproject` version → `1.5.0a11` and the CHANGELOG `Unreleased` section dated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)