### PR TITLE
feat(image): always-on WiFi access point (offline-first) with per-device SSID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **SD image: the Pi is an always-on WiFi access point (offline-first), with a
+  per-device SSID.** Previously the AP was a low-priority *fallback* that only
+  came up when no known network was reachable (`autoconnect-priority=-10`, a 25 s
+  conditional check), on the assumption you would join a home network. On a boat
+  there is no upstream WiFi, so the AP is now the primary interface: it comes up
+  at every boot at high priority (`100`), and a boot service sets its broadcast
+  SSID to `vanchor-<last 4 of the wlan0 MAC>` (e.g. `vanchor-a1b2`) so multiple
+  units don't collide. Joining a home network from the UI still works, but it is
+  now explicitly a temporary, this-session-only way to get online — the Pi
+  returns to its own AP on the next reboot. Password (`vanchor-boat`) and address
+  (`10.42.0.1` / `vanchor.local`) are unchanged; the WiFi status card now shows
+  the real per-device SSID.
+
 - **CI: releases don't re-run the test suite; automation works under branch
   protection.** A version-only `pyproject.toml` bump (a release commit) now skips
   the heavy CI jobs — the `changes` job detects it, on both PR and push events —

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -6,7 +6,7 @@ Builds a flashable Raspberry Pi SD image (`.img.xz`) containing:
 - Docker CE + docker-compose plugin
 - The `vanchor/vanchor` docker image pre-loaded (no first-boot internet required)
 - The `vanchor-supervisor` host daemon
-- NetworkManager setup hotspot (`vanchor-setup` / `vanchor-boat`)
+- NetworkManager always-on access point (SSID `vanchor-<last4 MAC>` / `vanchor-boat`)
 - SD-write minimisation: volatile journald, tmpfs `/tmp`+`/var/log`, noatime,
   bounded docker logs, zram swap
 
@@ -152,13 +152,13 @@ stage-vanchor/
     files/daemon.json    log-driver=local, max-size=5m, max-file=2
   01-net/
     00-packages          avahi-daemon
-    00-run.sh            install NM connection + dnsmasq + hotspot files
-    01-run-chroot.sh     wifi country, purge modemmanager, enable hotspot svc
+    00-run.sh            install NM connection + dnsmasq + AP files
+    01-run-chroot.sh     wifi country, purge modemmanager, enable AP svc
     files/
-      vanchor-setup.nmconnection   WPA2-PSK AP profile, priority -10
+      vanchor-setup.nmconnection   WPA2-PSK AP profile, priority 100 (offline-first)
       vanchor-dnsmasq.conf         address=/vanchor.local/10.42.0.1
-      vanchor-hotspot.service      systemd oneshot fallback
-      vanchor-hotspot-check.sh     25 s sleep then nmcli up if no active conn
+      vanchor-hotspot.service      systemd oneshot: bring the AP up at boot
+      vanchor-hotspot-setup.sh     set per-device SSID (vanchor-<last4 MAC>), nmcli up
   02-stack/
     00-run.sh            copy compose + supervisor + bundle + units into rootfs
     01-run-chroot.sh     enable units, add groups, noatime, zram, disable SD swap

--- a/deploy/image/stage-vanchor/01-net/00-run.sh
+++ b/deploy/image/stage-vanchor/01-net/00-run.sh
@@ -12,5 +12,5 @@ install -m 0644 files/vanchor-dnsmasq.conf \
     "${ROOTFS_DIR}/etc/NetworkManager/dnsmasq-shared.d/vanchor.conf"
 install -m 0644 files/vanchor-hotspot.service \
     "${ROOTFS_DIR}/etc/systemd/system/vanchor-hotspot.service"
-install -m 0755 files/vanchor-hotspot-check.sh \
-    "${ROOTFS_DIR}/usr/local/sbin/vanchor-hotspot-check"
+install -m 0755 files/vanchor-hotspot-setup.sh \
+    "${ROOTFS_DIR}/usr/local/sbin/vanchor-hotspot-setup"

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -4,5 +4,5 @@ raspi-config nonint do_wifi_country "${WPA_COUNTRY:-SE}" || true
 # Purge ModemManager — it probes /dev/ttyUSB* and /dev/ttyACM* on hotplug
 # and can seize the GPS and motor serial adapters.
 apt-get purge -y modemmanager || true
-# Enable the hotspot fallback service.
+# Enable the access-point service (brings the AP up at every boot; offline-first).
 systemctl enable vanchor-hotspot.service

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-check.sh
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-check.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# If no non-loopback connection is active, raise the setup hotspot.
-# BENCH-VERIFY: NM AP autoconnect timing is unverifiable without hardware.
-sleep 25
-if ! nmcli -t -f NAME,TYPE connection show --active | grep -qv '^lo:'; then
-    nmcli connection up vanchor-setup || true
-fi

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-setup.sh
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Bring up the vanchor access point at boot. Offline-first: a boat has no
+# upstream WiFi, so the Pi IS the network and must always be joinable.
+#
+# The broadcast SSID is per-device -- vanchor-<last 4 hex of the wlan0 MAC> --
+# so two units on the same water don't collide. The NetworkManager connection
+# *id* stays the stable "vanchor-setup" (what src/vanchor/wifi.py keys on); only
+# the 802-11-wireless.ssid field is rewritten here.
+#
+# BENCH-VERIFY: NM AP activation + SSID-modify timing is unverifiable without
+# real Pi WiFi hardware.
+set -u
+
+PROFILE="vanchor-setup"
+
+# Derive vanchor-<last4> from the wlan0 MAC (e.g. dc:a6:32:ab:cd:ef -> vanchor-cdef).
+mac="$(cat /sys/class/net/wlan0/address 2>/dev/null || true)"
+hex="${mac//:/}"           # strip colons
+suffix="${hex: -4}"        # last 4 hex digits (note the space before -4)
+suffix="${suffix,,}"       # lowercase
+if [ -n "$suffix" ]; then
+    nmcli connection modify "$PROFILE" 802-11-wireless.ssid "vanchor-${suffix}" || true
+fi
+
+# Always (re)activate the AP. If the operator has explicitly joined a home
+# network this session, that join holds the single radio; on the next reboot the
+# higher-priority AP profile wins again, which is why we come back to the AP.
+nmcli connection up "$PROFILE" || true

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot.service
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Vanchor setup-hotspot fallback
+Description=Vanchor access point (offline-first, per-device SSID)
 After=NetworkManager.service
 Wants=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/vanchor-hotspot-check
+ExecStart=/usr/local/sbin/vanchor-hotspot-setup
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-setup.nmconnection
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-setup.nmconnection
@@ -1,10 +1,17 @@
+# Offline-first: the boat has no upstream WiFi, so the Pi IS the network. This
+# access point comes up at every boot (high autoconnect priority beats any saved
+# home network, which sits at the default 0), so it wins on reboot even after an
+# optional temporary join. The `id` stays stable ("vanchor-setup" -- what
+# wifi.py keys on); the broadcast `ssid` here is only a placeholder, rewritten at
+# boot to vanchor-<last 4 of the wlan0 MAC> by vanchor-hotspot-setup so multiple
+# units don't collide.
 [connection]
 id=vanchor-setup
 uuid=b1e0c1a4-0000-4000-8000-76616e63686f
 type=wifi
 interface-name=wlan0
 autoconnect=true
-autoconnect-priority=-10
+autoconnect-priority=100
 
 [wifi]
 mode=ap

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -86,7 +86,8 @@ Settings.
 - Docker CE + docker-compose plugin
 - The `vanchor/vanchor` docker image pre-loaded (no first-boot pull)
 - The `vanchor-supervisor` host daemon (update / backup / disk / device policy)
-- NetworkManager hotspot (`vanchor-setup`) for initial phone connection
+- NetworkManager **access point** — always-on, offline-first; per-device SSID
+  `vanchor-<last 4 of the wlan0 MAC>` (e.g. `vanchor-a1b2`) so units don't collide
 - SD-write minimisation: volatile journald, tmpfs `/tmp`+`/var/log`, noatime,
   bounded docker logs (`local` driver, max 5 MB × 2), zram swap
 
@@ -101,36 +102,45 @@ Settings.
 3. *(Optional)* Click the gear ⚙ to pre-configure hostname / user / SSH / WiFi.
 4. Select your 16 GB (or larger) SD card and flash.
 
-### First boot (no ethernet, no WiFi configured)
+### First boot (offline, no configuration needed)
 
 1. Insert the card and power on. The root partition auto-expands (one automatic
    reboot is normal and expected).
 2. `vanchor-load-images` runs in the background (~30–60 s on Pi 4, once only).
 3. The docker stack comes up. Total time to a responsive UI: ≤ ~3 min.
-4. The setup hotspot **`vanchor-setup`** appears (WPA2 password `vanchor-boat`).
-   Connect your phone to it.
+4. The access point **`vanchor-<last 4 of the MAC>`** (e.g. `vanchor-a1b2`)
+   appears (WPA2 password `vanchor-boat`). This AP is always on — it is how you
+   reach the boat, no upstream WiFi required. Connect your phone to it.
 5. Open **`http://10.42.0.1:8000`** (or **`http://vanchor.local:8000`**) — the UI
    loads.
 
-### Join your home WiFi
+> The exact SSID is derived per-device from the Pi's wlan0 MAC, so it is unique.
+> To find yours before you go out, boot the Pi once and look for the
+> `vanchor-…` network, or read it in the UI under **WiFi & network**.
+
+### Optionally join a home WiFi (temporary — to get online)
+
+The AP is the primary interface and Vanchor is offline-first (updates upload
+through the UI, no internet needed). But you can put the Pi online for a session
+— e.g. to pull something from the internet — by joining a network.
 
 In the UI → Settings → "Data & system" → **WiFi & network** card:
 1. Click **Scan for networks** — your home network appears.
 2. Click it, enter the password → the join runs in the background.
-3. The hotspot drops while joining (single radio). Reconnect your phone to your
-   home WiFi, then open **`http://vanchor.local:8000`** (avahi mDNS on the LAN).
-4. If the wrong password was entered, the hotspot returns automatically after
-   ~60 s.
-5. On subsequent reboots the Pi joins your home WiFi directly (autoconnect
-   priority: saved home profiles 0 > hotspot -10). The hotspot only returns when
-   no known network is reachable.
+3. The AP drops while joined (single radio). Reconnect your phone to your home
+   WiFi, then open **`http://vanchor.local:8000`** (avahi mDNS on the LAN).
+4. If the wrong password was entered, the AP returns automatically after ~60 s.
+5. **The join is for this session only.** The AP has higher autoconnect priority
+   (100) than a saved home network (0), so on the **next reboot the Pi comes back
+   up as its own access point** — the boat is always reachable without any known
+   network in range. Join again when you next need to be online.
 
 ### Default credentials
 
 | Item | Value |
 |---|---|
-| Hotspot SSID | `vanchor-setup` |
-| Hotspot password | `vanchor-boat` |
+| Access-point SSID | `vanchor-<last 4 of wlan0 MAC>` (per device, e.g. `vanchor-a1b2`) |
+| Access-point password | `vanchor-boat` |
 | Console login | `vanchor` / `vanchor` (change with `passwd`) |
 | SSH | **Disabled by default.** Enable: touch a file named `ssh` on the boot partition and reboot. |
 
@@ -159,14 +169,14 @@ File a GitHub issue for any failing box.
 - [ ] **Flash** — Imager shows **Vanchor-NG** from the custom URL; write the card.
 - [ ] **Boot** — insert, power on; root auto-expands (one reboot is normal);
   `vanchor-load-images` completes; container is up. Responsive UI ≤ ~3 min.
-- [ ] **Hotspot** — SSID `vanchor-setup` appears; join with `vanchor-boat`; phone
-  gets a `10.42.0.x` lease.
+- [ ] **Access point** — SSID `vanchor-<last4 MAC>` appears (unique per device);
+  join with `vanchor-boat`; phone gets a `10.42.0.x` lease.
 - [ ] **UI reachable** — `http://10.42.0.1:8000` and `http://vanchor.local:8000`
   both load (test iOS **and** Android — Android mDNS is the weak spot).
-- [ ] **Join home WiFi** — Settings → WiFi & network → Scan → pick network →
-  hotspot drops; reconnect phone to home WiFi, `http://vanchor.local:8000` loads.
-  Wrong password → hotspot returns within ~60 s, and the error does **not** echo
-  the PSK.
+- [ ] **Optional join home WiFi** — Settings → WiFi & network → Scan → pick
+  network → AP drops; reconnect phone to home WiFi, `http://vanchor.local:8000`
+  loads. Wrong password → AP returns within ~60 s, and the error does **not**
+  echo the PSK. **Reboot → the Pi comes back up as its own AP** (offline-first).
 - [ ] **Device probe** — `systemctl status ModemManager` is `not-found`; a USB GPS
   on `/dev/ttyACM0` streams clean NMEA (not seized by ModemManager).
 

--- a/scripts/gen_imager_json.py
+++ b/scripts/gen_imager_json.py
@@ -58,8 +58,8 @@ def build_os_list(
                 "name": f"Vanchor-NG {version}",
                 "description": (
                     "Trolling-motor autopilot boat controller. "
-                    "Boots a setup hotspot 'vanchor-setup' (password vanchor-boat); "
-                    "UI at http://vanchor.local:8000."
+                    "Boots an always-on WiFi access point 'vanchor-<last4 of MAC>' "
+                    "(password vanchor-boat); UI at http://vanchor.local:8000."
                 ),
                 "url": url,
                 "extract_size": extract_size,

--- a/src/vanchor/wifi.py
+++ b/src/vanchor/wifi.py
@@ -16,6 +16,9 @@ from typing import Any
 
 logger = logging.getLogger("vanchor.wifi")
 
+# The stable NetworkManager connection *id* for the access point. Its broadcast
+# SSID is per-device (vanchor-<last4 MAC>, set at boot by vanchor-hotspot-setup),
+# so status() resolves the real SSID separately rather than showing this id.
 HOTSPOT_PROFILE = "vanchor-setup"
 JOIN_TIMEOUT_S = 45
 
@@ -130,12 +133,22 @@ async def status(runner=_run) -> dict:
                 hotspot_active = True
                 if mode not in ("wifi",):  # wifi outranks hotspot in mode display
                     mode = "hotspot"
-                    ssid = HOTSPOT_PROFILE
+                    ssid = HOTSPOT_PROFILE  # placeholder; resolved to the real SSID below
             else:
                 mode = "wifi"
                 ssid = name
         elif conn_type == "802-3-ethernet":
             mode = "ethernet"
+
+    # The hotspot broadcasts a per-device SSID (vanchor-<last4 MAC>), not its
+    # connection id -- resolve it so the UI shows the network the phone must join.
+    if hotspot_active and mode == "hotspot":
+        rc_s, out_s, _ = await runner(
+            ["nmcli", "-g", "802-11-wireless.ssid", "connection", "show", HOTSPOT_PROFILE],
+            timeout=10.0,
+        )
+        if rc_s == 0 and out_s.strip():
+            ssid = out_s.strip()
 
     # Best-effort IP lookup for wlan0
     ip: str | None = None

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -84,8 +84,10 @@ def test_nmconnection():
     assert cfg.get("ipv4", "method") == "shared"
     psk = cfg.get("wifi-security", "psk")
     assert len(psk) >= 8, f"PSK too short: {psk!r}"
+    # Offline-first: the AP is the primary interface and must win on reboot even
+    # over a saved home network (default priority 0), so its priority is positive.
     priority = cfg.get("connection", "autoconnect-priority")
-    assert priority == "-10"
+    assert int(priority) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -219,9 +221,7 @@ BOOT_TIME_SCRIPTS = [
     STAGE_ROOT / "02-stack" / "00-run.sh",
     STAGE_ROOT / "02-stack" / "01-run-chroot.sh",
     STAGE_ROOT / "02-stack" / "files" / "vanchor-load-images.sh",
-    STAGE_ROOT / "02-stack" / "files" / "vanchor-hotspot-check.sh" if \
-        (STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-check.sh").exists() else
-        STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-check.sh",
+    STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-setup.sh",
     STAGE_ROOT / "03-trim" / "00-run-chroot.sh",
 ]
 
@@ -229,7 +229,7 @@ BOOT_TIME_SCRIPTS = [
 BOOT_TIME_SCRIPTS_FIXED = [
     STAGE_ROOT / "01-net" / "00-run.sh",
     STAGE_ROOT / "01-net" / "01-run-chroot.sh",
-    STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-check.sh",
+    STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-setup.sh",
     STAGE_ROOT / "02-stack" / "00-run.sh",
     STAGE_ROOT / "02-stack" / "01-run-chroot.sh",
     STAGE_ROOT / "02-stack" / "files" / "vanchor-load-images.sh",

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -67,6 +67,7 @@ CONNECTIONS_WIFI = "HomeNet:802-11-wireless:wlan0\nlo:loopback:lo\n"
 CONNECTIONS_ETH = "eth0:802-3-ethernet:eth0\nlo:loopback:lo\n"
 CONNECTIONS_EMPTY = "lo:loopback:lo\n"
 IP_HOTSPOT = "IP4.ADDRESS[1]:10.42.0.1/24\n"
+SSID_HOTSPOT = "vanchor-a1b2\n"   # per-device SSID from `nmcli -g 802-11-wireless.ssid`
 IP_HOME = "IP4.ADDRESS[1]:192.168.1.50/24\n"
 
 SCAN_OUTPUT = (
@@ -126,14 +127,16 @@ async def test_scan_parses_sample():
 
 async def test_status_hotspot():
     r = make_runner(
-        (0, CONNECTIONS_HOTSPOT, ""),   # connection show
-        (0, IP_HOTSPOT, ""),             # device show
+        (0, CONNECTIONS_HOTSPOT, ""),   # connection show --active
+        (0, SSID_HOTSPOT, ""),           # nmcli -g 802-11-wireless.ssid (per-device)
+        (0, IP_HOTSPOT, ""),             # device show wlan0
     )
     result = await status(runner=r)
     assert result["ok"] is True
     assert result["available"] is True
     assert result["mode"] == "hotspot"
     assert result["hotspot_active"] is True
+    assert result["ssid"] == "vanchor-a1b2"   # real broadcast SSID, not the profile id
     assert result["ip"] == "10.42.0.1"
 
 


### PR DESCRIPTION
Corrects the image's network model. The AP was built as a low-priority **fallback** (`autoconnect-priority=-10`, a 25 s "raise only if nothing else is active" check) on a Home-Assistant-style *join-your-home-WiFi* assumption. On a boat there is no upstream WiFi — **the Pi is the network** — so the access point must be primary and always on.

## Changes
- **`vanchor-setup.nmconnection`** — `autoconnect-priority` `-10 → 100`, so the AP wins on reboot even over a saved home network (default priority `0`). The connection `id` stays stable (`vanchor-setup`, what `wifi.py` keys on); the `ssid` field is now just a placeholder, set at boot.
- **`vanchor-hotspot-setup.sh`** (renamed from `vanchor-hotspot-check.sh`) — derives a **per-device SSID `vanchor-<last 4 hex of the wlan0 MAC>`** (e.g. `vanchor-a1b2`) and brings the AP up **unconditionally** at boot, instead of sleeping 25 s and only raising it when nothing else is connected. Per-device SSID so two units on the same water don't collide. (Verified: `dc:a6:32:ab:cd:ef → vanchor-cdef`, uppercase MACs lowercased.)
- **`wifi.py` `status()`** — resolves and reports the **real broadcast SSID** (`nmcli -g 802-11-wireless.ssid`) instead of the connection id, so the WiFi card shows the network the phone must join.

## Behavior
- **Offline-first:** boot with nothing configured → the Pi is reachable at its own `vanchor-<last4>` AP (`vanchor-boat`, `10.42.0.1` / `vanchor.local`). No change to password or address.
- **Optional join still works but is temporary:** joining a home network from the UI takes the single radio for that session; on the **next reboot the higher-priority AP returns**. This matches offline-first (updates upload through the UI; no internet needed).

## Docs & tests
`docs/deploy-pi.md`, `deploy/image/README.md`, and the Imager description all reworded from "setup hotspot / `vanchor-setup`" to the always-on per-device AP, with the join section reframed as temporary. Tests updated: image priority assertion (`> 0`), renamed script reference, and the WiFi hotspot test asserts the resolved per-device SSID. Full suite **2236 passed**; ruff clean; `bash -n` OK.

## BENCH-VERIFY (needs real Pi WiFi, per the repo's convention)
AP activation timing, the SSID-modify-at-boot, and whether NM ever briefly flaps the high-priority AP against an explicitly-joined home network are unverifiable without hardware — flagged in the script and worth checking on the first-boot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)