### PR TITLE
fix(relay): fail over between Overpass endpoints on a relayed target error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Relayed fetches now fail over between Overpass endpoints.** When the online
+  fetch went through a connected client and the first OpenStreetMap/Overpass
+  endpoint answered with an error (e.g. HTTP 504 under load), the route planner
+  gave up instead of trying the second endpoint like the direct path does. A
+  client-reported *target* failure is now distinguished from a relay failure
+  (no client / no answer): target errors fail over to the next endpoint through
+  the same relay; relay failures still abort immediately with a clear message.
+
 ## [1.5.0a14] — 2026-08-10
 
 - **The boat now fetches online data through your phone when it has no internet.**

--- a/src/vanchor/nav/water.py
+++ b/src/vanchor/nav/water.py
@@ -206,10 +206,14 @@ def fetch_overpass(
     ``http_post(url, body_bytes, headers) -> bytes`` is an injectable transport:
     the runtime passes a client-fetch-relay-backed poster so an offline Pi can
     fetch THROUGH a connected phone/tablet; ``None`` (the default) posts
-    directly with requests. A relay poster raising ``FetchRelayError`` aborts
-    immediately (retrying the other endpoint through the same dead relay can't
-    help and would double the operator's wait) -- its message is operator-facing
-    and propagates as-is."""
+    directly with requests.
+
+    Relay error handling: a base ``FetchRelayError`` (no client connected / no
+    answer) aborts immediately -- retrying the other endpoint through the same
+    dead relay can't help and would double the operator's wait. But a
+    ``FetchRelayTargetError`` (the client answered; the TARGET failed, e.g.
+    Overpass 504 under load) falls through to the next endpoint, preserving the
+    same failover the direct path has. Operator-facing messages propagate."""
     from urllib.parse import urlencode
 
     query = overpass_query(south, west, north, east)
@@ -228,11 +232,16 @@ def fetch_overpass(
     for url in overpass_endpoints():
         try:
             return json.loads(http_post(url, body, headers)).get("elements", [])
-        except Exception as exc:  # pragma: no cover - network path
+        except Exception as exc:
+            # Exact-name check on purpose (no runtime import): the TargetError
+            # subclass has a different __name__ and so falls through to the
+            # next-endpoint retry below.
             if type(exc).__name__ == "FetchRelayError":
-                raise  # relay failed: clear message, retrying can't help
+                raise  # relay itself is dead: clear message, retrying can't help
             logger.warning("Overpass fetch from %s failed: %s", url, exc)
             last_exc = exc
+    if type(last_exc).__name__ == "FetchRelayTargetError":
+        raise last_exc  # keep the operator-facing relay message intact
     raise RuntimeError(f"all Overpass endpoints failed: {last_exc}")
 
 

--- a/src/vanchor/runtime/fetch_relay.py
+++ b/src/vanchor/runtime/fetch_relay.py
@@ -39,6 +39,14 @@ class FetchRelayError(RuntimeError):
     (the whole point: these failures must never be silent)."""
 
 
+class FetchRelayTargetError(FetchRelayError):
+    """The relay pipeline WORKED -- a client answered -- but the *target*
+    failed (e.g. Overpass replied HTTP 504 under load). Distinct from the base
+    class so callers with alternative targets (the second Overpass endpoint)
+    know retrying a DIFFERENT url through the same relay is worthwhile, whereas
+    a base FetchRelayError (no client / no answer) makes any retry pointless."""
+
+
 @dataclass
 class _Pending:
     future: "asyncio.Future[bytes]"
@@ -165,7 +173,9 @@ class FetchRelay:
         if ok and data is not None:
             pending.future.set_result(data)
         else:
-            pending.future.set_exception(FetchRelayError(
+            # The client DID answer -- the target itself failed (504, DNS, ...).
+            # TargetError so callers with alternative targets can fail over.
+            pending.future.set_exception(FetchRelayTargetError(
                 error or f"The connected device could not fetch {pending.url}."))
         return True
 

--- a/src/vanchor/runtime/nav_glue.py
+++ b/src/vanchor/runtime/nav_glue.py
@@ -40,9 +40,11 @@ class NavGlue:
     @staticmethod
     def _fetch_fail_message(exc: Exception) -> str:
         """Operator-facing message for a failed water fetch. A FetchRelayError
-        already says exactly what went wrong (no internet + no client, client
-        couldn't fetch, timeout); anything else gets the generic offline hint."""
-        if type(exc).__name__ == "FetchRelayError":
+        (incl. the TargetError subclass -- e.g. every Overpass endpoint 504'd
+        through the client) already says exactly what went wrong; anything else
+        gets the generic offline hint."""
+        from .fetch_relay import FetchRelayError
+        if isinstance(exc, FetchRelayError):
             return str(exc)
         return "No offline chart for this area; connect once to download it."
 

--- a/tests/test_fetch_relay.py
+++ b/tests/test_fetch_relay.py
@@ -156,3 +156,23 @@ async def test_relay_http_post_adapter():
     post = relay_http_post(r)
     out = await asyncio.to_thread(post, "http://overpass", b"data=q", {"User-Agent": "t"})
     assert out == b'{"elements": []}'
+
+
+async def test_client_error_raises_target_subclass():
+    # A client-reported failure means the relay pipeline worked -- the TARGET
+    # failed. Callers distinguish it (endpoint failover) via the subclass.
+    from vanchor.runtime.fetch_relay import FetchRelayTargetError
+
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True)
+    task = asyncio.ensure_future(r.fetch("http://overpass/api"))
+    await asyncio.sleep(0.02)
+    r.resolve("rid", ok=False, error="HTTP 504 from overpass-api.de")
+    with pytest.raises(FetchRelayTargetError):
+        await task
+    # Infra failures stay the BASE class (no-client case).
+    r2 = _relay(direct=direct, clients=False)
+    with pytest.raises(FetchRelayError) as ei:
+        await r2.fetch("http://x")
+    assert not isinstance(ei.value, FetchRelayTargetError)

--- a/tests/test_water_http_post_seam.py
+++ b/tests/test_water_http_post_seam.py
@@ -58,3 +58,41 @@ def test_fetch_fail_message_prefers_relay_error():
     assert "no connected device" in NavGlue._fetch_fail_message(
         FetchRelayError("No internet on the boat and no connected device")).lower()
     assert "offline chart" in NavGlue._fetch_fail_message(OSError("boom")).lower()
+
+
+def test_fetch_overpass_target_error_fails_over_to_next_endpoint():
+    # The client relayed fine but Overpass endpoint 1 replied 504: that is a
+    # TARGET failure -- the second endpoint is a different target, so the
+    # failover the direct path has must be preserved through the relay.
+    from vanchor.runtime.fetch_relay import FetchRelayTargetError
+    calls = []
+
+    def post(url, body, headers):
+        calls.append(url)
+        if len(calls) == 1:
+            raise FetchRelayTargetError("HTTP 504 from overpass-api.de")
+        return b'{"elements": [{"type": "way", "id": 2}]}'
+
+    out = water.fetch_overpass(59.0, 12.0, 59.1, 12.1, http_post=post)
+    assert out == [{"type": "way", "id": 2}]
+    assert len(calls) == 2                       # endpoint 2 tried and won
+
+
+def test_fetch_overpass_all_targets_fail_keeps_relay_message():
+    # Every endpoint 504'd through the client: the raised error keeps the
+    # operator-facing relay message (not a generic RuntimeError wrap).
+    from vanchor.runtime.fetch_relay import FetchRelayTargetError
+
+    def post(url, body, headers):
+        raise FetchRelayTargetError("HTTP 504 from " + url)
+
+    with pytest.raises(FetchRelayTargetError) as ei:
+        water.fetch_overpass(59.0, 12.0, 59.1, 12.1, http_post=post)
+    assert "504" in str(ei.value)
+
+
+def test_fetch_fail_message_covers_target_subclass():
+    from vanchor.runtime.fetch_relay import FetchRelayTargetError
+    from vanchor.runtime.nav_glue import NavGlue
+    msg = NavGlue._fetch_fail_message(FetchRelayTargetError("HTTP 504 from overpass-api.de"))
+    assert "504" in msg


### PR DESCRIPTION
**Reported:** HTTP 504 when fetching through the client.

## Cause
The public Overpass endpoints 504 under load. The **direct** path handles that by trying the second endpoint; but through the **relay**, a client-reported failure raised the same `FetchRelayError` that `water.fetch_overpass` treats as "the relay is dead — abort". So a single 504 from `overpass-api.de` killed the route plan without ever trying `overpass.kumi.systems`.

## Fix — distinguish the two failure classes
- **`FetchRelayTargetError` (new subclass):** the relay pipeline *worked* — a client answered — but the **target** failed (504/DNS/…). `resolve(ok=False)` raises this now. `fetch_overpass` lets it **fail over to the next endpoint** through the same relay (identical to direct-path behavior), and if *every* endpoint fails, the operator-facing message ("HTTP 504 from …") is preserved instead of a generic wrap.
- **`FetchRelayError` (base):** relay infrastructure failed (no client connected / no answer in time). Still **aborts immediately** — retrying another endpoint through a dead relay only doubles the wait.

`nav_glue._fetch_fail_message` now matches by `isinstance` so the 504 message surfaces verbatim in the route result.

+4 tests. Full suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)