### PR TITLE
fix(runtime): don't start the runtime twice when HTTPS is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Runtime no longer starts twice when HTTPS is enabled.** The CLI serves the
+  same app over two uvicorn servers (HTTP + HTTPS), and each server runs the
+  FastAPI lifespan, so `Runtime.start()`/`stop()` were each called once **per
+  server** -- booting *everything* twice: two controller loops driving the motor,
+  two simulator physics loops, and two serial readers on one port (which crashed
+  with `readuntil() called while another coroutine is already waiting`, so a
+  `gps_source: serial` receiver never delivered data). `start()`/`stop()` are now
+  ref-counted: the runtime boots once and tears down only when the last server
+  stops.
+
 - **SD image frees the GPIO UART for a pin-wired GPS/compass.** By default the Pi
   keeps a login console on the serial port, so a GPS wired to the TX/RX pins
   (`/dev/serial0`) can't be read — the most common wired-GPS gotcha (and the exact

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -473,6 +473,15 @@ class Runtime:
         )
 
         self._tasks: list[asyncio.Task] = []
+        # Guard against starting the runtime more than once. The CLI serves the
+        # SAME app over two uvicorn servers (HTTP + HTTPS), and each server runs
+        # the FastAPI lifespan -> start()/stop() are each called once PER server.
+        # Without this, every subsystem ran twice: two controller loops driving
+        # the motor, two simulator loops, two serial readers on one port (the
+        # asyncio "readuntil() while another coroutine is already waiting" crash).
+        # Ref-counted so the first start() actually starts and the last stop()
+        # (when every server has shut down) actually tears down.
+        self._start_count = 0
         self.calibration = CalibrationRunner(self)
 
         # --- Named boat profiles (#75, #89): persisted, selectable spec bundles.
@@ -1631,6 +1640,14 @@ class Runtime:
     # Lifecycle
     # ------------------------------------------------------------------ #
     async def start(self) -> None:
+        # Idempotent across multiple server lifespans (HTTP + HTTPS share one
+        # Runtime): only the first start() boots the subsystems; later ones are
+        # no-ops so nothing (controller, simulator, serial readers) runs twice.
+        self._start_count += 1
+        if self._start_count > 1:
+            logger.debug("runtime start() ignored (already started, count=%d)",
+                         self._start_count)
+            return
         self.recorder.start()
         # Arm the external hardware watchdog (#44) before the supervisor begins
         # petting it. A no-op when disabled; a bad GPIO must not crash boot.
@@ -1685,6 +1702,14 @@ class Runtime:
         await self._hw._start_armed_connectors()
 
     async def stop(self) -> None:
+        # Mirror start()'s ref-count: tear down only when the LAST server that
+        # started us shuts down. A stop() with servers still running is a no-op.
+        if self._start_count > 0:
+            self._start_count -= 1
+        if self._start_count > 0:
+            logger.debug("runtime stop() deferred (%d server(s) still up)",
+                         self._start_count)
+            return
         # Stop the Web Push worker thread before task cleanup (best-effort).
         with contextlib.suppress(Exception):
             self.push.stop()

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -57,6 +57,33 @@ async def test_stop_closes_and_stops_serial_motor():
     assert "CMD 0 F 0" in transport.written
 
 
+async def test_start_stop_refcounted_for_dual_server_lifespan():
+    # The CLI serves ONE app over two uvicorn servers (HTTP + HTTPS), so the
+    # FastAPI lifespan runs twice -> start()/stop() are each called twice. The
+    # runtime must boot once (no double controller/simulator/serial-reader) and
+    # tear down only when the LAST server shuts down.
+    rt, transport, motor = _serial_motor_runtime()
+    await rt.start()
+    n_tasks = len(rt._tasks)
+    sim_task = rt._sim_task
+    assert transport.opened
+
+    await rt.start()                       # second server's lifespan
+    assert rt._start_count == 2
+    assert len(rt._tasks) == n_tasks        # no duplicate controller/sim/supervisor tasks
+    assert rt._sim_task is sim_task         # simulator not restarted
+
+    await rt.stop()                        # first server shuts down -> still up
+    assert rt._start_count == 1
+    assert not transport.closed             # motor still live
+    assert not sim_task.done()
+
+    await rt.stop()                        # last server shuts down -> real teardown
+    assert rt._start_count == 0
+    assert transport.closed
+    assert "CMD 0 F 0" in transport.written
+
+
 async def test_reload_devices_stops_old_motor():
     rt, transport, motor = _serial_motor_runtime()
     await rt.start()


### PR DESCRIPTION
## The bug you hit
`gps_source: serial` never delivered data — the `SerialGps` looped forever on:
```
read error (readuntil() called while another coroutine is already waiting for incoming data); reconnecting
```
That's **two `run()` coroutines on one asyncio `StreamReader`** — i.e. the reader started twice.

## Root cause (bigger than the reader)
The CLI serves **one** FastAPI app over **two** uvicorn servers — HTTP `:8000` and HTTPS `:8443` — via `asyncio.gather` (`runtime/cli.py`). Each `uvicorn.Server` runs the app's **lifespan**, and the lifespan calls `runtime.start()`/`stop()`. So with HTTPS enabled (the default), the whole runtime booted **twice**:
- **two controller loops both commanding the motor** (safety-relevant),
- two simulator physics loops,
- two serial readers on one port → the `readuntil` crash above.

Confirmed in the live log — doubled throughout:
```
runtime started                 (×2)
controller loop started         (×2)
simulator physics loop started  (×2)
Uvicorn running on http://…:8000
Uvicorn running on https://…:8443
```

## Fix
Ref-count `Runtime.start()`/`stop()`. The first `start()` boots the subsystems; the second server's lifespan is a no-op. `stop()` tears down only when the **last** server shuts down. Minimal and keeps the lifespan contract intact (so `TestClient`-based tests still start the runtime).

## Verified live (after fix)
`runtime started` ×1, `controller loop` ×1, `simulator loop` ×1, **0 `readuntil` errors**, and the M9N delivers a valid fix over `gps_source: serial`:
```
$GNRMC,071147.20,A,5942.38372,N,01208.84840,E,1.484,302.13,…,A*07   (11 sats)
```

+1 regression test (`start()`/`stop()` twice → one boot, teardown on last stop). Full lifecycle suite green; ruff clean.

## Follow-up (your other point)
Devices sharing one physical port (e.g. `gps` + `compass` both `serial` on the same `/dev` node) should share a single reader instead of each opening one. That's a separate improvement — filing it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)