### PR TITLE
fix(depth): viewport water-clip is cache-only + boot-phase timing logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **The map's water-clip no longer touches the network at all (link-loss fix,
+  round 2).** The per-viewport clip lookup still tried a *direct* Overpass fetch
+  when uncached -- and on the boat "direct" doesn't fail fast: with the AP's DNS
+  pointing at a dead upstream every attempt hangs for the full timeout in an
+  executor thread, a few map pans exhaust the pool, and everything queued behind
+  it (depth grids/tiles) stalls -- the recurring "data link loss" right after an
+  "Overpass fetch from ..." log line. The viewport path is now **cache-only**
+  (like the land guard): uncached -> the overlay renders unclipped until the
+  area is prefetched via chart prefetch / route planning.
+- **Boot-phase timings in the log.** Startup logs how long Runtime construction,
+  app creation, TLS, mDNS, and runtime start each took, so a slow boot (reported
+  on the Pi without a network connection) shows exactly where the time goes.
+
 ## [1.5.0a17] — 2026-08-10
 
 - **Fixed the periodic "data stale" / WS drops around "land guard: water chart

--- a/src/vanchor/runtime/cli.py
+++ b/src/vanchor/runtime/cli.py
@@ -60,12 +60,20 @@ def main(argv: list[str] | None = None) -> None:
     if args.log_level:
         config.log_level = args.log_level
 
+    import time as _time
+
     import uvicorn
 
     from ..ui.server import create_app
 
+    # Boot-phase timings at INFO so a slow start (seen on the Pi without a
+    # network connection) shows WHERE the time goes in the journal.
+    _t0 = _time.monotonic()
     runtime = Runtime(config)
+    logger.info("boot: Runtime constructed in %.1fs", _time.monotonic() - _t0)
+    _t1 = _time.monotonic()
     app = create_app(runtime)
+    logger.info("boot: app created in %.1fs", _time.monotonic() - _t1)
 
     # Optional HTTPS listener on a second port: secure-context browser APIs
     # (Screen Wake Lock, full PWA installs) need it. Best-effort -- a busy port
@@ -77,9 +85,11 @@ def main(argv: list[str] | None = None) -> None:
             logger.warning("HTTPS port %d is in use; HTTPS disabled",
                            config.server.https_port)
         else:
+            _t2 = _time.monotonic()
             tls_pair = ensure_tls_cert(config.data_dir,
                                        config.server.ssl_certfile,
                                        config.server.ssl_keyfile)
+            logger.info("boot: TLS cert ready in %.1fs", _time.monotonic() - _t2)
 
     # Advertise over mDNS so a phone/PWA finds vanchor.local without an IP.
     advert = None
@@ -89,7 +99,9 @@ def main(argv: list[str] | None = None) -> None:
         props = {"version": __version__}
         if tls_pair:
             props["https_port"] = str(config.server.https_port)
+        _t3 = _time.monotonic()
         advert = advertise(config.server.port, config.server.host, properties=props)
+        logger.info("boot: mDNS advertise done in %.1fs", _time.monotonic() - _t3)
 
     log_level = (args.log_level or "info").lower()
     servers = [uvicorn.Server(uvicorn.Config(

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1505,14 +1505,17 @@ class Runtime:
         try:
             geom = cache.find_covering(wbbox)
             if geom is None:
-                # DIRECT fetch only -- deliberately NOT through the client relay.
-                # This endpoint fires PER VIEWPORT (every map pan/zoom); relaying
-                # it hammered Overpass through the phone (429/504), stalled
-                # executors, and saturated the boat link. The clip is optional
-                # decoration: offline it fails fast here and the overlay simply
-                # renders unclipped until the area is prefetched (chart prefetch
-                # / route plan DO use the relay -- one-shot, user-initiated).
-                geom = water.assemble_water(water.fetch_overpass(*wbbox))
+                # CACHE-ONLY -- no network fetch of any kind on this path. This
+                # endpoint fires PER VIEWPORT (every map pan/zoom). Relaying it
+                # hammered Overpass through the phone (429/504); and a "direct"
+                # fetch is no better on the boat: with the AP's DNS pointing at a
+                # dead upstream, each attempt HANGS for the full timeout in an
+                # executor thread, a few pans exhaust the pool, and everything
+                # queued behind it (depth grids/tiles) stalls -> "data link
+                # loss". The clip is optional decoration: uncached -> render
+                # unclipped. The cache is populated by the one-shot,
+                # user-initiated actions (chart prefetch / route plan).
+                return {"ok": False, "water": []}
                 if geom is not None and not geom.is_empty:
                     cache.store(wbbox, geom)
         except Exception as exc:  # noqa: BLE001 - network/parse; clip is optional
@@ -1667,6 +1670,8 @@ class Runtime:
             logger.debug("runtime start() ignored (already started, count=%d)",
                          self._start_count)
             return
+        import time as _time
+        _boot_t0 = _time.monotonic()
         self.recorder.start()
         # Arm the external hardware watchdog (#44) before the supervisor begins
         # petting it. A no-op when disabled; a bad GPIO must not crash boot.
@@ -1714,7 +1719,9 @@ class Runtime:
         # A connector that fails to build or start is logged and skipped;
         # it NEVER crashes the whole app (mirror the compass-driver resilience).
         await self._start_armed_connectors()
-        logger.info("runtime started (model=%s, hardware=%s)", self.config.sim.model, self.config.hardware.enabled)
+        logger.info("runtime started in %.1fs (model=%s, hardware=%s)",
+                    _time.monotonic() - _boot_t0, self.config.sim.model,
+                    self.config.hardware.enabled)
 
     async def _start_armed_connectors(self) -> None:
         """Shim → HardwareGlue (issue #73)."""

--- a/tests/test_water_http_post_seam.py
+++ b/tests/test_water_http_post_seam.py
@@ -98,10 +98,11 @@ def test_fetch_fail_message_covers_target_subclass():
     assert "504" in msg
 
 
-def test_viewport_water_clip_never_uses_the_relay(tmp_path, monkeypatch):
-    # /api/depth/water fires per viewport (every pan/zoom). It must fetch
-    # DIRECT-only -- relaying it hammered Overpass through the phone (429/504)
-    # and saturated the boat link. Offline it fails fast; the clip is optional.
+def test_viewport_water_clip_is_cache_only(tmp_path, monkeypatch):
+    # /api/depth/water fires per viewport (every pan/zoom). It must NEVER touch
+    # the network: relaying hammered Overpass through the phone (429/504), and a
+    # "direct" fetch hangs in DNS for the full timeout on the offline Pi,
+    # exhausting the executor pool ("data link loss"). Uncached -> clip skipped.
     from vanchor.app import Runtime
     from vanchor.core.config import load
 
@@ -109,13 +110,10 @@ def test_viewport_water_clip_never_uses_the_relay(tmp_path, monkeypatch):
     cfg.data_dir = str(tmp_path)
     rt = Runtime(cfg)
     rt.fetch_relay = object()   # a relay EXISTS; water_polygon must not use it
-    seen = {}
 
-    def fake_fetch(*bbox, http_post=None, **kw):
-        seen["http_post"] = http_post
-        raise OSError("offline")
+    def fake_fetch(*bbox, **kw):
+        raise AssertionError("viewport water-clip must not fetch (cache-only)")
 
     monkeypatch.setattr(water, "fetch_overpass", fake_fetch)
     out = rt.water_polygon((12.0, 59.0, 12.1, 59.1))
-    assert out == {"ok": False, "water": []}   # fail-fast, clip skipped
-    assert seen["http_post"] is None            # direct-only: relay untouched
+    assert out == {"ok": False, "water": []}   # uncached -> clip skipped, no fetch


### PR DESCRIPTION
**Reported:** STILL data link loss, exactly when `Overpass fetch from …` logs; and vanchor boots very slowly without a network connection.

## Link loss — the last network path on the viewport
a16 stopped the per-viewport water-clip from *relaying*, but left the **direct** fetch, assuming an offline Pi fails fast. It doesn't: the AP's dnsmasq forwards to a dead upstream, so each direct attempt **hangs in DNS/connect for the full timeout (60 s × 2 endpoints) in an executor thread**. A few map pans exhaust the small default pool (Pi: ~8 threads), everything queued behind it stalls (depth grids/tiles), and the app seizes → "data link loss" — with the `Overpass fetch from … failed` warnings landing as each timeout finally fires, which is exactly the correlation reported.

**Fix:** the viewport path is now **cache-only** (matching the land guard): uncached → `{ok:false}` and the overlay renders unclipped until the area is prefetched. The cache is populated by the one-shot user actions — chart prefetch and route planning — which keep the relay + endpoint failover.

## Slow boot — instrumentation
Audited the boot path (mDNS, TLS, session-upload, connectors): nothing network-bound is known to run at boot, so this adds **boot-phase timings at INFO** — Runtime construction, app creation, TLS, mDNS, and `runtime started in Xs`. The next Pi boot journal will show exactly which phase eats the time; then we fix that phase specifically.

Tightened the viewport test: `fetch_overpass` must not be called **at all** (asserts if it is). Full suite green; dev boot shows the timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)