### PR TITLE
fix(devices): label serial aliases by their own name in the port menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **`serial0` is now findable in the port menu.** The stable on-board-UART alias
+  was listed with only its resolved target's name, so `/dev/serial0` rendered as
+  a second "ttyAMA0" entry -- anyone looking for "serial0" concluded it wasn't
+  there. Alias entries now lead with their own name: `serial0 (ttyAMA0) -
+  on-board UART (stable)`.
+
 ## [1.5.0a20] — 2026-08-10
 
 - **GPS walk analysis tool (`python -m vanchor.analysis.gps_walk`).** Feeds the

--- a/src/vanchor/runtime/hardware_glue.py
+++ b/src/vanchor/runtime/hardware_glue.py
@@ -69,7 +69,12 @@ class HardwareGlue:
                 except OSError:
                     target = os.path.basename(link)
                 tag = " - on-board UART" if target.startswith(("ttyAMA", "ttyS", "ttyO", "ttymxc")) else ""
-                candidates.append((link, f"{target}{tag} (stable)"))
+                # Label with the ALIAS name first, target in parens: showing only
+                # the resolved target made /dev/serial0 render as a second
+                # "ttyAMA0" entry -- users looking for "serial0" couldn't find it.
+                name = os.path.basename(link)
+                label = name if name == target else f"{name} ({target})"
+                candidates.append((link, f"{label}{tag} (stable)"))
         try:
             from serial.tools import list_ports
             for p in list_ports.comports():

--- a/tests/test_device_gating.py
+++ b/tests/test_device_gating.py
@@ -144,3 +144,27 @@ def test_a_source_can_be_reset_to_auto_null():
     rt.set_device_config({"hardware": {"gps_source": "serial"}})
     rt.set_device_config({"hardware": {"compass_source": "sim"}})
     assert rt.config.hardware.gps_source == "serial"
+
+
+def test_serial_alias_labeled_by_alias_name(monkeypatch):
+    """Regression: /dev/serial0 rendered as a second "ttyAMA0" entry (label was
+    the resolved TARGET only), so users hunting for "serial0" in the port menu
+    couldn't find it. The alias name must lead the label."""
+    import glob as _glob
+    import os as _os
+
+    def fake_glob(pat):
+        return ["/dev/serial0"] if pat == "/dev/serial[0-9]" else []
+
+    monkeypatch.setattr(_glob, "glob", fake_glob)
+    monkeypatch.setattr(_os.path, "realpath", lambda p: "/dev/ttyAMA0")
+    try:  # pyserial may or may not be importable; silence its contribution
+        from serial.tools import list_ports
+        monkeypatch.setattr(list_ports, "comports", lambda: [])
+    except ImportError:
+        pass
+    ports = _rt().list_serial_ports()
+    entry = next(p for p in ports if p["path"] == "/dev/serial0")
+    assert entry["stable"] is True
+    assert entry["description"].startswith("serial0 (ttyAMA0)")
+    assert "on-board UART" in entry["description"]


### PR DESCRIPTION
**Field report resolved:** `/dev/serial0` exists on the a19-flashed Pi (image verified end-to-end from the artifact: `config.txt` `[all]` section, cmdline, getty masks, udev rule, container `/dev` mount) — yet "serial0 isn't visible in the device menu".

It **was** visible, mislabeled: the stable-alias entry's description used only the resolved target (`basename(realpath(link))`), so `/dev/serial0` rendered as a *second* **"ttyAMA0 – on-board UART (stable)"** entry. The string "serial0" never appeared anywhere in the dropdown, so anyone hunting for it concluded it was missing.

## Fix
Alias entries lead with their own name, target in parens:
`★ serial0 (ttyAMA0) - on-board UART (stable)`

+1 regression test (monkeypatched glob/realpath asserts the label leads with `serial0 (ttyAMA0)`). Full suite green.

(Feeds the UX audit's fresh-eyes list — the port dropdown's labeling was already flagged as part of the Devices-panel confusion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)