### PR TITLE
fix(serial): share one reader when GPS + compass use the same port (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Devices on the same serial port now share one reader.** Configuring both the
+  GPS and the compass as `serial` on the same port (a combo NMEA source emitting
+  RMC/GGA + HDG) previously opened the port twice, so two readers split/garbled
+  the byte stream and published every sentence to the bus twice. The compass now
+  reuses the GPS reader when the ports match (symlinks resolved), and the serial
+  sensor's start()/stop() are idempotent so a shared reader opens exactly once.
+
 ## [1.5.0a13] — 2026-08-10
 
 - **Runtime no longer starts twice when HTTPS is enabled.** The CLI serves the

--- a/src/vanchor/hardware/serial_devices.py
+++ b/src/vanchor/hardware/serial_devices.py
@@ -369,14 +369,21 @@ class _SerialNmeaSensor(Sensor):
             return f"{cls}: debug error ({exc})"
 
     async def start(self) -> None:
+        # Idempotent. When one reader is SHARED across device slots (e.g. a GPS
+        # and compass on the SAME serial port -- a combo NMEA source), start() is
+        # called once per slot; only the first opens the port and spawns the read
+        # task, so a shared port never gets two readers on one stream.
+        if self._task is not None and not self._task.done():
+            return
         await self.transport.open()
         self._task = asyncio.ensure_future(self._sup.run())
 
     async def stop(self) -> None:
+        if self._task is None:
+            return  # never started, or a shared instance already stopped
         self._sup.request_stop()
-        if self._task is not None:
-            self._task.cancel()
-            self._task = None
+        self._task.cancel()
+        self._task = None
         await self.transport.close()
 
 

--- a/src/vanchor/runtime/devices.py
+++ b/src/vanchor/runtime/devices.py
@@ -21,6 +21,21 @@ _BUILTIN_TRANSPORT = {"sim": "none", "serial": "serial", "nmea": "none",
 _OPTION_REG_KIND = {"sensor": "depth"}
 
 
+def _same_serial_port(a: str | None, b: str | None) -> bool:
+    """True if two configured serial ports point at the same device -- exact
+    match, or the same target after resolving symlinks (e.g. /dev/ttyACM0 vs
+    /dev/serial/by-id/...)."""
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    try:
+        import os
+        return os.path.realpath(a) == os.path.realpath(b)
+    except Exception:  # noqa: BLE001 - realpath on a nonexistent path shouldn't crash
+        return False
+
+
 def _source_transports(options: dict, reg_transports: dict) -> dict:
     """``{option_key: {source: transport}}`` merging the built-in sources with the
     registry's per-driver transport, so the UI can show serial / I2C / no
@@ -420,6 +435,17 @@ class DeviceManager:
                     "compass source %r could not be built (%s); running without a "
                     "compass. Change it in Settings -> Devices.", src["compass"], exc)
                 compass = None
+        # Share ONE reader when the compass is a serial NMEA source on the SAME
+        # port as the serial GPS (a combo source emitting RMC/GGA + HDG). Two
+        # readers on one port double-read the stream and publish every line to
+        # events.NMEA_IN twice; both sensors are dumb pipes to that bus, so one
+        # reader feeds the navigator (GPS *and* compass sentences) for both slots.
+        if (src["gps"] == "serial" and src["compass"] == "serial"
+                and gps is not None and compass is not None
+                and _same_serial_port(cfg.hardware.gps_port, cfg.hardware.compass_port)):
+            compass = gps
+            logger.info("compass shares the GPS serial reader (same port %s)",
+                        cfg.hardware.gps_port)
         if src["depth"] == "sim":
             depth = SimDepthSounder(
                 simulator.truth,

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -16,7 +16,11 @@ from unittest.mock import patch
 
 from vanchor.app import Runtime
 from vanchor.core.config import load
-from vanchor.hardware.serial_devices import SerialMotorController
+from vanchor.hardware.serial_devices import (
+    SerialCompass,
+    SerialGps,
+    SerialMotorController,
+)
 from vanchor.hardware.serial_link import FakeSerialTransport
 
 
@@ -82,6 +86,29 @@ async def test_start_stop_refcounted_for_dual_server_lifespan():
     assert rt._start_count == 0
     assert transport.closed
     assert "CMD 0 F 0" in transport.written
+
+
+async def test_gps_and_compass_on_same_serial_port_share_one_reader():
+    # A combo NMEA source (RMC/GGA + HDG on one port) configured as both the
+    # serial GPS and the serial compass must open the port ONCE and read it with
+    # a single reader -- not two readers double-reading + double-publishing.
+    cfg = load(None)
+    cfg.hardware.gps_source = "serial"
+    cfg.hardware.compass_source = "serial"
+    cfg.hardware.gps_port = cfg.hardware.compass_port = "/dev/ttyTEST"
+    gtx, ctx = FakeSerialTransport(), FakeSerialTransport()
+    with patch.object(Runtime, "_build_serial_gps", lambda self, c: SerialGps(gtx, self.bus)), \
+         patch.object(Runtime, "_build_serial_compass", lambda self, c: SerialCompass(ctx, self.bus)):
+        rt = Runtime(cfg)
+    # Same port -> the compass slot reuses the GPS reader instance.
+    assert rt.gps is rt.compass
+    await rt.start()
+    try:
+        assert gtx.open_calls == 1   # the shared port opened exactly once...
+        assert ctx.open_calls == 0   # ...and the compass's own transport was never used
+    finally:
+        await rt.stop()
+    assert gtx.closed                # shared reader closed once, no double-close error
 
 
 async def test_reload_devices_stops_old_motor():


### PR DESCRIPTION
Closes #144.

A combo NMEA source (RMC/GGA + HDG on **one** serial port) configured as both the serial GPS **and** the serial compass built two separate reader instances, each opening its own transport on the same `/dev` node — so two readers split/garbled the byte stream and published every sentence to `events.NMEA_IN` **twice**.

## Fix
Both serial sensors are dumb pipes to `NMEA_IN` (the navigator parses GPS *and* compass sentences off that one topic), so **one reader suffices**. When the compass is `serial` on the **same port** as the serial GPS, the compass slot now **reuses the GPS reader instance** (ports compared with symlinks resolved, so `/dev/ttyACM0` ≡ `/dev/serial/by-id/…`).

To make one shared instance safe across the two device slots, `_SerialNmeaSensor.start()`/`stop()` are now **idempotent**: the first `start()` opens the port and spawns the read task; later ones (the second slot, or a `runtime.start()` re-entry) are no-ops — so a shared port never gets two readers on one stream.

Different ports → unchanged (independent readers).

+1 test: same-port gps+compass → one shared instance, port opened once, closed once. Serial + lifecycle suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)