### PR TITLE
ci: skip heavy CI on release commits + fix automated release under branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,14 @@ jobs:
           files="$(git diff --name-only "$base" "$head")"
           printf 'changed files:\n%s\n' "$files"
           # docs-only = every changed file is markdown / under docs/ / the PR template / LICENSE
-          if [ -z "$files" ] || ! printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          docs_re='(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'
+          nondoc="$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)"
+          if [ -z "$files" ] || [ -z "$nondoc" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # docs-only change
+          elif [ "$nondoc" = "pyproject.toml" ] && ! git diff "$base" "$head" -- pyproject.toml | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qvE '^[+-]version *= *'; then
+            # Release commit: the only non-docs change is a version bump in
+            # pyproject.toml -> nothing to test (the code was tested when it merged).
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # release: version-only bump (+ docs)
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,8 +40,12 @@ jobs:
           fi
           files="$(git diff --name-only "$base" "$head")"
           printf 'changed files:\n%s\n' "$files"
-          if [ -z "$files" ] || ! printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          docs_re='(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'
+          nondoc="$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)"
+          if [ -z "$files" ] || [ -z "$nondoc" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # docs-only change
+          elif [ "$nondoc" = "pyproject.toml" ] && ! git diff "$base" "$head" -- pyproject.toml | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qvE '^[+-]version *= *'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # release: version-only bump (+ docs)
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,8 +45,12 @@ jobs:
           fi
           files="$(git diff --name-only "$base" "$head")"
           printf 'changed files:\n%s\n' "$files"
-          if [ -z "$files" ] || ! printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          docs_re='(^docs/|\.md$|^\.github/pull_request_template\.md$|^LICENSE$)'
+          nondoc="$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)"
+          if [ -z "$files" ] || [ -z "$nondoc" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # docs-only change
+          elif [ "$nondoc" = "pyproject.toml" ] && ! git diff "$base" "$head" -- pyproject.toml | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qvE '^[+-]version *= *'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"          # release: version-only bump (+ docs)
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,15 @@ name: Release
 #   * push a tag v*       — publish a GitHub Release for an already-pushed tag
 #     (e.g. one cut locally). Notes come from the matching CHANGELOG section.
 #
-# Note: the bump job pushes a commit + tag to the default branch, so the branch
-# must allow the Actions bot to push (no protection rule that blocks it).
+# Note: the bump job pushes a commit + tag to the default branch. `main` is
+# protected (required status checks), which BLOCKS the default GITHUB_TOKEN push.
+# So the checkout below uses `secrets.RELEASE_PAT` when present — a fine-grained
+# PAT (or classic `repo`) owned by an admin, which bypasses the checks
+# (enforce_admins is off). One-time setup: create the token and add it as the
+# `RELEASE_PAT` repo secret; then `gh workflow run release.yml -f bump=alpha`
+# cuts a release with no manual PR. The release commit itself skips the heavy CI
+# (see the `changes` job's version-only-bump detection). Without the secret it
+# falls back to GITHUB_TOKEN and the push will fail while `main` is protected.
 on:
   workflow_dispatch:
     inputs:
@@ -32,6 +39,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Admin PAT (if set) so the bump commit can push to protected main;
+          # otherwise the default token (works only if main isn't protected).
+          token: ${{ secrets.RELEASE_PAT || github.token }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,20 @@ To change the required set or strictness later:
 `gh api --method PUT repos/AlexAsplund/Vanchor/branches/main/protection --input <file>`
 (GET the same path to see the current config).
 
+**Releases are automated — don't hand-craft a release PR.** Cut an alpha (or
+patch/minor/major/final) with the **Release** workflow:
+```bash
+gh workflow run release.yml -f bump=alpha     # or: Actions tab -> Release -> Run
+```
+It bumps `pyproject` + rolls the `CHANGELOG` (`Unreleased` -> dated section),
+commits `release: v<version>`, tags `v<version>`, pushes, and publishes the
+GitHub Release — no PR. The push to protected `main` uses the `RELEASE_PAT`
+secret (an admin fine-grained/classic-`repo` token; needed because required
+checks block the default token). A **version-only `pyproject` bump** skips the
+heavy CI (the `changes` job detects it), so a release never re-runs the suite —
+whether it lands via the workflow's direct push or a manual PR. Pushing a
+`v*` tag by itself also publishes a Release from the matching CHANGELOG section.
+
 ## 7. Verify before done
 
 Before opening/merging a PR, get the required checks (§6) green **locally** — at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **CI: releases don't re-run the test suite; automation works under branch
+  protection.** A version-only `pyproject.toml` bump (a release commit) now skips
+  the heavy CI jobs — the `changes` job detects it, on both PR and push events —
+  so cutting a release no longer runs the whole suite again. The **Release**
+  workflow (`gh workflow run release.yml -f bump=alpha`) pushes the bump + tag to
+  protected `main` using a `RELEASE_PAT` secret, so a release is one command with
+  no hand-made PR.
+
 ## [1.5.0a11] — 2026-08-07
 
 - **I2C magnetometer compass driver (autodetecting).** A new `compass_source:


### PR DESCRIPTION
Addresses two release-flow gaps.

## 1. A release commit no longer re-runs the test suite
The docs-skip `changes` job (in `ci`, `fuzz`, `regression`) now also returns `skip=true` when the **only** non-docs change is a **version bump in `pyproject.toml`** — verified by diffing pyproject and confirming every changed `+/-` content line is the `version = ` line. This applies on **both** PR and push events, so cutting a release (whether via the Release workflow's direct push to `main` or a manual PR) doesn't re-run the whole suite — the code was already tested when it merged. A real dependency change in `pyproject` still runs everything.

Verified locally against the real `v1.5.0a11` release commit → `skip=true`; against a code commit → `skip=false`.

## 2. Automated releases work under branch protection
There's already a **Release** workflow (`workflow_dispatch`: bump → CHANGELOG → tag → GitHub Release), but its bump commit pushes directly to `main`, which branch protection (required status checks) blocks for the default token — which is why recent releases became manual PRs. `release.yml` now checks out with `secrets.RELEASE_PAT` (fallback `GITHUB_TOKEN`); an admin PAT bypasses the checks (`enforce_admins` is off), so:

```bash
gh workflow run release.yml -f bump=alpha   # one command, no PR
```

**One-time setup:** add an admin fine-grained (contents:write) or classic (`repo`) PAT as the `RELEASE_PAT` repo secret. Documented in `AGENTS.md §6`.

## Notes
Only touches `.github/workflows/*` + AGENTS + CHANGELOG. This PR itself runs full CI (it changes CI logic — correct to validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)