### PR TITLE
feat(boot): don't gate boot on network-online + background depth-map load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Faster boot, especially offline.** Three changes: (1) the SD image no longer
+  gates boot on "network online" -- `NetworkManager-wait-online` blocked Docker
+  (and therefore vanchor) for its full 30-60 s timeout on the internet-less boat
+  AP; (2) firmware delays trimmed (`disable_splash=1`, `boot_delay=0`); (3) the
+  saved depth map/chart now loads in the background after the server is up --
+  a big imported chart took seconds on a Pi before the UI would answer at all;
+  overlays briefly render blank and pop in when loaded. Estimated ~30-90 s
+  faster to a responsive UI on an offline boot (image changes need a reflash;
+  the depth-load change arrives with the bundle).
+
 ## [1.5.0a19] — 2026-08-10
 
 - **Opt-in captive-portal responder (`server.captive_port`, default off).**

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -27,5 +27,20 @@ systemctl mask serial-getty@ttyAMA0.service 2>/dev/null || true
 systemctl mask serial-getty@ttyS0.service 2>/dev/null || true
 systemctl mask serial-getty@serial0.service 2>/dev/null || true
 
+# Boot time: don't gate boot on "network online". docker.service Wants=
+# network-online.target, which runs NetworkManager-wait-online -- and on the
+# boat (an AP with no upstream internet) that blocks for its FULL timeout
+# (30-60 s) before Docker (and therefore vanchor) even starts. The boat never
+# needs to be "online" to serve its own AP; disabling the wait lets the target
+# activate immediately. (Dependencies can't be removed via drop-in, so
+# disabling the wait service is the standard appliance fix.)
+systemctl disable NetworkManager-wait-online.service 2>/dev/null || true
+
+# Boot time: shave firmware delays (no rainbow splash, no boot_delay wait).
+if [ -f "$BOOT_DIR/config.txt" ]; then
+    grep -q '^disable_splash=1' "$BOOT_DIR/config.txt" || echo 'disable_splash=1' >> "$BOOT_DIR/config.txt"
+    grep -q '^boot_delay=0'     "$BOOT_DIR/config.txt" || echo 'boot_delay=0'     >> "$BOOT_DIR/config.txt"
+fi
+
 # Enable the access-point service (brings the AP up at every boot; offline-first).
 systemctl enable vanchor-hotspot.service

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -1688,8 +1688,19 @@ class Runtime:
                 logger.exception("background depth-map load failed; starting empty")
                 return
             boot_map = self.depth_map
+            # Merge-preserving swap: anything that touched the boot map while
+            # the load ran (an early import, a test fixture, live soundings)
+            # must survive. Replay soundings into the fresh map, and carry over
+            # bulk fields the fresh load doesn't have. If someone REPLACED the
+            # map object meanwhile (an import with replace=True), keep theirs.
+            if self.depth_map is not boot_map:
+                return
             for lat, lon, depth in list(boot_map.points):  # soundings during load
                 fresh.record(GeoPoint(lat, lon), depth)
+            for attr in ("composition", "contours", "hardness"):
+                boot_val = getattr(boot_map, attr, None)
+                if len(boot_val or []) and not len(getattr(fresh, attr, None) or []):
+                    setattr(fresh, attr, boot_val)
             self.depth_map = fresh
             self._depth_saved_n = len(fresh.points)
             logger.info("boot: depth map loaded in background (%d points)",

--- a/src/vanchor/runtime/runtime.py
+++ b/src/vanchor/runtime/runtime.py
@@ -247,12 +247,15 @@ class Runtime:
         self.battery_monitor = dev["battery_monitor"]
         motor = dev["motor"]
 
-        # Accumulates depth soundings for the auto depth-map overlay.
+        # Accumulates depth soundings for the auto depth-map overlay. The saved
+        # map/chart is LOADED IN THE BACKGROUND from start() (a big imported
+        # chart takes seconds on a Pi and used to block boot before the server
+        # would accept a single request); until the swap the map is just empty,
+        # so overlays render blank briefly and then pop in.
         self.depth_map = DepthMap()
         self._depth_map_path = os.path.join(cfg.data_dir, "depthmap.json")
         self._depth_chart_path = os.path.join(cfg.data_dir, "depthchart.json")
-        self.depth_map.load(self._depth_map_path, self._depth_chart_path)
-        self._depth_saved_n = len(self.depth_map.points)
+        self._depth_saved_n = 0
         # Depth cluster (issue #71): depth soundings, chart management, depth
         # grid/query, contour routing, import -- all live in DepthService.
         self._depth = DepthService(self)
@@ -1672,6 +1675,26 @@ class Runtime:
             return
         import time as _time
         _boot_t0 = _time.monotonic()
+        # Load the saved depth map/chart off the boot path: build a fresh
+        # DepthMap in a worker thread, then swap it in on the loop, replaying
+        # any soundings recorded into the boot map meanwhile (the swap is a
+        # plain attribute assignment, so readers see old-empty or new-full).
+        async def _load_depth_bg() -> None:
+            try:
+                fresh = DepthMap()
+                await asyncio.to_thread(
+                    fresh.load, self._depth_map_path, self._depth_chart_path)
+            except Exception:  # noqa: BLE001 - a corrupt file must not kill boot
+                logger.exception("background depth-map load failed; starting empty")
+                return
+            boot_map = self.depth_map
+            for lat, lon, depth in list(boot_map.points):  # soundings during load
+                fresh.record(GeoPoint(lat, lon), depth)
+            self.depth_map = fresh
+            self._depth_saved_n = len(fresh.points)
+            logger.info("boot: depth map loaded in background (%d points)",
+                        len(fresh.points))
+        self._tasks.append(asyncio.ensure_future(_load_depth_bg()))
         self.recorder.start()
         # Arm the external hardware watchdog (#44) before the supervisor begins
         # petting it. A no-op when disabled; a bad GPIO must not crash boot.

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -103,6 +103,15 @@ def test_load_images_service():
     assert "WantedBy=multi-user.target" in text
 
 
+def test_net_chroot_speeds_up_offline_boot():
+    """Boot time: the wait-online gate (which blocks Docker 30-60 s on an
+    internet-less boat) must be disabled, and the firmware delays trimmed."""
+    text = (STAGE_ROOT / "01-net" / "01-run-chroot.sh").read_text()
+    assert "systemctl disable NetworkManager-wait-online.service" in text
+    assert "disable_splash=1" in text
+    assert "boot_delay=0" in text
+
+
 def test_dnsmasq_aliases_connectivity_checks():
     """The AP's dnsmasq must alias the OS connectivity-check hostnames to the
     boat (answered by ui/captive.py on :80) so phones stop re-probing an

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -151,3 +151,32 @@ async def test_depth_map_loads_in_background_after_start(tmp_path):
         assert rt._depth_saved_n == 2            # save-threshold baseline updated
     finally:
         await rt.stop()
+
+
+async def test_background_depth_load_preserves_early_mutations(tmp_path):
+    # Regression (caught by CI ordering): data put into the map BETWEEN start()
+    # and the background swap -- an early import, a test fixture, live
+    # soundings -- must survive the swap instead of being clobbered.
+    import asyncio
+    import json
+
+    from vanchor.core.models import GeoPoint
+
+    (tmp_path / "depthmap.json").write_text(
+        json.dumps({"points": [[59.0, 13.0, 4.2]]}))
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    await rt.start()
+    try:
+        # Mutate the boot map immediately (races the background load on purpose).
+        rt.depth_map.composition = [{"pct": 50.0, "ring": [[59, 13], [59.1, 13.1], [59.1, 13]]}]
+        rt.depth_map.record(GeoPoint(59.5, 13.5), 7.0)
+        for _ in range(100):
+            if len(rt.depth_map.points) >= 2:      # disk point + recorded point
+                break
+            await asyncio.sleep(0.02)
+        assert len(rt.depth_map.points) == 2
+        assert len(rt.depth_map.composition) == 1  # early mutation survived
+    finally:
+        await rt.stop()

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -125,3 +125,29 @@ async def test_reload_devices_stops_old_motor():
     assert rt.controller.motor is not motor  # swapped to the new (sim) motor
 
     await rt.stop()
+
+
+async def test_depth_map_loads_in_background_after_start(tmp_path):
+    # A big saved chart used to load synchronously in Runtime.__init__, blocking
+    # boot for seconds on a Pi before the server could serve anything. It now
+    # loads in a background task started by start(): pre-seeded data appears
+    # shortly after start() without having blocked construction.
+    import asyncio
+    import json
+
+    (tmp_path / "depthmap.json").write_text(
+        json.dumps({"points": [[59.0, 13.0, 4.2], [59.001, 13.001, 5.0]]}))
+    cfg = load(None)
+    cfg.data_dir = str(tmp_path)
+    rt = Runtime(cfg)
+    assert len(rt.depth_map.points) == 0        # constructor no longer loads
+    await rt.start()
+    try:
+        for _ in range(100):                     # background task swaps it in
+            if len(rt.depth_map.points) == 2:
+                break
+            await asyncio.sleep(0.02)
+        assert len(rt.depth_map.points) == 2
+        assert rt._depth_saved_n == 2            # save-threshold baseline updated
+    finally:
+        await rt.stop()


### PR DESCRIPTION
Implements the boot-time reduction list in full (from the earlier read-only analysis).

## Changes
1. **Image — kill the offline-boot stall:** `systemctl disable NetworkManager-wait-online.service`. Stock `docker.service` `Wants=network-online.target`; on the internet-less boat AP the wait blocks its **full 30–60 s timeout** before Docker (and everything vanchor) starts — the reported "incredibly slow boot without a network connection". The boat never needs to be *online* to serve its own AP.
2. **Image — firmware trims:** `disable_splash=1`, `boot_delay=0` (~2–4 s).
3. **App — background depth-map load:** the saved map/chart (soundings + contours + composition — seconds of parsing on a Pi) now loads in a background task started by `runtime.start()` instead of blocking `Runtime.__init__`. Fresh `DepthMap` built in a worker thread → swapped in on the loop → soundings recorded during the load replayed into the new map → save-threshold baseline updated. Overlays render blank briefly, then pop in (`boot: depth map loaded in background (N points)`).

**Estimated ~30–90 s faster to a responsive UI on an offline boot.** Items 1–2 need a reflash; item 3 arrives via the bundle. The a18 `boot:` phase timings will show the before/after on the real Pi.

+2 tests. Full suite 2298 passed; e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)