### PR TITLE
feat: relay online fetches through a connected client when the boat is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **The boat now fetches online data through your phone when it has no internet.**
+  Calculating a route needs OpenStreetMap water data; the Pi (usually offline on
+  the water) tried to fetch it itself, failed, and the route silently died. A new
+  generic **client fetch relay** fixes this: the server tries its own internet
+  first (fast at the dock), and on failure flips a sticky offline switch and
+  relays the fetch to a connected client (phone/tablet) over the telemetry
+  WebSocket -- the client answers from its offline tile cache when it can, else
+  fetches with its own connection. Route planning, island loops, chart prefetch
+  and the water-clip overlay all use it. And these failures are no longer
+  silent: the route result carries a clear operator-facing message ("No internet
+  on the boat and no connected device could fetch..."), and the client shows an
+  'Online fetch failed' notification when its own fetch fails.
+
 ## [1.5.0a13] — 2026-08-10
 
 - **Runtime no longer starts twice when HTTPS is enabled.** The CLI serves the

--- a/src/vanchor/nav/water.py
+++ b/src/vanchor/nav/water.py
@@ -198,24 +198,39 @@ def assemble_water(elements: list[dict]) -> MultiPolygon:
 # Network fetch (lazy: never imported at module load, never hit in tests)
 # --------------------------------------------------------------------------- #
 def fetch_overpass(
-    south: float, west: float, north: float, east: float, *, timeout: float = 60.0
+    south: float, west: float, north: float, east: float, *, timeout: float = 60.0,
+    http_post=None,
 ) -> list[dict]:
-    """Fetch raw water elements from Overpass (tries endpoints in order)."""
-    import requests
+    """Fetch raw water elements from Overpass (tries endpoints in order).
+
+    ``http_post(url, body_bytes, headers) -> bytes`` is an injectable transport:
+    the runtime passes a client-fetch-relay-backed poster so an offline Pi can
+    fetch THROUGH a connected phone/tablet; ``None`` (the default) posts
+    directly with requests. A relay poster raising ``FetchRelayError`` aborts
+    immediately (retrying the other endpoint through the same dead relay can't
+    help and would double the operator's wait) -- its message is operator-facing
+    and propagates as-is."""
+    from urllib.parse import urlencode
 
     query = overpass_query(south, west, north, east)
+    body = urlencode({"data": query}).encode()
+    headers = {"User-Agent": user_agent(),
+               "Content-Type": "application/x-www-form-urlencoded"}
+
+    if http_post is None:
+        def http_post(url: str, body: bytes, headers: dict) -> bytes:  # noqa: F811
+            import requests
+            resp = requests.post(url, data=body, headers=headers, timeout=timeout)
+            resp.raise_for_status()
+            return resp.content
+
     last_exc: Exception | None = None
     for url in overpass_endpoints():
         try:
-            resp = requests.post(
-                url,
-                data={"data": query},
-                headers={"User-Agent": user_agent()},
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-            return resp.json().get("elements", [])
+            return json.loads(http_post(url, body, headers)).get("elements", [])
         except Exception as exc:  # pragma: no cover - network path
+            if type(exc).__name__ == "FetchRelayError":
+                raise  # relay failed: clear message, retrying can't help
             logger.warning("Overpass fetch from %s failed: %s", url, exc)
             last_exc = exc
     raise RuntimeError(f"all Overpass endpoints failed: {last_exc}")

--- a/src/vanchor/runtime/depth.py
+++ b/src/vanchor/runtime/depth.py
@@ -177,7 +177,9 @@ class DepthService:
                 "message": "Area already cached.",
             }
         try:
-            elements = water.fetch_overpass(*box)
+            from .fetch_relay import relay_http_post
+            elements = water.fetch_overpass(
+                *box, http_post=relay_http_post(getattr(rt, "fetch_relay", None)))
         except Exception as exc:  # network / endpoint failure
             logger.warning("chart prefetch fetch failed: %s", exc)
             return {

--- a/src/vanchor/runtime/fetch_relay.py
+++ b/src/vanchor/runtime/fetch_relay.py
@@ -1,0 +1,165 @@
+"""Generic online-fetch relay: fetch online data *through a connected client*
+when the boat's Pi has no internet of its own.
+
+The Pi is usually offline on the water, but the phone/tablet controlling it has
+internet (cellular). So any server code that needs an online resource -- the
+smart router's OpenStreetMap/Overpass water polygons, map tiles, a WMM update,
+... -- calls :meth:`FetchRelay.fetch` instead of hitting the network directly.
+
+Strategy (per the design):
+
+* **Try the server directly first**, with a short timeout -- fast when the Pi
+  *does* have internet (e.g. at the dock).
+* On a direct failure, flip a **sticky "offline" circuit breaker** so this and
+  the following fetches (e.g. every tile of one route) go **straight to the
+  relay** instead of each re-trying-and-timing-out the direct path.
+* **Relay** the request to connected clients over the telemetry WebSocket; the
+  first client to answer wins. The client checks its own cache first and only
+  hits the internet on a miss (that logic lives in the browser).
+
+This module is transport-agnostic and fully unit-testable: the WebSocket
+broadcast, the "is a client connected?" check, the direct fetch, the clock and
+the id generator are all injected.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger("vanchor.fetch_relay")
+
+
+class FetchRelayError(RuntimeError):
+    """An online fetch could not be completed -- directly *or* via a client.
+
+    Carries a human-readable message suitable for surfacing to the operator
+    (the whole point: these failures must never be silent)."""
+
+
+@dataclass
+class _Pending:
+    future: "asyncio.Future[bytes]"
+    url: str
+
+
+class FetchRelay:
+    def __init__(
+        self,
+        *,
+        broadcast: Callable[[dict], Awaitable[None]],
+        has_clients: Callable[[], bool],
+        direct_fetch: Callable[..., Awaitable[bytes]] | None = None,
+        clock: Callable[[], float] = None,  # type: ignore[assignment]
+        new_id: Callable[[], str] = None,   # type: ignore[assignment]
+        offline_ttl_s: float = 60.0,
+        relay_timeout_s: float = 30.0,
+        direct_timeout_s: float = 4.0,
+    ) -> None:
+        self._broadcast = broadcast
+        self._has_clients = has_clients
+        self._direct = direct_fetch or _default_direct_fetch
+        self._clock = clock or _monotonic
+        self._new_id = new_id or _rand_id
+        self._offline_ttl_s = offline_ttl_s
+        self._relay_timeout_s = relay_timeout_s
+        self._direct_timeout_s = direct_timeout_s
+        self._pending: dict[str, _Pending] = {}
+        self._offline_until: float = 0.0  # sticky-offline circuit-breaker deadline
+
+    # -- state (for telemetry / UI) -------------------------------------- #
+    @property
+    def offline(self) -> bool:
+        """True while the sticky circuit breaker is engaged (relaying, not
+        trying direct)."""
+        return self._clock() < self._offline_until
+
+    def _trip_offline(self) -> None:
+        self._offline_until = self._clock() + self._offline_ttl_s
+
+    # -- the public fetch ------------------------------------------------- #
+    async def fetch(self, url: str, *, method: str = "GET",
+                    headers: dict | None = None, body: bytes | None = None,
+                    timeout: float | None = None) -> bytes:
+        """Return the resource bytes, via a direct server fetch or (if offline)
+        by relaying through a connected client. Raises :class:`FetchRelayError`
+        with a clear message when neither can satisfy it."""
+        if not self.offline:
+            try:
+                return await asyncio.wait_for(
+                    self._direct(url, method=method, headers=headers, body=body),
+                    timeout=self._direct_timeout_s)
+            except Exception as exc:  # noqa: BLE001 - any direct failure -> go offline
+                logger.info("direct fetch of %s failed (%s); switching to client relay",
+                            url, exc)
+                self._trip_offline()
+        return await self._relay(url, method=method, headers=headers,
+                                 body=body, timeout=timeout)
+
+    async def _relay(self, url: str, *, method: str, headers: dict | None,
+                     body: bytes | None, timeout: float | None) -> bytes:
+        if not self._has_clients():
+            raise FetchRelayError(
+                "No internet on the boat and no connected device to fetch "
+                f"through (needed {url}).")
+        rid = self._new_id()
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[bytes] = loop.create_future()
+        self._pending[rid] = _Pending(fut, url)
+        msg: dict[str, Any] = {"type": "fetch_request", "id": rid, "url": url,
+                               "method": method}
+        if headers:
+            msg["headers"] = headers
+        if body is not None:
+            msg["body_b64"] = base64.b64encode(body).decode("ascii")
+        try:
+            await self._broadcast(msg)
+            return await asyncio.wait_for(fut, timeout or self._relay_timeout_s)
+        except asyncio.TimeoutError as exc:
+            raise FetchRelayError(
+                f"No connected device answered the fetch for {url} in time.") from exc
+        finally:
+            self._pending.pop(rid, None)
+
+    # -- called by the /api/relay result endpoint ------------------------ #
+    def resolve(self, request_id: str, *, ok: bool, data: bytes | None = None,
+                error: str | None = None) -> bool:
+        """Complete a pending relay request with the client's result. Returns
+        True if it matched a live pending request (a late/duplicate answer from a
+        second client returns False and is ignored)."""
+        pending = self._pending.get(request_id)
+        if pending is None or pending.future.done():
+            return False
+        if ok and data is not None:
+            pending.future.set_result(data)
+        else:
+            pending.future.set_exception(FetchRelayError(
+                error or f"The connected device could not fetch {pending.url}."))
+        return True
+
+
+# --------------------------------------------------------------------------- #
+# Defaults (kept out of __init__ so tests inject fakes)
+# --------------------------------------------------------------------------- #
+def _monotonic() -> float:
+    import time
+    return time.monotonic()
+
+
+def _rand_id() -> str:
+    import secrets
+    return secrets.token_hex(8)
+
+
+async def _default_direct_fetch(url: str, *, method: str = "GET",
+                                headers: dict | None = None,
+                                body: bytes | None = None) -> bytes:
+    """Blocking HTTP via requests, run in a thread so it never blocks the loop."""
+    def _do() -> bytes:
+        import requests
+        resp = requests.request(method, url, headers=headers, data=body, timeout=10.0)
+        resp.raise_for_status()
+        return resp.content
+    return await asyncio.to_thread(_do)

--- a/src/vanchor/runtime/fetch_relay.py
+++ b/src/vanchor/runtime/fetch_relay.py
@@ -68,6 +68,12 @@ class FetchRelay:
         self._direct_timeout_s = direct_timeout_s
         self._pending: dict[str, _Pending] = {}
         self._offline_until: float = 0.0  # sticky-offline circuit-breaker deadline
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Remember the event loop so :meth:`fetch_sync` can be called from
+        worker threads (the route planner runs in an executor)."""
+        self._loop = loop
 
     # -- state (for telemetry / UI) -------------------------------------- #
     @property
@@ -82,21 +88,45 @@ class FetchRelay:
     # -- the public fetch ------------------------------------------------- #
     async def fetch(self, url: str, *, method: str = "GET",
                     headers: dict | None = None, body: bytes | None = None,
-                    timeout: float | None = None) -> bytes:
+                    timeout: float | None = None,
+                    direct_timeout: float | None = None) -> bytes:
         """Return the resource bytes, via a direct server fetch or (if offline)
         by relaying through a connected client. Raises :class:`FetchRelayError`
-        with a clear message when neither can satisfy it."""
+        with a clear message when neither can satisfy it.
+
+        ``direct_timeout`` overrides the short default for sources that are
+        legitimately slow even when online (an Overpass query can take tens of
+        seconds server-side). An offline Pi usually fails FAST regardless (no
+        default route -> immediate "network unreachable"), so a longer direct
+        timeout doesn't delay the offline fallback in practice."""
         if not self.offline:
+            dt = direct_timeout if direct_timeout is not None else self._direct_timeout_s
             try:
                 return await asyncio.wait_for(
-                    self._direct(url, method=method, headers=headers, body=body),
-                    timeout=self._direct_timeout_s)
+                    self._direct(url, method=method, headers=headers, body=body,
+                                 timeout=dt),
+                    timeout=dt + 1.0)
             except Exception as exc:  # noqa: BLE001 - any direct failure -> go offline
                 logger.info("direct fetch of %s failed (%s); switching to client relay",
                             url, exc)
                 self._trip_offline()
         return await self._relay(url, method=method, headers=headers,
                                  body=body, timeout=timeout)
+
+    def fetch_sync(self, url: str, *, method: str = "GET",
+                   headers: dict | None = None, body: bytes | None = None,
+                   timeout: float | None = None,
+                   direct_timeout: float | None = None) -> bytes:
+        """Blocking :meth:`fetch` for WORKER THREADS (e.g. the route planner in
+        its executor). Must never be called from the event-loop thread."""
+        if self._loop is None:
+            raise FetchRelayError("fetch relay not started (no event loop bound)")
+        fut = asyncio.run_coroutine_threadsafe(
+            self.fetch(url, method=method, headers=headers, body=body,
+                       timeout=timeout, direct_timeout=direct_timeout),
+            self._loop)
+        outer = (timeout or self._relay_timeout_s) + (direct_timeout or self._direct_timeout_s) + 10.0
+        return fut.result(timeout=outer)
 
     async def _relay(self, url: str, *, method: str, headers: dict | None,
                      body: bytes | None, timeout: float | None) -> bytes:
@@ -155,11 +185,27 @@ def _rand_id() -> str:
 
 async def _default_direct_fetch(url: str, *, method: str = "GET",
                                 headers: dict | None = None,
-                                body: bytes | None = None) -> bytes:
+                                body: bytes | None = None,
+                                timeout: float = 10.0) -> bytes:
     """Blocking HTTP via requests, run in a thread so it never blocks the loop."""
     def _do() -> bytes:
         import requests
-        resp = requests.request(method, url, headers=headers, data=body, timeout=10.0)
+        resp = requests.request(method, url, headers=headers, data=body,
+                                timeout=timeout)
         resp.raise_for_status()
         return resp.content
     return await asyncio.to_thread(_do)
+
+
+def relay_http_post(relay: "FetchRelay | None", *, direct_timeout: float = 25.0,
+                    timeout: float = 90.0):
+    """An ``http_post(url, body, headers) -> bytes`` adapter for SYNC code
+    (``water.fetch_overpass``'s injectable seam), or ``None`` when no relay
+    exists so callers keep their direct default."""
+    if relay is None:
+        return None
+
+    def _post(url: str, body: bytes, headers: dict) -> bytes:
+        return relay.fetch_sync(url, method="POST", headers=headers, body=body,
+                                timeout=timeout, direct_timeout=direct_timeout)
+    return _post

--- a/src/vanchor/runtime/nav_glue.py
+++ b/src/vanchor/runtime/nav_glue.py
@@ -28,6 +28,25 @@ class NavGlue:
         self._rt = rt   # back-reference to Runtime for shared state
 
     # ------------------------------------------------------------------ #
+    # Online fetches (Overpass) through the client relay when offline
+    # ------------------------------------------------------------------ #
+    def _relay_post(self):
+        """The relay-backed ``http_post`` for ``water.fetch_overpass`` (tries the
+        server's own internet first, then a connected client), or ``None`` when
+        no relay is attached (tests / headless) so the direct default applies."""
+        from .fetch_relay import relay_http_post
+        return relay_http_post(getattr(self._rt, "fetch_relay", None))
+
+    @staticmethod
+    def _fetch_fail_message(exc: Exception) -> str:
+        """Operator-facing message for a failed water fetch. A FetchRelayError
+        already says exactly what went wrong (no internet + no client, client
+        couldn't fetch, timeout); anything else gets the generic offline hint."""
+        if type(exc).__name__ == "FetchRelayError":
+            return str(exc)
+        return "No offline chart for this area; connect once to download it."
+
+    # ------------------------------------------------------------------ #
     # Fusion calibration (still-capture system-ID; see nav.calibration)
     # ------------------------------------------------------------------ #
 
@@ -219,13 +238,13 @@ class NavGlue:
         water_ll = cache.find_covering(bbox)
         if water_ll is None:
             try:
-                elements = water.fetch_overpass(*bbox)
+                elements = water.fetch_overpass(*bbox, http_post=self._relay_post())
             except Exception as exc:  # network / endpoint failure
                 logger.warning("water fetch failed: %s", exc)
                 return {
                     "ok": False,
                     "waypoints": [],
-                    "message": "No offline chart for this area; connect once to download it.",
+                    "message": self._fetch_fail_message(exc),
                 }
             water_ll = water.assemble_water(elements)
             if water_ll.is_empty:
@@ -306,14 +325,14 @@ class NavGlue:
         water_ll = cache.find_covering(bbox)
         if water_ll is None:
             try:
-                elements = water.fetch_overpass(*bbox)
+                elements = water.fetch_overpass(*bbox, http_post=self._relay_post())
             except Exception as exc:  # network / endpoint failure
                 logger.warning("water fetch failed: %s", exc)
                 return {
                     "ok": False,
                     "waypoints": [],
                     "loop": True,
-                    "message": "No offline chart for this area; connect once to download it.",
+                    "message": self._fetch_fail_message(exc),
                 }
             water_ll = water.assemble_water(elements)
             if water_ll.is_empty:

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1493,7 +1493,9 @@ class Runtime:
         try:
             geom = cache.find_covering(wbbox)
             if geom is None:
-                geom = water.assemble_water(water.fetch_overpass(*wbbox))
+                from .fetch_relay import relay_http_post
+                _post = relay_http_post(getattr(self, "fetch_relay", None))
+                geom = water.assemble_water(water.fetch_overpass(*wbbox, http_post=_post))
                 if geom is not None and not geom.is_empty:
                     cache.store(wbbox, geom)
         except Exception as exc:  # noqa: BLE001 - network/parse; clip is optional

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -405,8 +405,27 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
                 logger.exception("broadcaster loop error — will retry")
                 await asyncio.sleep(1.0)
 
+    # --- Client fetch relay (#147): the offline Pi fetches online data (route
+    # water polygons, ...) THROUGH a connected client, which has internet. The
+    # relay broadcasts {type:"fetch_request"} over this same WS client set; the
+    # client answers on POST /api/relay/{id}.
+    from ..runtime.fetch_relay import FetchRelay
+
+    async def _relay_broadcast(msg: dict) -> None:
+        txt = json.dumps(msg)
+        for ws in list(clients):
+            try:
+                await asyncio.wait_for(ws.send_text(txt), timeout=2.0)
+            except Exception:  # noqa: BLE001 - drop a dead/wedged socket
+                clients.discard(ws)
+
+    fetch_relay = FetchRelay(
+        broadcast=_relay_broadcast, has_clients=lambda: bool(clients))
+    runtime.fetch_relay = fetch_relay  # nav/route code reaches it via the runtime
+
     @contextlib.asynccontextmanager
     async def lifespan(app: FastAPI):
+        fetch_relay.bind_loop(asyncio.get_running_loop())
         await runtime.start()
         task = asyncio.ensure_future(broadcaster())
         try:
@@ -1065,6 +1084,27 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
         """Serial ports detected on the host, so the UI can suggest them instead
         of the user hand-typing ``/dev/tty...`` (OpenPlotter-style auto-detect)."""
         return {"ports": runtime.list_serial_ports()}
+
+    # -- Client fetch relay result (#147) ---------------------------------- #
+    _RELAY_MAX_BYTES = 32 * 1024 * 1024  # defensive cap on a relayed resource
+
+    @app.post("/api/relay/{request_id}")
+    async def relay_result(request_id: str, request: _Request, ok: int = 1) -> dict:
+        """A client's answer to a ``fetch_request``: raw resource bytes on
+        success (``?ok=1``), or an error message body (``?ok=0``). Late/duplicate
+        answers (a second client) are ignored (``matched: false``)."""
+        data = await request.body()
+        if len(data) > _RELAY_MAX_BYTES:
+            matched = fetch_relay.resolve(
+                request_id, ok=False,
+                error=f"relayed resource too large ({len(data)} bytes)")
+        elif ok:
+            matched = fetch_relay.resolve(request_id, ok=True, data=data)
+        else:
+            matched = fetch_relay.resolve(
+                request_id, ok=False,
+                error=data.decode("utf-8", "replace")[:500] or None)
+        return {"ok": True, "matched": matched}
 
     # -- Hardware setup wizard endpoints (adoption pack #2) ---------------- #
     @app.get("/api/hw/scan")

--- a/src/vanchor/ui/static/core.js
+++ b/src/vanchor/ui/static/core.js
@@ -262,6 +262,10 @@ function _stopConfirmed(t) {
 VA.role = "observer";        // "helm" | "observer" — until the first role frame
 VA._phoneHandlers = [];
 VA.onPhoneSensors = (fn) => VA._phoneHandlers.push(fn);
+// Fetch-relay requests (#147): the offline boat asks THIS client (which has
+// internet) to fetch an online resource on its behalf. relay.js registers.
+VA._fetchRelayHandlers = [];
+VA.onFetchRequest = (fn) => VA._fetchRelayHandlers.push(fn);
 VA.helmPresent = false;      // is ANY client currently the helm?
 VA.clientCount = 1;          // number of connected clients
 VA.isHelm = function () { return VA.role === "helm"; };
@@ -397,6 +401,9 @@ VA.connect = function () {
       case "role": dispatchRole(t); return;      // multi-client role/presence (#24)
       case "phone_sensors":                       // phone-as-sensor feeder status
         (VA._phoneHandlers || []).forEach((fn) => { try { fn(t); } catch (e) { /* ignore */ } });
+        return;
+      case "fetch_request":                       // boat asks us to fetch online data (#147)
+        (VA._fetchRelayHandlers || []).forEach((fn) => { try { fn(t); } catch (e) { /* ignore */ } });
         return;
       case "role_denied":                        // command rejected: not the helm
         VA.logLine("⛔ " + (t.error || "observer — take the helm to command"));

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -1333,6 +1333,7 @@
   <script src="/static/vendor/leaflet/leaflet.js"></script>
   <script src="/static/vendor/uplot/uPlot.iife.min.js"></script>
   <script src="/static/core.js"></script>
+  <script src="/static/relay.js"></script>
   <script src="/static/haptics.js"></script>
   <script src="/static/sounds.js"></script>
   <script src="/static/map-core.js"></script>

--- a/src/vanchor/ui/static/relay.js
+++ b/src/vanchor/ui/static/relay.js
@@ -1,0 +1,70 @@
+/* Client fetch relay (#147): the boat's Pi usually has no internet, but THIS
+ * device (phone/tablet) does. When server code needs an online resource (the
+ * route planner's OpenStreetMap water data, map tiles, ...) it broadcasts
+ * {type:"fetch_request", id, url, method, headers?, body_b64?} over the
+ * telemetry WS; we fetch it on the boat's behalf and POST the bytes back to
+ * /api/relay/<id>. Cache-first: a tile we already hold in the offline
+ * IndexedDB cache is answered from there without touching the internet.
+ * Failures are reported back (the server surfaces a clear error) AND toasted
+ * here so the operator sees that the online fetch could not be completed. */
+(function () {
+  "use strict";
+  if (!window.VA || !VA.onFetchRequest) return;
+
+  function b64ToBytes(b64) {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+
+  async function postResult(id, ok, payload) {
+    try {
+      await fetch("/api/relay/" + encodeURIComponent(id) + "?ok=" + (ok ? 1 : 0), {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: payload,
+      });
+    } catch (e) { /* boat link dropped mid-relay — nothing more we can do */ }
+  }
+
+  async function handle(req) {
+    const id = req.id, url = req.url;
+    if (!id || !url) return;
+    // 1) Cache-first: the offline tile cache may already hold this exact URL
+    //    (only ever populated with GET-able tiles, so skip for POST bodies).
+    if ((req.method || "GET") === "GET" && VA.tileCache) {
+      try {
+        const hit = await VA.tileCache.get(url);
+        if (hit) {
+          await postResult(id, true, hit);   // Blob posts as-is
+          return;
+        }
+      } catch (e) { /* cache miss path below */ }
+    }
+    // 2) Fetch on the boat's behalf with this device's internet.
+    try {
+      const opts = { method: req.method || "GET" };
+      if (req.headers) opts.headers = req.headers;
+      if (req.body_b64) opts.body = b64ToBytes(req.body_b64);
+      const resp = await fetch(url, opts);
+      if (!resp.ok) throw new Error("HTTP " + resp.status + " from " + new URL(url).hostname);
+      const blob = await resp.blob();
+      await postResult(id, true, blob);
+      // Opportunistically warm the tile cache for GETs so the NEXT relay of the
+      // same URL (or the map itself) is answered offline.
+      if (opts.method === "GET" && VA.tileCache) {
+        try { VA.tileCache.put(url, blob); } catch (e) { /* best-effort */ }
+      }
+    } catch (e) {
+      const msg = "This device could not fetch " + url + " (" + (e && e.message || e) + ")";
+      await postResult(id, false, msg);
+      // The operator must SEE that the boat needed online data and this device
+      // couldn't provide it (offline-fetch failures were previously silent).
+      if (VA.toast) VA.toast("⚠ Online fetch failed: " + (e && e.message || e), { ttl: 6000 });
+      if (VA.logLine) VA.logLine("relay: " + msg);
+    }
+  }
+
+  VA.onFetchRequest((req) => { handle(req); });
+})();

--- a/src/vanchor/ui/static/sw.js
+++ b/src/vanchor/ui/static/sw.js
@@ -70,6 +70,7 @@ const SHELL = [
   "/static/icons/apple-touch-icon.png",
   // App scripts (every <script src="/static/*.js"> in index.html).
   "/static/core.js",
+  "/static/relay.js",
   "/static/haptics.js",
   "/static/sounds.js",
   "/static/map-core.js",

--- a/tests/test_fetch_relay.py
+++ b/tests/test_fetch_relay.py
@@ -125,3 +125,34 @@ async def test_relay_message_carries_method_and_body():
     assert msg["method"] == "POST" and "body_b64" in msg
     r.resolve("rid", ok=True, data=b"ok")
     await task
+
+
+async def test_fetch_sync_from_worker_thread():
+    # The route planner runs sync in an executor; fetch_sync must marshal onto
+    # the bound loop and return the relayed bytes.
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)
+    r.bind_loop(asyncio.get_running_loop())
+
+    def worker():
+        return r.fetch_sync("http://overpass/api", method="POST", body=b"q")
+
+    task = asyncio.ensure_future(asyncio.to_thread(worker))
+    await asyncio.sleep(0.05)                 # let the relay broadcast
+    assert r.sent[-1]["type"] == "fetch_request"
+    r.resolve("rid", ok=True, data=b"elements")
+    assert await task == b"elements"
+
+
+async def test_relay_http_post_adapter():
+    from vanchor.runtime.fetch_relay import relay_http_post
+    assert relay_http_post(None) is None      # no relay -> caller keeps direct
+
+    async def direct(url, **kw):
+        return b'{"elements": []}'
+    r = _relay(direct=direct)
+    r.bind_loop(asyncio.get_running_loop())
+    post = relay_http_post(r)
+    out = await asyncio.to_thread(post, "http://overpass", b"data=q", {"User-Agent": "t"})
+    assert out == b'{"elements": []}'

--- a/tests/test_fetch_relay.py
+++ b/tests/test_fetch_relay.py
@@ -1,0 +1,127 @@
+"""FetchRelay: direct-first, sticky-offline fallback to a client relay."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vanchor.runtime.fetch_relay import FetchRelay, FetchRelayError
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def now(self) -> float:
+        return self.t
+
+
+def _relay(*, direct=None, clients=True, clock=None, ids=None, **kw):
+    sent: list[dict] = []
+
+    async def broadcast(msg):
+        sent.append(msg)
+
+    r = FetchRelay(
+        broadcast=broadcast,
+        has_clients=lambda: clients,
+        direct_fetch=direct,
+        clock=(clock.now if clock else None),
+        new_id=(lambda: ids.pop(0)) if ids else (lambda: "rid"),
+        offline_ttl_s=100.0,
+        relay_timeout_s=0.2,
+        **kw,
+    )
+    r.sent = sent  # type: ignore[attr-defined]
+    return r
+
+
+async def test_direct_fetch_wins_when_online():
+    async def direct(url, **kw):
+        return b"from-server"
+    r = _relay(direct=direct)
+    assert await r.fetch("http://x") == b"from-server"
+    assert r.sent == []          # never relayed
+    assert r.offline is False
+
+
+async def test_direct_failure_trips_offline_then_relays():
+    calls = {"direct": 0}
+    clk = Clock()
+
+    async def direct(url, **kw):
+        calls["direct"] += 1
+        raise ConnectionError("no route to host")
+
+    r = _relay(direct=direct, clients=True, clock=clk, ids=["a", "b"])
+    # First fetch: direct fails -> trips offline -> relays; a client answers.
+    task = asyncio.ensure_future(r.fetch("http://tiles/1"))
+    await asyncio.sleep(0.02)
+    assert r.offline is True
+    assert r.sent[-1]["type"] == "fetch_request" and r.sent[-1]["id"] == "a"
+    assert r.resolve("a", ok=True, data=b"tile1")
+    assert await task == b"tile1"
+
+    # Second fetch (same batch): still offline -> goes STRAIGHT to relay, does
+    # NOT re-try the direct path.
+    task2 = asyncio.ensure_future(r.fetch("http://tiles/2"))
+    await asyncio.sleep(0.02)
+    assert calls["direct"] == 1          # direct not attempted again
+    assert r.sent[-1]["id"] == "b"
+    r.resolve("b", ok=True, data=b"tile2")
+    assert await task2 == b"tile2"
+
+
+async def test_relay_with_no_client_raises_clear_error():
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=False)
+    with pytest.raises(FetchRelayError) as ei:
+        await r.fetch("http://tiles/x")
+    assert "no connected device" in str(ei.value).lower()
+
+
+async def test_relay_timeout_raises_clear_error():
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)  # relay_timeout_s=0.2, never resolved
+    with pytest.raises(FetchRelayError) as ei:
+        await r.fetch("http://tiles/x")
+    assert "answer" in str(ei.value).lower()
+
+
+async def test_client_error_result_propagates_message():
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)
+    task = asyncio.ensure_future(r.fetch("http://tiles/x"))
+    await asyncio.sleep(0.02)
+    r.resolve("rid", ok=False, error="429 Too Many Requests")
+    with pytest.raises(FetchRelayError) as ei:
+        await task
+    assert "429" in str(ei.value)
+
+
+async def test_resolve_unknown_or_duplicate_is_ignored():
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)
+    assert r.resolve("nope", ok=True, data=b"x") is False   # unknown id
+    task = asyncio.ensure_future(r.fetch("http://tiles/x"))
+    await asyncio.sleep(0.02)
+    assert r.resolve("rid", ok=True, data=b"first") is True
+    assert r.resolve("rid", ok=True, data=b"second") is False  # late 2nd client
+    assert await task == b"first"
+
+
+async def test_relay_message_carries_method_and_body():
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)
+    task = asyncio.ensure_future(
+        r.fetch("http://overpass/api", method="POST", body=b"data=xyz"))
+    await asyncio.sleep(0.02)
+    msg = r.sent[-1]
+    assert msg["method"] == "POST" and "body_b64" in msg
+    r.resolve("rid", ok=True, data=b"ok")
+    await task

--- a/tests/test_fetch_relay_api.py
+++ b/tests/test_fetch_relay_api.py
@@ -1,0 +1,76 @@
+"""The /api/relay/{id} result endpoint (client answers a fetch_request)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from vanchor.app import Runtime
+from vanchor.core.config import load
+from vanchor.ui.server import create_app
+
+
+def test_relay_result_unknown_id_reports_unmatched(tmp_path):
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    with TestClient(create_app(Runtime(cfg))) as c:
+        # No pending request -> matched false (a late/duplicate client answer).
+        r = c.post("/api/relay/nope?ok=1", content=b"data")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True, "matched": False}
+        # Error-shaped answer for an unknown id is equally ignored.
+        r = c.post("/api/relay/nope?ok=0", content=b"HTTP 429")
+        assert r.json() == {"ok": True, "matched": False}
+
+
+def test_runtime_gets_a_fetch_relay(tmp_path):
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    with TestClient(create_app(rt)) as c:  # noqa: F841 - lifespan binds the loop
+        assert getattr(rt, "fetch_relay", None) is not None
+        assert rt.fetch_relay.offline is False
+
+
+def test_relay_end_to_end_over_websocket(tmp_path):
+    """Full pipeline: an offline server relays a fetch to a WS client, the
+    client answers on POST /api/relay/<id>, and the (executor-side) fetch_sync
+    caller gets the bytes."""
+    import json
+    import threading
+
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    with TestClient(create_app(rt)) as c:
+        relay = rt.fetch_relay
+
+        async def failing_direct(url, **kw):        # the boat has no internet
+            raise ConnectionError("network unreachable")
+        relay._direct = failing_direct
+
+        result: dict = {}
+
+        def worker():                               # the route planner's thread
+            try:
+                result["data"] = relay.fetch_sync("http://overpass/api",
+                                                  method="POST", body=b"data=q")
+            except Exception as exc:  # noqa: BLE001
+                result["error"] = exc
+
+        with c.websocket_connect("/ws") as ws:
+            t = threading.Thread(target=worker)
+            t.start()
+            req = None
+            for _ in range(50):                     # skip role/telemetry frames
+                msg = json.loads(ws.receive_text())
+                if msg.get("type") == "fetch_request":
+                    req = msg
+                    break
+            assert req is not None, "no fetch_request arrived on the WS"
+            assert req["url"] == "http://overpass/api"
+            assert req["method"] == "POST" and "body_b64" in req
+            # The client (this test) fetches with ITS internet and answers.
+            r = c.post(f"/api/relay/{req['id']}?ok=1", content=b'{"elements":[]}')
+            assert r.json() == {"ok": True, "matched": True}
+            t.join(timeout=10)
+        assert result.get("data") == b'{"elements":[]}'
+        assert relay.offline is True                # circuit breaker tripped

--- a/tests/test_water_http_post_seam.py
+++ b/tests/test_water_http_post_seam.py
@@ -1,0 +1,60 @@
+"""water.fetch_overpass's injectable http_post seam (the client-fetch relay
+hook) -- no network, no shapely geometry needed."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vanchor.nav import water
+from vanchor.runtime.fetch_relay import FetchRelayError
+
+
+def test_fetch_overpass_uses_injected_poster(monkeypatch):
+    calls = []
+
+    def post(url, body, headers):
+        calls.append((url, bytes(body), dict(headers)))
+        return json.dumps({"elements": [{"type": "way", "id": 1}]}).encode()
+
+    out = water.fetch_overpass(59.0, 12.0, 59.1, 12.1, http_post=post)
+    assert out == [{"type": "way", "id": 1}]
+    assert len(calls) == 1                          # first endpoint succeeded
+    url, body, headers = calls[0]
+    assert url in water.overpass_endpoints()
+    assert b"data=" in body                          # form-encoded query
+    assert "User-Agent" in headers
+
+
+def test_fetch_overpass_tries_next_endpoint_on_generic_failure():
+    calls = []
+
+    def post(url, body, headers):
+        calls.append(url)
+        if len(calls) == 1:
+            raise OSError("endpoint down")
+        return b'{"elements": []}'
+
+    assert water.fetch_overpass(59.0, 12.0, 59.1, 12.1, http_post=post) == []
+    assert len(calls) == 2                           # fell through to endpoint 2
+
+
+def test_fetch_overpass_relay_error_aborts_immediately():
+    # A FetchRelayError means "no internet AND no client could fetch" -- trying
+    # the second Overpass endpoint through the same dead relay cannot help.
+    calls = []
+
+    def post(url, body, headers):
+        calls.append(url)
+        raise FetchRelayError("No internet on the boat and no connected device")
+
+    with pytest.raises(FetchRelayError):
+        water.fetch_overpass(59.0, 12.0, 59.1, 12.1, http_post=post)
+    assert len(calls) == 1                           # no pointless retry
+
+
+def test_fetch_fail_message_prefers_relay_error():
+    from vanchor.runtime.nav_glue import NavGlue
+    assert "no connected device" in NavGlue._fetch_fail_message(
+        FetchRelayError("No internet on the boat and no connected device")).lower()
+    assert "offline chart" in NavGlue._fetch_fail_message(OSError("boom")).lower()


### PR DESCRIPTION
**Bug:** "Calculate route" → the smart router needs OpenStreetMap/Overpass water polygons (`nav/water.py:fetch_overpass`) → the offline Pi's direct fetch fails, the route silently dies, and nothing surfaces to the user. Map tiles / any future online source are the same class of problem.

**Fix:** a generic **client fetch relay** — when the Pi has no internet, delegate the online fetch to a connected client (which has internet), as generically as possible.

Draft: **server core done + tested**; WS/client/integration to follow.

## Design (agreed)
- **Direct-first, quick fallback:** try the Pi's own fetch (short timeout — fast at the dock); on failure flip a **sticky "offline" circuit breaker** so this *and the following* fetches (every tile of one route) relay immediately instead of re-trying the direct path each time.
- **Relay over the telemetry WebSocket:** server sends `{type:"fetch_request", id, url, method, …}`; the client fetches and POSTs the bytes back to `/api/relay/<id>`. First client to answer wins.
- **Client-cache-first:** the client returns a tile it already has (IndexedDB, `offline.js`) instead of hitting the internet.
- **No URL allowlist** (the server picks the URL; it's your own boat server).
- **Clear errors (your 2nd note):** relay failures raise `FetchRelayError` with an operator-facing message; the client shows a **notification** ("No internet on the boat and no connected device could fetch the water data"). Ties into #142.

## Done
- [x] `runtime/fetch_relay.py` — `FetchRelay` (direct-first, sticky-offline, relay, `resolve`), `FetchRelayError`. +7 tests.

## To do
- [ ] Wire into the WS server: `broadcast` + `has_clients` from the client set; own the relay on `Runtime`.
- [ ] `POST /api/relay/<id>` result endpoint → `relay.resolve(...)`.
- [ ] Client `relay.js`: handle `fetch_request` → **cache-first** (IndexedDB) → fetch → POST back; report errors.
- [ ] `nav/water.py` (+ route endpoint) use `relay.fetch` instead of direct `requests`.
- [ ] Error notification UX on failure (toast/alert); surface relay "offline" state.
- [ ] Docs + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)