### PR TITLE
fix(image): correct the os_list.json download URL (repo slug + real filename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Fixed the SD-image download URL in `os_list.json`.** The Raspberry Pi Imager
+  custom-repo JSON pointed at `github.com/AlexAsplund/vanchor-ng/.../vanchor-<ver>-arm64.img.xz`
+  — wrong on two counts: the repo is `AlexAsplund/Vanchor`, and pi-gen names the
+  image `image_<date>-vanchor-lite.img.xz`, not the guessed name. Both 404'd, so
+  Imager couldn't fetch the image. The generator now uses the correct repo and
+  derives the filename from the actual built image. Also corrected the
+  `vanchor-ng` URLs in the deploy docs / README. (The v1.5.0a12 release asset was
+  patched in place.)
+
 ## [1.5.0a12] — 2026-08-10
 
 - **Battery source "none" now actually disables the gauge.** Selecting **None (no

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ serves the app directly to your phone.
 Paste the URL below into Raspberry Pi Imager (OS → "Use custom → Provide URL"):
 
 ```
-https://github.com/AlexAsplund/vanchor-ng/releases/latest/download/os_list.json
+https://github.com/AlexAsplund/Vanchor/releases/latest/download/os_list.json
 ```
 
 **On a laptop / dev machine:**

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -96,7 +96,7 @@ Settings.
 1. Open [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (≥ v1.8).
 2. Click **OS → Use custom → Provide URL**, paste:
    ```
-   https://github.com/AlexAsplund/vanchor-ng/releases/latest/download/os_list.json
+   https://github.com/AlexAsplund/Vanchor/releases/latest/download/os_list.json
    ```
    Select **Vanchor-NG** from the list.
 3. *(Optional)* Click the gear ⚙ to pre-configure hostname / user / SSH / WiFi.
@@ -187,7 +187,7 @@ File a GitHub issue for any failing box.
 ### Sideload updates (recommended — no Pi internet required)
 
 On your phone or laptop:
-1. Go to **[GitHub Releases](https://github.com/AlexAsplund/vanchor-ng/releases/latest)**
+1. Go to **[GitHub Releases](https://github.com/AlexAsplund/Vanchor/releases/latest)**
    and download `vanchor-update-<version>.bundle.tar`.
 2. In the Vanchor UI → Settings → **System & updates** → "Sideload update bundle"
    → upload the bundle.
@@ -365,7 +365,7 @@ Deploy under a service user (here `pi`) in `/opt/vanchor` (or a home dir):
 
 ```bash
 sudo mkdir -p /opt/vanchor && sudo chown $USER /opt/vanchor
-git clone https://github.com/AlexAsplund/vanchor-ng /opt/vanchor
+git clone https://github.com/AlexAsplund/Vanchor /opt/vanchor
 cd /opt/vanchor
 
 python3 -m venv .venv

--- a/scripts/gen_imager_json.py
+++ b/scripts/gen_imager_json.py
@@ -26,7 +26,7 @@ import sys
 
 
 GITHUB_OWNER = "AlexAsplund"
-GITHUB_REPO = "vanchor-ng"
+GITHUB_REPO = "Vanchor"
 
 
 def sha256_of(path: pathlib.Path) -> str:
@@ -47,9 +47,12 @@ def build_os_list(
     download_size = img_xz.stat().st_size
     download_sha256 = sha256_of(img_xz)
 
+    # Derive the download filename from the ACTUAL built image, not a guessed
+    # name -- image.yml uploads it under its real basename (pi-gen names it e.g.
+    # image_<date>-vanchor-lite.img.xz), so a hardcoded name would 404.
     url = (
         f"https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}"
-        f"/releases/download/v{version}/vanchor-{version}-arm64.img.xz"
+        f"/releases/download/v{version}/{img_xz.name}"
     )
 
     return {

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -155,8 +155,12 @@ def test_gen_imager_json(tmp_path):
     expected_sha = hashlib.sha256(fake_img.read_bytes()).hexdigest()
     assert entry["image_download_sha256"] == expected_sha
 
-    # Version appears in URL
-    assert "1.5.0a8" in entry["url"]
+    # URL points at the real repo, the release tag, and the ACTUAL image
+    # basename (not a guessed name that would 404).
+    assert entry["url"] == (
+        "https://github.com/AlexAsplund/Vanchor/releases/download/"
+        "v1.5.0a8/" + fake_img.name
+    )
 
     # JSON round-trips
     assert json.loads(json.dumps(data)) == data


### PR DESCRIPTION
**Reported:** the URL in `os_list.json` (the Raspberry Pi Imager custom-repo JSON) is wrong.

## Cause
The generator hardcoded the image download URL as:
```
https://github.com/AlexAsplund/vanchor-ng/releases/download/v<ver>/vanchor-<ver>-arm64.img.xz
```
Wrong on **two** counts:
1. The repo is **`AlexAsplund/Vanchor`** — `AlexAsplund/vanchor-ng` does not exist.
2. pi-gen names the image **`image_<date>-vanchor-lite.img.xz`**, and `image.yml` uploads it under that real basename — never the guessed `vanchor-<ver>-arm64.img.xz`.

Either alone 404s, so Raspberry Pi Imager couldn't download the image.

## Fix
`gen_imager_json.py` now uses `GITHUB_REPO = "Vanchor"` and derives the filename from **`img_xz.name`** — the actual built image it's already handed — so the URL always matches the uploaded asset regardless of pi-gen's naming. Test strengthened to assert the full correct URL. Also corrected the `vanchor-ng` URLs in `docs/deploy-pi.md` (×3) and `README.md`.

## Live release already patched
The published **v1.5.0a12** `os_list.json` asset was patched in place (url only; sha/sizes untouched) and verified:
- new URL → **HTTP 200**
- old URL → **404**

Full image-tooling suite: 33 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)