### PR TITLE
fix(relay): stop per-viewport water-clip from relaying + coalesce identical fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Map panning no longer hammers the phone/Overpass (link-loss fix).** The
+  water-clip lookup behind the depth overlays fires on every map pan/zoom, and
+  since the client fetch relay it was relayed through the phone whenever the Pi
+  was offline -- flooding Overpass (HTTP 429/504), stalling the server, and
+  saturating the boat link (perceived link loss / paused data link). The
+  per-viewport clip is now direct-only again (offline it fails fast and the
+  overlay renders unclipped until the area is prefetched); only one-shot,
+  user-initiated actions (route planning, island loops, chart prefetch) go
+  through the relay. Identical concurrent relayed requests now also coalesce
+  into a single fetch instead of stampeding the client.
+
 ## [1.5.0a15] — 2026-08-10
 
 - **Relayed fetches now fail over between Overpass endpoints.** When the online

--- a/src/vanchor/runtime/fetch_relay.py
+++ b/src/vanchor/runtime/fetch_relay.py
@@ -75,6 +75,9 @@ class FetchRelay:
         self._relay_timeout_s = relay_timeout_s
         self._direct_timeout_s = direct_timeout_s
         self._pending: dict[str, _Pending] = {}
+        # Identical concurrent requests coalesce onto one relayed fetch:
+        # (url, method, body) -> the pending entry whose future they share.
+        self._inflight: dict[tuple, _Pending] = {}
         self._offline_until: float = 0.0  # sticky-offline circuit-breaker deadline
         self._loop: asyncio.AbstractEventLoop | None = None
 
@@ -142,10 +145,22 @@ class FetchRelay:
             raise FetchRelayError(
                 "No internet on the boat and no connected device to fetch "
                 f"through (needed {url}).")
+        # Coalesce identical in-flight requests: concurrent callers wanting the
+        # SAME resource (a viewport burst, parallel tile loops) share ONE relayed
+        # request instead of stampeding the client and the target (429s).
+        key = (url, method, body)
+        existing = self._inflight.get(key)
+        if existing is not None and not existing.future.done():
+            # shield: a secondary awaiter timing out must not cancel the shared
+            # future out from under the primary (or other) awaiters.
+            return await asyncio.wait_for(asyncio.shield(existing.future),
+                                          timeout or self._relay_timeout_s)
         rid = self._new_id()
         loop = asyncio.get_event_loop()
         fut: asyncio.Future[bytes] = loop.create_future()
-        self._pending[rid] = _Pending(fut, url)
+        pending = _Pending(fut, url)
+        self._pending[rid] = pending
+        self._inflight[key] = pending
         msg: dict[str, Any] = {"type": "fetch_request", "id": rid, "url": url,
                                "method": method}
         if headers:
@@ -160,6 +175,8 @@ class FetchRelay:
                 f"No connected device answered the fetch for {url} in time.") from exc
         finally:
             self._pending.pop(rid, None)
+            if self._inflight.get(key) is pending:
+                self._inflight.pop(key, None)
 
     # -- called by the /api/relay result endpoint ------------------------ #
     def resolve(self, request_id: str, *, ok: bool, data: bytes | None = None,

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1493,9 +1493,14 @@ class Runtime:
         try:
             geom = cache.find_covering(wbbox)
             if geom is None:
-                from .fetch_relay import relay_http_post
-                _post = relay_http_post(getattr(self, "fetch_relay", None))
-                geom = water.assemble_water(water.fetch_overpass(*wbbox, http_post=_post))
+                # DIRECT fetch only -- deliberately NOT through the client relay.
+                # This endpoint fires PER VIEWPORT (every map pan/zoom); relaying
+                # it hammered Overpass through the phone (429/504), stalled
+                # executors, and saturated the boat link. The clip is optional
+                # decoration: offline it fails fast here and the overlay simply
+                # renders unclipped until the area is prefetched (chart prefetch
+                # / route plan DO use the relay -- one-shot, user-initiated).
+                geom = water.assemble_water(water.fetch_overpass(*wbbox))
                 if geom is not None and not geom.is_empty:
                     cache.store(wbbox, geom)
         except Exception as exc:  # noqa: BLE001 - network/parse; clip is optional

--- a/tests/test_fetch_relay.py
+++ b/tests/test_fetch_relay.py
@@ -176,3 +176,23 @@ async def test_client_error_raises_target_subclass():
     with pytest.raises(FetchRelayError) as ei:
         await r2.fetch("http://x")
     assert not isinstance(ei.value, FetchRelayTargetError)
+
+
+async def test_identical_concurrent_requests_coalesce_to_one_broadcast():
+    # A viewport burst asking for the SAME resource must produce ONE relayed
+    # request; all callers share the answer (no client/target stampede -> 429s).
+    async def direct(url, **kw):
+        raise ConnectionError("offline")
+    r = _relay(direct=direct, clients=True, ids=["only", "other"])
+    t1 = asyncio.ensure_future(r.fetch("http://overpass/api", method="POST", body=b"q"))
+    await asyncio.sleep(0.02)
+    t2 = asyncio.ensure_future(r.fetch("http://overpass/api", method="POST", body=b"q"))
+    t3 = asyncio.ensure_future(r.fetch("http://overpass/api", method="POST", body=b"DIFFERENT"))
+    await asyncio.sleep(0.02)
+    reqs = [m for m in r.sent if m["type"] == "fetch_request"]
+    assert len(reqs) == 2                      # q coalesced; DIFFERENT separate
+    r.resolve("only", ok=True, data=b"shared")
+    assert await t1 == b"shared"
+    assert await t2 == b"shared"               # coalesced caller shares the answer
+    with pytest.raises(FetchRelayError):       # its own request timed out (0.2 s)
+        await t3

--- a/tests/test_water_http_post_seam.py
+++ b/tests/test_water_http_post_seam.py
@@ -96,3 +96,26 @@ def test_fetch_fail_message_covers_target_subclass():
     from vanchor.runtime.nav_glue import NavGlue
     msg = NavGlue._fetch_fail_message(FetchRelayTargetError("HTTP 504 from overpass-api.de"))
     assert "504" in msg
+
+
+def test_viewport_water_clip_never_uses_the_relay(tmp_path, monkeypatch):
+    # /api/depth/water fires per viewport (every pan/zoom). It must fetch
+    # DIRECT-only -- relaying it hammered Overpass through the phone (429/504)
+    # and saturated the boat link. Offline it fails fast; the clip is optional.
+    from vanchor.app import Runtime
+    from vanchor.core.config import load
+
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    rt.fetch_relay = object()   # a relay EXISTS; water_polygon must not use it
+    seen = {}
+
+    def fake_fetch(*bbox, http_post=None, **kw):
+        seen["http_post"] = http_post
+        raise OSError("offline")
+
+    monkeypatch.setattr(water, "fetch_overpass", fake_fetch)
+    out = rt.water_polygon((12.0, 59.0, 12.1, 59.1))
+    assert out == {"ok": False, "water": []}   # fail-fast, clip skipped
+    assert seen["http_post"] is None            # direct-only: relay untouched


### PR DESCRIPTION
**Reported (real Pi):** tile fetching misbehaving — link loss while fetching, HTTP 429/504; data link pauses blocked the bundle update.

## Root cause
`GET /api/depth/water` (the optional water-clip behind the depth overlays) fires on **every map pan/zoom**. Since #147, `runtime.water_polygon` relayed through the phone whenever the Pi was offline — so each viewport change pushed an Overpass query through the phone: upstream rate-limits (429) and gateway timeouts (504), executor threads blocked for the full relay timeout, and the AP link saturated → the "paused data link".

## Fix
- **Per-viewport water-clip is direct-only again** (pre-#147 behavior): offline it fails fast and the overlay renders unclipped until the area is prefetched. The relay remains for **one-shot, user-initiated** actions only — route plan, island loop, chart prefetch.
- **Relay coalescing:** identical concurrent requests (url+method+body) share **one** relayed fetch instead of stampeding the client/target.
- Client map tiles were already cache-first ("use what's on screen first") — unchanged and unaffected.

## Boot question (from the same report)
The relay does nothing at startup — constructed inertly, acts only on demand — so **no-internet cannot crash boot** from this code. If the a15 image still doesn't launch vanchor, that's a separate problem: need `journalctl -u vanchor-supervisor` / `docker ps` from the Pi.

+2 tests. Full suite **2286 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)