### PR TITLE
fix(safety): non-finite sensor value must not command full thrust (+ atomic devices.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Safety: a non-finite sensor value can no longer command full thrust.** A
+  `NaN`/`inf` reaching `MotorCommand.clamped()` used to pass through
+  `max(low, min(high, NaN))`, which evaluates to `high` — i.e. **full thrust /
+  hard-over**, not zero. The clamp now coerces any non-finite command to the safe
+  neutral (0.0). Defense in depth on the way there: the `PID` freezes its state
+  and returns neutral on a non-finite error (a `NaN` error otherwise poisoned the
+  integral permanently); `SensorGuard.check_heading` rejects non-finite headings
+  (a first `NaN` used to latch and then reject every good heading after it); and
+  the COG-fallback no longer writes a `NaN` course/speed into the heading. Added
+  regression tests for each layer.
+- **Safety: `devices.json` is written atomically** (tmp + `os.replace`, like every
+  other store). A power loss mid-write (routine on a boat) previously left a
+  truncated file that load then discarded, silently reverting all hardware config
+  (GPS, compass, motor) to defaults.
+
 - **CI: releases don't re-run the test suite; automation works under branch
   protection.** A version-only `pyproject.toml` bump (a release commit) now skips
   the heavy CI jobs — the `changes` job detects it, on both PR and push events —

--- a/src/vanchor/core/config.py
+++ b/src/vanchor/core/config.py
@@ -926,8 +926,16 @@ def save_device_overrides(
         payload["sim_motor"] = asdict(sim_motor)
     d = Path(data_dir)
     d.mkdir(parents=True, exist_ok=True)
-    (d / DEVICES_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    log.info("saved device overrides to %s", d / DEVICES_FILE)
+    dest = d / DEVICES_FILE
+    # Atomic write (tmp + os.replace), like every other store (prefs, boat
+    # profiles, alert log). A boat loses power mid-write often; a bare write_text
+    # can leave a truncated devices.json that _load_device_overrides then discards
+    # as invalid, silently reverting ALL hardware config (GPS, compass, motor) to
+    # defaults. os.replace is atomic on POSIX, so a crash sees old file or new.
+    tmp = d / (DEVICES_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, dest)
+    log.info("saved device overrides to %s", dest)
     return payload
 
 

--- a/src/vanchor/core/models.py
+++ b/src/vanchor/core/models.py
@@ -222,4 +222,11 @@ class BoatState:
 
 
 def _clamp(value: float, low: float, high: float) -> float:
+    # A non-finite command (NaN/inf from a bad sensor, a divide-by-zero, or a
+    # poisoned PID) must NOT slip through: max(low, min(high, nan)) evaluates to
+    # `high` -- i.e. FULL thrust / hard-over. Coerce it to the safe neutral (0.0
+    # when in range, else the low bound) so garbage coasts instead of slamming a
+    # limit. This is the last line of defence, downstream of every sensor source.
+    if not math.isfinite(value):
+        return 0.0 if low <= 0.0 <= high else low
     return max(low, min(high, value))

--- a/src/vanchor/core/pid.py
+++ b/src/vanchor/core/pid.py
@@ -6,6 +6,7 @@ and to unit-test. Supports output clamping with integral anti-windup.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 
@@ -35,6 +36,13 @@ class PID:
         Useful for headings, where the error must be the *shortest* angular
         difference rather than a naive subtraction.
         """
+        # A non-finite error (NaN/inf heading or measurement) would poison the
+        # integral permanently (NaN + anything = NaN) and, via the output clamp,
+        # saturate to output_max. Freeze all state and command the safe neutral
+        # instead, so one bad sample doesn't wedge the loop.
+        if not (math.isfinite(error) and math.isfinite(dt)):
+            return 0.0 if self.output_min <= 0.0 <= self.output_max else self.output_min
+
         if dt <= 0:
             dt = 1e-6
 

--- a/src/vanchor/nav/guard.py
+++ b/src/vanchor/nav/guard.py
@@ -13,6 +13,7 @@ dropped. It also rejects out-of-range coordinates outright.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from ..core.geo import angle_difference, haversine_m
@@ -65,6 +66,14 @@ class SensorGuard:
         return False
 
     def check_heading(self, heading_deg: float) -> bool:
+        # Reject non-finite headings outright (like check_position rejects
+        # out-of-range coords). A NaN/inf heading otherwise latches into
+        # _last_heading on the first sample -- angle_difference(NaN, x) is NaN, so
+        # every later good heading then fails the jump test and is rejected too,
+        # while the stored NaN flows to state.heading_deg -> the PID/motor.
+        if not math.isfinite(heading_deg):
+            self.heading_rejected += 1
+            return False
         if self._last_heading is None:
             self._last_heading = heading_deg
             return True

--- a/src/vanchor/nav/navigator.py
+++ b/src/vanchor/nav/navigator.py
@@ -335,8 +335,10 @@ class Navigator:
             return  # never had a compass; don't invent a heading
         if (self._mono_fn() - compass_mono) <= COMPASS_STALE_S:
             return  # compass still fresh -> keep using it
-        if not fix.valid or fix.sog_knots < COG_HEADING_MIN_SOG_KNOTS:
-            return  # at rest -> COG is meaningless, keep coasting
+        if not fix.valid or not (fix.sog_knots >= COG_HEADING_MIN_SOG_KNOTS):
+            return  # at rest / NaN sog -> COG is meaningless, keep coasting
+        if not math.isfinite(fix.cog_deg):
+            return  # garbage course -> keep coasting (don't write NaN heading)
         self.state.heading_deg = fix.cog_deg % 360
         self.state.heading_received_mono = self._mono_fn()
         self.state.heading_from_cog = True

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -54,6 +54,21 @@ def test_save_load_round_trip(tmp_path):
     assert loaded["nmea_tcp"]["port"] == 10111
 
 
+def test_save_is_atomic_no_tmp_left_and_replaces_cleanly(tmp_path):
+    # Atomic write: the tmp file must not survive, and an existing (older) file is
+    # fully replaced, never left truncated. Guards against a power-loss mid-write
+    # silently reverting all hardware config to defaults.
+    hw = HardwareConfig(enabled=True, gps_source="nmea")
+    nmea = NmeaTcpConfig(enabled=False, port=10110)
+    save_device_overrides(tmp_path, hw, nmea)
+    # Overwrite with a different config; result must be the new one, clean JSON.
+    save_device_overrides(tmp_path, HardwareConfig(enabled=True, gps_source="ublox"), nmea)
+    assert not (tmp_path / (DEVICES_FILE + ".tmp")).exists()  # no tmp litter
+    on_disk = json.loads((tmp_path / DEVICES_FILE).read_text())  # not truncated
+    assert on_disk["hardware"]["gps_source"] == "ublox"
+    assert load_device_overrides(tmp_path)["hardware"]["gps_source"] == "ublox"
+
+
 def test_load_missing_returns_none(tmp_path):
     assert load_device_overrides(tmp_path) is None
 

--- a/tests/test_heading_fallback.py
+++ b/tests/test_heading_fallback.py
@@ -7,6 +7,8 @@ steering. These tests drive the navigator directly with a controllable
 monotonic clock (matching the other navigator tests).
 """
 
+import math
+
 import pytest
 
 from vanchor.core.models import GeoPoint
@@ -148,6 +150,34 @@ def test_fresh_rmc_still_drives_cog_after_gga():
     nav.handle_sentence(nmea.encode_rmc(_POS, sog_knots=3.0, cog_deg=270.0))
     assert state.heading_from_cog is True
     assert state.heading_deg == pytest.approx(270.0)
+
+
+def test_stale_compass_nan_cog_does_not_write_nan_heading():
+    """A garbage (NaN) course while the compass is stale must NOT be written into
+    state.heading_deg -- a NaN heading clamps the steering PID to hard-over. The
+    fallback declines and the governor keeps coasting on the stale compass."""
+    clock = [0.0]
+    state, nav = _nav(clock)
+    nav.handle_sentence(nmea.encode_hdt(90.0))
+    stamp_before = state.heading_received_mono
+    clock[0] = COMPASS_STALE_S + 1.0
+    nav.handle_sentence(nmea.encode_rmc(_POS, sog_knots=3.0, cog_deg=float("nan")))
+    assert math.isfinite(state.heading_deg)
+    assert state.heading_deg == pytest.approx(90.0)   # last compass value held
+    assert state.heading_from_cog is False
+    assert state.heading_received_mono == pytest.approx(stamp_before)  # stays stale
+
+
+def test_stale_compass_nan_sog_does_not_engage_cog():
+    """A NaN sog must not sneak past the speed gate (NaN >= threshold is False),
+    which would otherwise adopt a meaningless COG as heading."""
+    clock = [0.0]
+    state, nav = _nav(clock)
+    nav.handle_sentence(nmea.encode_hdt(90.0))
+    clock[0] = COMPASS_STALE_S + 1.0
+    nav.handle_sentence(nmea.encode_rmc(_POS, sog_knots=float("nan"), cog_deg=270.0))
+    assert state.heading_deg == pytest.approx(90.0)
+    assert state.heading_from_cog is False
 
 
 def test_heading_from_cog_in_telemetry():

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from vanchor.core.pid import PID
@@ -40,3 +42,22 @@ def test_reset_clears_state():
     pid.reset()
     # After reset the integral is gone, so a fresh small error gives a small out.
     assert pid.update_error(0.5, dt=1.0) == pytest.approx(0.5)
+
+
+def test_nonfinite_error_returns_neutral_and_freezes_state():
+    # A NaN/inf error must not poison the integral (NaN + x = NaN forever) nor
+    # saturate the output via the clamp. It returns the safe neutral (0.0) and
+    # leaves prior state intact, so the next good sample behaves normally.
+    pid = PID(kp=1.0, ki=1.0, kd=0.0, setpoint=0.0, output_min=-1.0, output_max=1.0)
+    pid.update_error(0.3, dt=1.0)          # build some integral
+    assert pid.update_error(float("nan"), dt=1.0) == 0.0
+    assert pid.update_error(float("inf"), dt=1.0) == 0.0
+    # Integral was not poisoned: a zero error now yields only the kept integral,
+    # a finite number (not NaN).
+    out = pid.update_error(0.0, dt=1.0)
+    assert math.isfinite(out) and out == pytest.approx(0.3)
+
+
+def test_nonfinite_dt_returns_neutral():
+    pid = PID(kp=1.0, setpoint=0.0, output_min=-1.0, output_max=1.0)
+    assert pid.update_error(0.5, dt=float("nan")) == 0.0

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -25,6 +25,18 @@ def _state(mode=ControlModeName.MANUAL, dist=0.0, radius=5.0, anchor=True) -> Na
     return s
 
 
+def test_nonfinite_command_clamps_to_neutral_not_full_thrust():
+    # The actuator backstop: a NaN/inf thrust or steering must coerce to 0.0, NOT
+    # to +1.0. Bare max(low, min(high, nan)) evaluates to `high` -- full thrust /
+    # hard-over -- which is the P0 defect this guards. Independent of any sensor.
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        c = MotorCommand(thrust=bad, steering=bad).clamped()
+        assert c.thrust == 0.0 and c.steering == 0.0
+    # Finite values still clamp normally.
+    c = MotorCommand(thrust=5.0, steering=-9.0).clamped()
+    assert c.thrust == 1.0 and c.steering == -1.0
+
+
 def test_thrust_step_is_slew_limited():
     gov = _gov(max_thrust_slew_per_s=1.0)
     cmd, status = gov.govern(MotorCommand(thrust=1.0), _state(), dt=0.2, fix_is_fresh=True)

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,5 +1,7 @@
 """Tests for sensor-anomaly protection (spike rejection with confirmation)."""
 
+import math
+
 from vanchor.core.geo import destination_point
 from vanchor.core.models import GeoPoint
 from vanchor.nav.guard import SensorGuard, SensorGuardConfig
@@ -55,3 +57,15 @@ def test_heading_wrap_small_change_accepted():
     g.check_heading(355.0)
     assert g.check_heading(5.0)  # 10 deg across the wrap, accepted
     assert g.heading_rejected == 0
+
+
+def test_nonfinite_heading_rejected_and_does_not_latch():
+    # A NaN/inf heading must be rejected outright, and must NOT poison the guard:
+    # a following good heading is still accepted (regression for the "first NaN
+    # latches _last_heading and then rejects everything" bug that reached the PID).
+    g = _g(heading_jump_max_deg=30.0)
+    assert not g.check_heading(float("nan"))
+    assert not g.check_heading(float("inf"))
+    assert g.heading_rejected == 2
+    assert g.check_heading(90.0)   # good heading after garbage -> accepted
+    assert g.check_heading(95.0)


### PR DESCRIPTION
Top findings from the parallel project review. The lead defect was confirmed **independently by two reviewers** (safety + navigation) from opposite ends of the code, which is why it goes first.

## 🔴 P0 — a NaN/inf sensor value commanded FULL thrust, not zero
`MotorCommand.clamped()` ran each channel through `max(low, min(high, value))`. In Python `min(1.0, NaN) == 1.0` and `max(-1.0, 1.0) == 1.0`, so a single non-finite value clamped to **+1.0 — full thrust / hard-over**. There was no `isfinite` gate anywhere on the sensor → command → motor path. A glitchy AHRS yaw or a malformed NMEA field (`float("nan")` parses cleanly) was enough to reach it.

### Fixes (defense in depth, one regression test each)
- **`core/models._clamp`** — non-finite → safe neutral (`0.0` when in range, else `low`). The **actuator backstop**: catches NaN from *any* source (heading, cog/sog, divide-by-zero, a poisoned PID) right before the motor.
- **`core/pid.update_error`** — non-finite error/dt freezes all state and returns neutral. A NaN error otherwise poisoned the integral permanently (`NaN + x = NaN`) and saturated the output to `output_max`.
- **`nav/guard.check_heading`** — reject non-finite headings outright, mirroring how `check_position` already rejects out-of-range coords. A first NaN used to latch into `_last_heading`; thereafter `angle_difference(NaN, x) = NaN` rejected *every* good heading, while the stored NaN flowed to `state.heading_deg`.
- **`nav/navigator` COG-fallback** — guard non-finite sog (`NaN >= thr` is `False`) and cog, so a garbage course is never written as heading. This path writes `state.heading_deg` directly, bypassing `check_heading`, so it needed its own guard.

## 🟠 P1 — `devices.json` written atomically
`save_device_overrides` did a bare `write_text`, unlike every other store (prefs, boat profiles, alert log) which use tmp + `os.replace`. A power loss mid-write (routine on a boat) left a truncated file that `load` then discarded as invalid — **silently reverting all hardware config (GPS, compass, motor) to defaults** on next boot. Now atomic.

## Tests
+6 regression tests (clamp backstop, PID freeze + no integral poison, non-finite heading no-latch, NaN cog/sog fallback decline, atomic write leaves no tmp + clean replace). Full suite **2243 passed**; ruff clean.

## Not included here (need your call — they change safety *posture*/defaults)
Tracking separately: enabling the GPIO motor-deadman by default + bench-validating it; giving STOP/failsafe an instant path instead of slew-ramping to zero; and host-testing the firmware loss-of-signal watchdog. I'll open an issue for these unless you'd rather fold them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)