### PR TITLE
fix(link): relax WS keepalive + tune the AP radio (periodic ~45 s disconnects)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Fixed the ~45 s WebSocket drop cycle ("data stale" flashes).** A debug
+  recording showed the server perfectly healthy while the phone's socket got
+  error/close/reopen every ~45 s: uvicorn's default WS keepalive (ping 20 s /
+  timeout 20 s) disconnects a phone whose WiFi power-naps long enough to delay
+  one pong -- routine on an iPhone on the boat AP, aggressive in Low Power Mode.
+  The server now pings less often and tolerates slow pongs (25 s / 60 s); real
+  link loss is still caught by the app's own ping + data-stale detection.
+- **SD image: AP radio tuned for phones on deck.** The boot script now disables
+  Pi-side WiFi power-save and prefers a 5 GHz AP (channel 36) when the hardware
+  supports it (Pi 3B+/4/5), with a guaranteed 2.4 GHz fallback if activation
+  fails -- the boat always ends up joinable.
+
 ## [1.5.0a18] — 2026-08-10
 
 - **The map's water-clip no longer touches the network at all (link-loss fix,

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-setup.sh
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-hotspot-setup.sh
@@ -22,7 +22,25 @@ if [ -n "$suffix" ]; then
     nmcli connection modify "$PROFILE" 802-11-wireless.ssid "vanchor-${suffix}" || true
 fi
 
+# Radio tuning for a phone-on-deck link:
+# - Disable WiFi power-save on the Pi's radio (2 = disable). Power-napping
+#   caused missed WS keepalives -> the phone saw periodic disconnects.
+# - Prefer 5 GHz (band a, ch 36) when the hardware supports it (Pi 3B+/4/5):
+#   cleaner spectrum + iPhones nap less aggressively there. Falls back to the
+#   universal 2.4 GHz profile default when 5 GHz is unsupported, and reverts at
+#   the activation step below if the 5 GHz attempt fails for any other reason.
+# BENCH-VERIFY: 5 GHz AP channel acceptance is region/hw dependent.
+nmcli connection modify "$PROFILE" 802-11-wireless.powersave 2 || true
+if [ "$(nmcli -g WIFI-PROPERTIES.5GHZ device show wlan0 2>/dev/null)" = "yes" ]; then
+    nmcli connection modify "$PROFILE" 802-11-wireless.band a 802-11-wireless.channel 36 || true
+fi
+
 # Always (re)activate the AP. If the operator has explicitly joined a home
 # network this session, that join holds the single radio; on the next reboot the
 # higher-priority AP profile wins again, which is why we come back to the AP.
-nmcli connection up "$PROFILE" || true
+if ! nmcli connection up "$PROFILE"; then
+    # 5 GHz attempt (or anything else) failed -> force the universal 2.4 GHz
+    # setup and retry once. The boat MUST always end up joinable.
+    nmcli connection modify "$PROFILE" 802-11-wireless.band bg 802-11-wireless.channel 0 || true
+    nmcli connection up "$PROFILE" || true
+fi

--- a/src/vanchor/runtime/cli.py
+++ b/src/vanchor/runtime/cli.py
@@ -104,13 +104,23 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("boot: mDNS advertise done in %.1fs", _time.monotonic() - _t3)
 
     log_level = (args.log_level or "info").lower()
+    # WS keepalive tuned for a phone on the boat AP: uvicorn's defaults
+    # (ping 20 s / timeout 20 s) DISCONNECT a client whose WiFi power-naps long
+    # enough to delay one pong -- on an iPhone (esp. Low Power Mode) that made
+    # the server close the socket every ~45 s ("data stale" flashes; confirmed
+    # in a debug recording: ws error/close/open cycles at +0.6 s and +46.3 s
+    # with the server perfectly healthy). Ping less often and tolerate slow
+    # pongs; the app has its OWN ping + data-stale detection for real losses.
+    _ws_keepalive = {"ws_ping_interval": 25.0, "ws_ping_timeout": 60.0}
     servers = [uvicorn.Server(uvicorn.Config(
-        app, host=config.server.host, port=config.server.port, log_level=log_level))]
+        app, host=config.server.host, port=config.server.port, log_level=log_level,
+        **_ws_keepalive))]
     if tls_pair:
         cert, key = tls_pair
         servers.append(uvicorn.Server(uvicorn.Config(
             app, host=config.server.host, port=config.server.https_port,
-            log_level=log_level, ssl_certfile=cert, ssl_keyfile=key)))
+            log_level=log_level, ssl_certfile=cert, ssl_keyfile=key,
+            **_ws_keepalive)))
         logger.info("HTTPS listening on port %d (cert: %s)",
                     config.server.https_port, cert)
 

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -103,6 +103,19 @@ def test_load_images_service():
     assert "WantedBy=multi-user.target" in text
 
 
+def test_hotspot_setup_tunes_the_radio():
+    """The AP boot script must disable Pi-side WiFi power-save and prefer 5 GHz
+    when supported, with a guaranteed 2.4 GHz fallback so the boat is ALWAYS
+    joinable (activation failure -> band bg retry)."""
+    text = (STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot-setup.sh").read_text()
+    assert "802-11-wireless.powersave 2" in text          # power-save disabled
+    assert "WIFI-PROPERTIES.5GHZ" in text                  # capability-gated 5 GHz
+    assert "802-11-wireless.band a" in text
+    assert "802-11-wireless.band bg" in text               # fallback path exists
+    # Fallback must be tied to a FAILED activation, not unconditional.
+    assert "if ! nmcli connection up" in text
+
+
 def test_net_chroot_frees_gpio_uart():
     """01-net chroot must free /dev/serial0 for a pin-wired GPS/compass: enable
     the UART, disable Bluetooth (so PL011 lands on the pins), drop the serial


### PR DESCRIPTION
Debug-recording analysis: the server was **perfectly healthy** (telemetry max gap 0.2 s, NMEA full rate for the whole 77 s window) while the phone's WS cycled `error → close → open` at **+0.6 s and +46.3 s** — a ~45 s cadence matching uvicorn's default WS keepalive (`ping_interval=20` + `ping_timeout=20`): a phone whose WiFi power-naps long enough to delay one pong is **disconnected by the server**. Routine for an iPhone on the boat AP, aggressive in Low Power Mode (visible in the operator's screenshot).

## Changes
1. **`cli.py`** — `ws_ping_interval=25`, `ws_ping_timeout=60` on both listeners (HTTP + HTTPS). A napping phone no longer gets server-side closed; genuine link loss is still caught by the app's own ping + data-stale detection (which stays unchanged).
2. **SD image AP tuning** (`vanchor-hotspot-setup.sh`):
   - `802-11-wireless.powersave 2` — Pi-side power-save off
   - Prefer **5 GHz** (band `a`, ch 36) when the hardware supports it, capability-gated via `nmcli -g WIFI-PROPERTIES.5GHZ` (Pi 3B+/4/5)
   - If activation fails for any reason → force `band bg` and retry: **the boat always ends up joinable**
   - BENCH-VERIFY: 5 GHz AP channel acceptance is region/hw dependent

+1 image test locking the tuning. e2e smoke 29/29 (runs the real CLI, so the new kwargs are exercised); full suite green.

Note: change 1 reaches existing boats via the update **bundle**; change 2 only via a **reflash** (or two manual `nmcli` commands, documented in the PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)