### PR TITLE
fix(land-guard): stop reloading the water chart every 20 s (event-loop stall)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Fixed the periodic "data stale" / WS drops around "land guard: water chart
+  loaded".** The land guard's chart refresh re-parsed the cached water chart
+  (WKB) and re-handed the full geometry to the safety governor **every 20 s**,
+  on the event loop -- with a big imported chart that's a repeating multi-hundred
+  ms stall that froze telemetry and dropped the WebSocket, in sync with that log
+  line. And when the boat was *outside* any cached chart, the throttle was
+  bypassed entirely -- a full cache re-scan at 1 Hz. Now: while covered, nothing
+  reloads (the chart is already in the governor); while uncovered, retry attempts
+  are throttled to the 20 s cadence.
+
 ## [1.5.0a16] — 2026-08-10
 
 - **Map panning no longer hammers the phone/Overpass (link-loss fix).** The

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1167,7 +1167,19 @@ class Runtime:
         bb = self._land_water_bbox
         inside = (bb is not None and
                   bb[0] <= pos.lat <= bb[2] and bb[1] <= pos.lon <= bb[3])
-        if now < self._land_water_next and inside and gov.has_water_geometry:
+        if inside and gov.has_water_geometry:
+            # Covered: nothing to (re)load. The old guard fell through here
+            # whenever the 20 s timer expired, re-parsing the cached chart (WKB)
+            # and re-handing the whole geometry to the governor ON the event
+            # loop every 20 s -- on a big chart a periodic multi-hundred-ms
+            # stall ("data stale" + WS drops correlating with the "water chart
+            # loaded" log line). Just keep the retry timer fresh.
+            self._land_water_next = now + 20.0
+            return False
+        if now < self._land_water_next:
+            # Throttle (re)load ATTEMPTS. The old guard required `inside` here,
+            # so a boat OUTSIDE any cached chart re-scanned the whole cache at
+            # the full supervisor rate (1 Hz) -- same event-loop stall.
             return False
         self._land_water_next = now + 20.0
         try:

--- a/tests/test_land_guard.py
+++ b/tests/test_land_guard.py
@@ -145,3 +145,61 @@ def test_guard_cut_does_not_freeze_the_probe_direction():
     cmd, status = _govern(gov, st, thrust=-0.4)  # commanding reverse (away)
     assert not status.land_stop
     assert cmd.thrust != 0.0
+
+
+# --- refresh_land_guard_water reload cadence (event-loop stall regression) --- #
+
+def _refresh_rt(tmp_path, monkeypatch):
+    """A sim Runtime with a controllable clock and a counting WaterCache."""
+    from vanchor.app import Runtime
+    from vanchor.core.config import load as _load
+    from vanchor.core.models import GeoPoint, GpsFix
+    from vanchor.nav import water as _water
+
+    cfg = _load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    rt.controller.safety.config.land_guard_enabled = True
+    rt.state.fix = GpsFix(point=GeoPoint(59.66, 13.32), valid=True)
+    clock = {"t": 1000.0}
+    rt._mono_fn = lambda: clock["t"]
+    calls = {"n": 0}
+
+    def counting_find(self, bbox):
+        calls["n"] += 1
+        return None                      # nothing cached
+
+    monkeypatch.setattr(_water.WaterCache, "find_covering", counting_find)
+    return rt, clock, calls
+
+
+def test_covered_boat_never_reloads_the_chart(tmp_path, monkeypatch):
+    # Regression: with the chart loaded and the boat inside the trigger box, the
+    # 20 s timer used to force a FULL cache re-parse + geometry hand-off every
+    # expiry -- a periodic event-loop stall ("data stale" + WS drops). Covered
+    # must mean NO reload, ever.
+    from shapely.geometry import MultiPolygon, Polygon
+    rt, clock, calls = _refresh_rt(tmp_path, monkeypatch)
+    rt.controller.safety.set_water_geometry(
+        MultiPolygon([Polygon([(13.0, 59.5), (13.6, 59.5), (13.6, 59.8), (13.0, 59.8)])]))
+    rt._land_water_bbox = (59.6, 13.2, 59.7, 13.4)   # boat inside
+    for k in range(10):
+        clock["t"] += 25.0                            # every timer expiry
+        assert rt.refresh_land_guard_water() is False
+    assert calls["n"] == 0                            # cache never touched
+
+
+def test_uncovered_boat_throttles_reload_attempts(tmp_path, monkeypatch):
+    # Regression: OUTSIDE any cached chart, the old guard bypassed the timer and
+    # re-scanned the whole cache at the 1 Hz supervisor rate. Attempts must be
+    # throttled to the 20 s cadence.
+    rt, clock, calls = _refresh_rt(tmp_path, monkeypatch)
+    assert rt.refresh_land_guard_water() is False     # first attempt (miss)
+    assert calls["n"] == 1
+    for k in range(19):                               # 19 more 1 Hz ticks
+        clock["t"] += 1.0
+        rt.refresh_land_guard_water()
+    assert calls["n"] == 1                            # throttled: no re-scan yet
+    clock["t"] += 2.0                                 # past the 20 s timer
+    rt.refresh_land_guard_water()
+    assert calls["n"] == 2                            # one retry per 20 s


### PR DESCRIPTION
**Reported:** recurring "data stale" + `/ws` disconnect, *"usually around land guard: water chart loaded around boat"* — with the log showing that line twice in 21 s.

## Root cause
`refresh_land_guard_water`'s skip-guard required **(timer AND inside AND has-geometry)**, so:
- **Covered boat:** every 20 s timer expiry fell through to a **full reload** — `WaterCache.find_covering` re-reads + WKB-parses the cached chart, and `set_water_geometry` re-scales and re-extracts the entire shoreline boundary — all **on the event loop**. With a big imported chart that's a periodic multi-hundred-ms stall: telemetry freezes ("data stale") and the WS ping window is missed (`ws: error` / `close`), exactly in sync with the log line in the screenshot.
- **Uncovered boat:** `inside=false` bypassed the timer entirely → full cache re-scan at the **1 Hz** supervisor rate. Same stall, continuous.

## Fix
- Covered → **never reload** (the governor already holds the chart); just keep the retry timer fresh.
- Uncovered → reload **attempts** throttled to the 20 s cadence.
- The load itself is unchanged and still **cache-only** (the safety path never touches the network/relay).

+2 regression tests (covered: cache untouched across 10 timer expiries; uncovered: 1 attempt per 20 s, not per tick). Full suite green.

Note: this is on-boat a15's remaining stall source alongside the per-viewport relay hammer fixed in a16 — together they should resolve the paused data link that's been blocking bundle updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)