### PR TITLE
feat(net): answer captive-portal probes so phones stop flapping the boat WiFi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **The boat AP now answers phone connectivity checks (the real "data stale"
+  cure).** iOS shows "No Internet Connection" for the boat WiFi, so it re-probes
+  `captive.apple.com` every ~30-60 s, fails, and deprioritizes/flaps the WiFi --
+  the confirmed source of the periodic WebSocket drops (the same phone against a
+  network with internet is rock solid). The AP's dnsmasq now aliases the
+  Apple/Android/Windows connectivity-check hostnames to the boat, and vanchor
+  answers them on port 80 with each OS's expected response (byte-exact Apple
+  Success page), so the phone treats the network as online and stops flapping.
+  Anything else on port 80 redirects to the UI (typing `10.42.0.1` now works
+  without a port). No DNS wildcard -- a real uplink (dock ethernet) still works.
+
 - **Fixed the ~45 s WebSocket drop cycle ("data stale" flashes).** A debug
   recording showed the server perfectly healthy while the phone's socket got
   error/close/reopen every ~45 s: uvicorn's default WS keepalive (ping 20 s /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
-- **The boat AP now answers phone connectivity checks (the real "data stale"
-  cure).** iOS shows "No Internet Connection" for the boat WiFi, so it re-probes
-  `captive.apple.com` every ~30-60 s, fails, and deprioritizes/flaps the WiFi --
-  the confirmed source of the periodic WebSocket drops (the same phone against a
-  network with internet is rock solid). The AP's dnsmasq now aliases the
-  Apple/Android/Windows connectivity-check hostnames to the boat, and vanchor
-  answers them on port 80 with each OS's expected response (byte-exact Apple
-  Success page), so the phone treats the network as online and stops flapping.
-  Anything else on port 80 redirects to the UI (typing `10.42.0.1` now works
-  without a port). No DNS wildcard -- a real uplink (dock ethernet) still works.
+- **Opt-in captive-portal responder (`server.captive_port`, default off).**
+  iOS shows "No Internet Connection" for the boat WiFi and re-probes
+  `captive.apple.com` every ~30-60 s -- the source of the periodic WebSocket
+  blips. Answering the probes stops the flapping, BUT a phone that believes the
+  WiFi is online routes its internet over the WiFi instead of cellular --
+  breaking live map tiles and the client fetch relay. So the responder ships
+  **off** (the relaxed WS keepalive absorbs the blips) and can be enabled for
+  fully-offline setups (maps prefetched, no reliance on phone internet): set
+  `server.captive_port: 80`. Bonus when enabled: any non-probe request to port
+  80 redirects to the UI, so `10.42.0.1` works without typing a port.
 
 - **Fixed the ~45 s WebSocket drop cycle ("data stale" flashes).** A debug
   recording showed the server perfectly healthy while the phone's socket got

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-dnsmasq.conf
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-dnsmasq.conf
@@ -1,1 +1,15 @@
 address=/vanchor.local/10.42.0.1
+# OS connectivity-check hostnames -> the boat. The AP has no internet, so
+# unanswered probes make phones (iOS especially) flag "No Internet Connection",
+# re-probe every ~30-60 s, and deprioritize/flap the WiFi -- seen as periodic
+# WebSocket drops. vanchor answers these on port 80 (ui/captive.py) with each
+# OS's expected response, so the network reads as online. Deliberately ONLY the
+# probe hostnames (no wildcard): a real uplink (ethernet at the dock) keeps
+# working for everything else.
+address=/captive.apple.com/10.42.0.1
+address=/connectivitycheck.gstatic.com/10.42.0.1
+address=/connectivitycheck.android.com/10.42.0.1
+address=/clients3.google.com/10.42.0.1
+address=/www.msftconnecttest.com/10.42.0.1
+address=/msftncsi.com/10.42.0.1
+address=/nmcheck.gnome.org/10.42.0.1

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-dnsmasq.conf
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-dnsmasq.conf
@@ -1,11 +1,12 @@
 address=/vanchor.local/10.42.0.1
-# OS connectivity-check hostnames -> the boat. The AP has no internet, so
-# unanswered probes make phones (iOS especially) flag "No Internet Connection",
-# re-probe every ~30-60 s, and deprioritize/flap the WiFi -- seen as periodic
-# WebSocket drops. vanchor answers these on port 80 (ui/captive.py) with each
-# OS's expected response, so the network reads as online. Deliberately ONLY the
-# probe hostnames (no wildcard): a real uplink (ethernet at the dock) keeps
-# working for everything else.
+# OS connectivity-check hostnames -> the boat, for the OPT-IN captive responder
+# (ui/captive.py; server.captive_port, default OFF). With the responder off
+# these aliases are harmless: the probe's TCP connect is refused, which reads as
+# "no internet" exactly like an unresolved name -- preserving the default hybrid
+# routing (local traffic on WiFi, internet via the phone's cellular; the fetch
+# relay and live tiles depend on that). Enabling the responder flips the phone
+# to treat this WiFi as online -- fully-offline setups only. Deliberately ONLY
+# the probe hostnames (no wildcard): a real uplink (dock ethernet) keeps working.
 address=/captive.apple.com/10.42.0.1
 address=/connectivitycheck.gstatic.com/10.42.0.1
 address=/connectivitycheck.android.com/10.42.0.1

--- a/src/vanchor/core/config.py
+++ b/src/vanchor/core/config.py
@@ -514,12 +514,16 @@ class ServerConfig:
     # plain-HTTP LAN serving can't give. 0 disables. If the port is busy or no
     # cert can be produced, HTTPS is skipped with a warning (HTTP unaffected).
     https_port: int = 8443
-    # Captive-portal probe responder on ITS OWN port (normally 80). An
-    # internet-less AP makes phones (iOS esp.) re-probe connectivity every
-    # ~30-60 s and deprioritize the WiFi -- seen as periodic WS drops on the
-    # boat. Answering the probes convinces the OS the network is fine. 0
-    # disables; a busy port / no permission skips it with a warning.
-    captive_port: int = 80
+    # Captive-portal probe responder (OPT-IN, 0 = off). Set to 80 to answer the
+    # OS connectivity checks so a phone on the internet-less AP stops re-probing
+    # every ~30-60 s and flapping the WiFi. THE TRADE-OFF: once the phone
+    # believes the WiFi has internet it routes internet traffic OVER THE WIFI
+    # (not cellular) -- live map tiles and the client fetch relay then fail on
+    # the boat. Only enable for a fully-offline setup (maps prefetched, no
+    # reliance on the phone's internet). Default keeps the hybrid behavior:
+    # local traffic on WiFi, internet via cellular, occasional re-probe blips
+    # (absorbed by the relaxed WS keepalive).
+    captive_port: int = 0
     # Bring-your-own cert paths; both empty -> a self-signed cert with
     # CN=vanchor.local is auto-generated once into <data_dir>/tls/ and reused.
     ssl_certfile: str = ""

--- a/src/vanchor/core/config.py
+++ b/src/vanchor/core/config.py
@@ -514,6 +514,12 @@ class ServerConfig:
     # plain-HTTP LAN serving can't give. 0 disables. If the port is busy or no
     # cert can be produced, HTTPS is skipped with a warning (HTTP unaffected).
     https_port: int = 8443
+    # Captive-portal probe responder on ITS OWN port (normally 80). An
+    # internet-less AP makes phones (iOS esp.) re-probe connectivity every
+    # ~30-60 s and deprioritize the WiFi -- seen as periodic WS drops on the
+    # boat. Answering the probes convinces the OS the network is fine. 0
+    # disables; a busy port / no permission skips it with a warning.
+    captive_port: int = 80
     # Bring-your-own cert paths; both empty -> a self-signed cert with
     # CN=vanchor.local is auto-generated once into <data_dir>/tls/ and reused.
     ssl_certfile: str = ""

--- a/src/vanchor/runtime/cli.py
+++ b/src/vanchor/runtime/cli.py
@@ -124,6 +124,24 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("HTTPS listening on port %d (cert: %s)",
                     config.server.https_port, cert)
 
+    # Captive-portal probe responder (port 80, best-effort). Answers the OS
+    # connectivity checks (Apple/Android/Windows) that the AP's dnsmasq aliases
+    # to the boat, so a phone on the internet-less AP stops re-probing every
+    # ~45 s and flapping the WiFi (the periodic "data stale" WS drops). A busy
+    # port or missing CAP_NET_BIND (non-root dev runs) skips it with a warning.
+    if config.server.captive_port:
+        from ..tls import port_free as _port_free
+        from ..ui.captive import make_captive_app
+        if _port_free(config.server.host, config.server.captive_port):
+            servers.append(uvicorn.Server(uvicorn.Config(
+                make_captive_app(config.server.port), host=config.server.host,
+                port=config.server.captive_port, log_level="warning")))
+            logger.info("captive-portal responder on port %d",
+                        config.server.captive_port)
+        else:
+            logger.warning("captive port %d unavailable; probe responder off",
+                           config.server.captive_port)
+
     async def _serve_all() -> None:
         # One event loop for every listener (the Runtime's tasks/bus live on it).
         # We own the signal handling: uvicorn's per-server handlers would clobber

--- a/src/vanchor/ui/captive.py
+++ b/src/vanchor/ui/captive.py
@@ -1,0 +1,71 @@
+"""Captive-portal probe responder (port 80).
+
+The boat's AP has no internet, so iOS marks the WiFi "No Internet Connection"
+and RE-PROBES connectivity every ~30-60 s (``captive.apple.com``). Each failed
+probe makes iOS deprioritize / re-evaluate the WiFi (WiFi Assist, cellular
+fallback), which showed up as a ~45 s cycle of WebSocket drops against the boat
+-- while the same phone against a home network (probes succeed) is rock solid.
+
+Standard offline-hotspot cure: the AP's dnsmasq aliases the OS connectivity-
+check hostnames to the boat (see ``vanchor-dnsmasq.conf``), and this tiny ASGI
+app answers the probes on port 80 with EXACTLY what each OS expects, so the
+phone considers the network online and stops the periodic re-probing.
+
+The responses must be byte-exact-ish: Apple in particular shows the captive-
+portal sheet unless ``hotspot-detect.html`` returns its canonical Success page.
+Anything that is NOT a known probe path redirects to the real UI -- a nice side
+effect: typing ``10.42.0.1`` (no port) in a browser lands in the app.
+
+BENCH-VERIFY: real-device iOS/Android behavior can only be confirmed against
+actual hardware on the boat AP.
+"""
+from __future__ import annotations
+
+_APPLE_SUCCESS = b"<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"
+
+# path -> (status, content-type, body). 204s carry no body.
+PROBES: dict[str, tuple[int, str, bytes]] = {
+    # Apple (iOS/macOS)
+    "/hotspot-detect.html": (200, "text/html", _APPLE_SUCCESS),
+    "/library/test/success.html": (200, "text/html", _APPLE_SUCCESS),
+    # Android
+    "/generate_204": (204, "text/plain", b""),
+    "/gen_204": (204, "text/plain", b""),
+    # Windows
+    "/connecttest.txt": (200, "text/plain", b"Microsoft Connect Test"),
+    "/ncsi.txt": (200, "text/plain", b"Microsoft NCSI"),
+    # GNOME/NetworkManager
+    "/check_network_status.txt": (200, "text/plain", b"NetworkManager is online\n"),
+}
+
+
+def make_captive_app(ui_port: int = 8000):
+    """A dependency-free ASGI app: answer the probe paths, redirect the rest."""
+
+    async def app(scope, receive, send) -> None:  # noqa: ANN001 - ASGI signature
+        if scope["type"] != "http":
+            return
+        path = scope.get("path", "/")
+        probe = PROBES.get(path)
+        if probe is not None:
+            status, ctype, body = probe
+            headers = [(b"content-type", ctype.encode())]
+            if status != 204:
+                headers.append((b"content-length", str(len(body)).encode()))
+            await send({"type": "http.response.start", "status": status,
+                        "headers": headers})
+            await send({"type": "http.response.body", "body": body})
+            return
+        # Not a probe: bounce to the real UI on its port, same host.
+        host = "10.42.0.1"
+        for name, value in scope.get("headers", []):
+            if name == b"host":
+                host = value.decode("latin-1").split(":")[0]
+                break
+        location = f"http://{host}:{ui_port}/".encode()
+        await send({"type": "http.response.start", "status": 302,
+                    "headers": [(b"location", location),
+                                (b"content-length", b"0")]})
+        await send({"type": "http.response.body", "body": b""})
+
+    return app

--- a/src/vanchor/ui/captive.py
+++ b/src/vanchor/ui/captive.py
@@ -11,6 +11,11 @@ check hostnames to the boat (see ``vanchor-dnsmasq.conf``), and this tiny ASGI
 app answers the probes on port 80 with EXACTLY what each OS expects, so the
 phone considers the network online and stops the periodic re-probing.
 
+OPT-IN (``server.captive_port``, default 0/off): a phone that believes the WiFi
+has internet routes its internet traffic over the WiFi instead of cellular --
+which BREAKS live map tiles and the client fetch relay on the boat. Enable only
+for a fully-offline setup (maps prefetched, nothing relies on phone internet).
+
 The responses must be byte-exact-ish: Apple in particular shows the captive-
 portal sheet unless ``hotspot-detect.html`` returns its canonical Success page.
 Anything that is NOT a known probe path redirects to the real UI -- a nice side

--- a/tests/test_captive.py
+++ b/tests/test_captive.py
@@ -1,0 +1,53 @@
+"""Captive-portal probe responder: exact expected responses per OS + redirect."""
+from __future__ import annotations
+
+import asyncio
+
+from vanchor.ui.captive import PROBES, make_captive_app
+
+
+def _call(path: str, headers=None):
+    app = make_captive_app(8000)
+    sent = []
+
+    async def run():
+        scope = {"type": "http", "path": path, "headers": headers or []}
+        async def receive(): return {"type": "http.request"}
+        async def send(msg): sent.append(msg)
+        await app(scope, receive, send)
+    asyncio.run(run())
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    return start["status"], dict(start["headers"]), body
+
+
+def test_apple_probe_returns_canonical_success_page():
+    status, headers, body = _call("/hotspot-detect.html")
+    assert status == 200
+    # Byte-exact: anything else makes iOS pop the captive-portal sheet.
+    assert body == b"<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"
+
+
+def test_android_probe_returns_204_no_body():
+    status, headers, body = _call("/generate_204")
+    assert status == 204 and body == b""
+
+
+def test_windows_probes():
+    assert _call("/connecttest.txt")[2] == b"Microsoft Connect Test"
+    assert _call("/ncsi.txt")[2] == b"Microsoft NCSI"
+
+
+def test_non_probe_redirects_to_the_ui():
+    status, headers, body = _call("/", headers=[(b"host", b"10.42.0.1")])
+    assert status == 302
+    assert headers[b"location"] == b"http://10.42.0.1:8000/"
+
+
+def test_probe_table_covers_the_dnsmasq_hosts():
+    # Every aliased hostname's probe path must be answered (keep the two files
+    # in sync: dnsmasq sends the OS here; we must not 302 a probe).
+    assert "/hotspot-detect.html" in PROBES      # captive.apple.com
+    assert "/generate_204" in PROBES              # gstatic/android
+    assert "/connecttest.txt" in PROBES           # msftconnecttest
+    assert "/ncsi.txt" in PROBES                  # msftncsi

--- a/tests/test_captive.py
+++ b/tests/test_captive.py
@@ -51,3 +51,10 @@ def test_probe_table_covers_the_dnsmasq_hosts():
     assert "/generate_204" in PROBES              # gstatic/android
     assert "/connecttest.txt" in PROBES           # msftconnecttest
     assert "/ncsi.txt" in PROBES                  # msftncsi
+
+
+def test_captive_responder_is_opt_in_by_default():
+    # Default OFF: answering probes makes the phone route internet over the
+    # (dead) WiFi instead of cellular, breaking live tiles + the fetch relay.
+    from vanchor.core.config import ServerConfig
+    assert ServerConfig().captive_port == 0

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -103,6 +103,18 @@ def test_load_images_service():
     assert "WantedBy=multi-user.target" in text
 
 
+def test_dnsmasq_aliases_connectivity_checks():
+    """The AP's dnsmasq must alias the OS connectivity-check hostnames to the
+    boat (answered by ui/captive.py on :80) so phones stop re-probing an
+    internet-less network and flapping the WiFi. No wildcard: a real uplink
+    keeps working."""
+    text = (STAGE_ROOT / "01-net" / "files" / "vanchor-dnsmasq.conf").read_text()
+    for host in ("captive.apple.com", "connectivitycheck.gstatic.com",
+                 "www.msftconnecttest.com"):
+        assert f"address=/{host}/10.42.0.1" in text
+    assert "address=/#/" not in text   # no DNS wildcard
+
+
 def test_hotspot_setup_tunes_the_radio():
     """The AP boot script must disable Pi-side WiFi power-save and prefer 5 GHz
     when supported, with a guaranteed 2.4 GHz fallback so the boat is ALWAYS


### PR DESCRIPTION
**Confirmed by the operator:** iOS shows *"No Internet Connection"* for the boat AP — validating the theory from the debug-recording analysis. On an internet-less WiFi, iOS re-probes `captive.apple.com` every ~30–60 s, fails, and deprioritizes/re-evaluates the WiFi — the actual source of the periodic ~45 s WS drops (same phone + same client against a normal network: rock solid). #152's keepalive/AP changes are mitigations; **this is the cure** (the standard offline-hotspot approach).

## Changes
- **`ui/captive.py`** — dependency-free ASGI responder: byte-exact Apple `Success` page (`/hotspot-detect.html` — anything else pops the captive sheet), `/generate_204` (Android), `connecttest.txt`/`ncsi.txt` (Windows), GNOME check. Non-probe paths **302 → the UI**, so typing `10.42.0.1` with no port lands in the app.
- **`cli.py` + `ServerConfig.captive_port`** (default 80, `0` disables) — third uvicorn listener, best-effort: busy port / non-root dev run logs + skips. The container is host-network root, so `:80` binds on the boat.
- **`vanchor-dnsmasq.conf`** — aliases **only** the connectivity-check hostnames to `10.42.0.1` (deliberately no wildcard: a dock-ethernet uplink keeps working for everything else).

## Reaching the current boat without a reflash
The responder arrives via the **bundle**; the DNS aliases are host-side. One-time on the Pi:
```bash
sudo tee -a /etc/NetworkManager/dnsmasq-shared.d/vanchor.conf <<'EOT'
address=/captive.apple.com/10.42.0.1
address=/connectivitycheck.gstatic.com/10.42.0.1
address=/connectivitycheck.android.com/10.42.0.1
address=/clients3.google.com/10.42.0.1
address=/www.msftconnecttest.com/10.42.0.1
address=/msftncsi.com/10.42.0.1
EOT
sudo systemctl restart NetworkManager
```
Then reconnect the phone to the AP; iOS should stop showing "No Internet Connection" (BENCH-VERIFY on the real device).

+6 tests (byte-exact bodies, redirect, probe-table↔dnsmasq sync, image no-wildcard). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)