### PR TITLE
feat(image): free the GPIO UART for a pin-wired GPS/compass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **SD image frees the GPIO UART for a pin-wired GPS/compass.** By default the Pi
+  keeps a login console on the serial port, so a GPS wired to the TX/RX pins
+  (`/dev/serial0`) can't be read — the most common wired-GPS gotcha (and the exact
+  wall a maker hit in the discussions). The image now enables the UART
+  (`enable_uart=1`), removes the serial console from `cmdline.txt`, masks the
+  serial `getty`, and disables onboard Bluetooth (`dtoverlay=disable-bt`) so the
+  reliable PL011 UART lands on the GPIO pins. No manual `raspi-config` step; USB
+  GPS is unaffected. (BENCH-VERIFY: UART routing can't be validated without a Pi.)
+
 - **Fixed the SD-image download URL in `os_list.json`.** The Raspberry Pi Imager
   custom-repo JSON pointed at `github.com/AlexAsplund/vanchor-ng/.../vanchor-<ver>-arm64.img.xz`
   — wrong on two counts: the repo is `AlexAsplund/Vanchor`, and pi-gen names the

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -153,7 +153,9 @@ stage-vanchor/
   01-net/
     00-packages          avahi-daemon
     00-run.sh            install NM connection + dnsmasq + AP files
-    01-run-chroot.sh     wifi country, purge modemmanager, enable AP svc
+    01-run-chroot.sh     wifi country, purge modemmanager, free GPIO UART
+                         (enable_uart + disable-bt + drop serial console),
+                         enable AP svc
     files/
       vanchor-setup.nmconnection   WPA2-PSK AP profile, priority 100 (offline-first)
       vanchor-dnsmasq.conf         address=/vanchor.local/10.42.0.1

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -4,5 +4,28 @@ raspi-config nonint do_wifi_country "${WPA_COUNTRY:-SE}" || true
 # Purge ModemManager — it probes /dev/ttyUSB* and /dev/ttyACM* on hotplug
 # and can seize the GPS and motor serial adapters.
 apt-get purge -y modemmanager || true
+
+# Free the GPIO UART (/dev/serial0) for a pin-wired GPS/compass. By default the
+# Pi keeps a login console on that port, so a GPS wired to the TX/RX pins can't
+# be read — the #1 wired-GPS gotcha. Enable the UART, take the console off it,
+# and (Pi 3/4) hand the reliable PL011 to the GPIO pins by disabling onboard
+# Bluetooth (unused on a boat; the flaky mini-UART otherwise lands on the pins).
+# USB GPS is unaffected. BENCH-VERIFY: exact UART routing (mini-UART vs PL011,
+# Pi 5 specifics) is unverifiable without hardware.
+BOOT_DIR=/boot/firmware        # Bookworm; older layouts use /boot
+[ -d "$BOOT_DIR" ] || BOOT_DIR=/boot
+if [ -f "$BOOT_DIR/config.txt" ]; then
+    grep -q '^enable_uart=1'        "$BOOT_DIR/config.txt" || echo 'enable_uart=1'        >> "$BOOT_DIR/config.txt"
+    grep -q '^dtoverlay=disable-bt' "$BOOT_DIR/config.txt" || echo 'dtoverlay=disable-bt' >> "$BOOT_DIR/config.txt"
+fi
+if [ -f "$BOOT_DIR/cmdline.txt" ]; then
+    # Drop the serial-console token so getty no longer holds the port.
+    sed -i -E 's/console=(serial0|ttyAMA0|ttyS0),[0-9]+ ?//g' "$BOOT_DIR/cmdline.txt"
+fi
+systemctl disable hciuart 2>/dev/null || true              # BT-over-UART (paired with disable-bt)
+systemctl mask serial-getty@ttyAMA0.service 2>/dev/null || true
+systemctl mask serial-getty@ttyS0.service 2>/dev/null || true
+systemctl mask serial-getty@serial0.service 2>/dev/null || true
+
 # Enable the access-point service (brings the AP up at every boot; offline-first).
 systemctl enable vanchor-hotspot.service

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -88,6 +88,9 @@ Settings.
 - The `vanchor-supervisor` host daemon (update / backup / disk / device policy)
 - NetworkManager **access point** — always-on, offline-first; per-device SSID
   `vanchor-<last 4 of the wlan0 MAC>` (e.g. `vanchor-a1b2`) so units don't collide
+- **GPIO UART freed** for a pin-wired GPS/compass: `enable_uart=1`, the serial
+  login console removed, and Bluetooth disabled so the reliable PL011 UART lands
+  on the pins (`/dev/serial0`). No manual `raspi-config` step; USB GPS unaffected.
 - SD-write minimisation: volatile journald, tmpfs `/tmp`+`/var/log`, noatime,
   bounded docker logs (`local` driver, max 5 MB × 2), zram swap
 

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -103,6 +103,18 @@ def test_load_images_service():
     assert "WantedBy=multi-user.target" in text
 
 
+def test_net_chroot_frees_gpio_uart():
+    """01-net chroot must free /dev/serial0 for a pin-wired GPS/compass: enable
+    the UART, disable Bluetooth (so PL011 lands on the pins), drop the serial
+    console from cmdline.txt, and mask the serial getty."""
+    text = (STAGE_ROOT / "01-net" / "01-run-chroot.sh").read_text()
+    assert "enable_uart=1" in text
+    assert "dtoverlay=disable-bt" in text
+    assert "cmdline.txt" in text and "console=" in text   # strips the serial console
+    assert "serial-getty@" in text and "mask" in text     # getty no longer holds the port
+    assert "disable hciuart" in text                       # BT-UART service off
+
+
 def test_hotspot_service():
     path = STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot.service"
     assert path.exists()


### PR DESCRIPTION
**Answers "does the image free up serial0?" — previously no; now yes.**

By default the Pi keeps a login console on the serial port, so a GPS/compass wired to the GPIO **TX/RX pins** (`/dev/serial0`) can't be read. That's the #1 wired-GPS gotcha and the exact wall the BE-880 maker hit in [discussion #114](https://github.com/AlexAsplund/Vanchor/discussions/114) — previously only fixable with a manual `raspi-config` step. The image now does it automatically.

## What the 01-net chroot now does (build time)
- `enable_uart=1` in `config.txt`
- `dtoverlay=disable-bt` — hands the reliable **PL011** UART to the GPIO pins (the flaky mini-UART otherwise lands there); onboard Bluetooth is unused on a boat
- strips `console=(serial0|ttyAMA0|ttyS0),<baud>` from `cmdline.txt`
- masks `serial-getty@{ttyAMA0,ttyS0,serial0}` and disables `hciuart`

Handles both the Bookworm `/boot/firmware` and the older `/boot` layout. **USB GPS is unaffected.**

## Tradeoffs (as discussed)
- Loses serial-**console** debug access (HDMI/keyboard console + the AP-based UI still work; SSH already off).
- Disables the Pi's onboard **Bluetooth** — intended, and required to get the good UART on the pins.

## Tests
+1 test asserting the freeing (`enable_uart` / `disable-bt` / cmdline console strip / getty mask / hciuart). `bash -n` and the zero-network boot-script guard pass. 34 image-tooling tests green.

> **BENCH-VERIFY:** exact UART routing (mini-UART vs PL011, Pi 5 specifics) can't be validated without real hardware — worth confirming on the first-boot pass that `/dev/serial0` reads a wired GPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)