### PR TITLE
feat(gps): distinguish "signal too weak / acquiring" from "GPS lost" (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **"GPS lost" now says WHY when the receiver is actually fine.** A u-blox that
+  is receiving but below its own fix-quality gate (few satellites, poor sky
+  view -- e.g. indoors) used to show a bare "GPS LOST", identically to a dead
+  cable. The driver now reports its live signal quality, the red banner reads
+  e.g. "GPS: signal too weak: 4 sats, ±33 m (below receiver quality gate) —
+  acquiring", and the HUD shows "ACQ 4" instead of "LOST" while satellites are
+  being tracked. First shipped slice of the device-error-visibility work (#142).
+
 - **`serial0` is now findable in the port menu.** The stable on-board-UART alias
   was listed with only its resolved target's name, so `/dev/serial0` rendered as
   a second "ttyAMA0" entry -- anyone looking for "serial0" concluded it wasn't

--- a/src/vanchor/hardware/drivers/ublox.py
+++ b/src/vanchor/hardware/drivers/ublox.py
@@ -48,6 +48,8 @@ class UbloxGps(Sensor):
         self.last_data_monotonic: float | None = None
         # Latest RAW decode for the Devices -> Debug live view.
         self._last_pvt: ubx.NavPvt | None = None
+        # Latest signal quality (every decode, incl. rejected fixes); see _emit.
+        self.signal: dict | None = None
         self._last_pvt_monotonic: float | None = None
         self._frames_received = 0
 
@@ -119,6 +121,11 @@ class UbloxGps(Sensor):
         self._last_pvt = pvt
         self._last_pvt_monotonic = time.monotonic()
         self._frames_received += 1
+        # Live signal-quality snapshot, kept for EVERY decode (valid or not) so
+        # the UI can say "receiving, fix below quality gate (4 sats)" instead of
+        # a bare "GPS lost" (#142). Read by _device_health via duck typing.
+        self.signal = {"fix_type": pvt.fix_type, "num_sv": pvt.num_sv,
+                       "h_acc_m": round(pvt.h_acc_m, 1), "fix_ok": pvt.valid}
         if not pvt.valid:
             return
         self.healthy = True
@@ -131,6 +138,21 @@ class UbloxGps(Sensor):
         )
         if self.bus is not None:
             await self.bus.publish(events.GPS_FIX_IN, fix)
+
+    @property
+    def status_detail(self) -> str | None:
+        """Operator-facing one-liner distinguishing "no data" / "acquiring" /
+        "fix below the receiver's quality gate" from a healthy fix -- so the UI
+        never reduces a weak-signal state to a bare "GPS lost"."""
+        s = self.signal
+        if s is None:
+            return None
+        if s["fix_ok"]:
+            return f"{s['num_sv']} sats, \u00b1{s['h_acc_m']} m"
+        if s["fix_type"] >= 2:
+            return (f"signal too weak: {s['num_sv']} sats, \u00b1{s['h_acc_m']} m "
+                    "(below receiver quality gate) \u2014 acquiring")
+        return f"no fix ({s['num_sv']} sats) \u2014 acquiring"
 
     def debug(self) -> str:
         pvt = self._last_pvt

--- a/src/vanchor/runtime/devices.py
+++ b/src/vanchor/runtime/devices.py
@@ -545,6 +545,15 @@ class DeviceManager:
                 "healthy": bool(healthy),
                 "data_age_s": round(now - last, 2) if last is not None else None,
             }
+            # Optional richer status (duck-typed; e.g. the u-blox driver's
+            # signal quality) so the UI can explain WHY a device is unhealthy
+            # ("4 sats, below quality gate") instead of a bare lost state (#142).
+            detail = getattr(dev, "status_detail", None)
+            if detail:
+                out[name]["detail"] = detail
+            signal = getattr(dev, "signal", None)
+            if isinstance(signal, dict):
+                out[name]["signal"] = signal
         # Hardware watchdog (#44): only when enabled. healthy = the heartbeat is
         # armed + running (a stopped watchdog would drop the motor-supply relay).
         wd = getattr(rt, "watchdog", None)

--- a/src/vanchor/ui/static/health.js
+++ b/src/vanchor/ui/static/health.js
@@ -101,11 +101,20 @@
     }
 
     // ---- fix_lost --------------------------------------------------------
+    // With a u-blox driver we know WHY: the device-health detail distinguishes
+    // "receiving but signal too weak (N sats)" from a truly dead GPS (#142).
     const fixLost = !!h.fix_lost;
+    const gpsDetail = h.devices && h.devices.gps && h.devices.gps.detail;
+    if (fixLost) {
+      fixLostBanner.textContent = gpsDetail ? ("GPS: " + gpsDetail) : "GPS LOST";
+    }
     if (fixLost !== prevFixLost) {
       prevFixLost = fixLost;
       setBanner(fixLostBanner, fixLost);
-      if (fixLost && VA.logAlert) VA.logAlert("alarm", "GPS fix lost", { level: "high" });
+      if (fixLost && VA.logAlert) {
+        VA.logAlert("alarm", gpsDetail ? ("GPS unusable — " + gpsDetail) : "GPS fix lost",
+                    { level: "high" });
+      }
     }
 
     // ---- depth_stale -----------------------------------------------------

--- a/src/vanchor/ui/static/hud.js
+++ b/src/vanchor/ui/static/hud.js
@@ -19,7 +19,14 @@
   // ---- GPS fix label -----------------------------------------------------
   function fixLabel(t) {
     if (t.has_fix === false) return "NO FIX";
-    if (t.safety && t.safety.fix_lost) return "LOST";
+    if (t.safety && t.safety.fix_lost) {
+      // Receiving frames but the fix is below the receiver's quality gate ->
+      // "ACQ n" (acquiring, n sats) instead of a misleading "LOST".
+      const sig = t.health && t.health.devices && t.health.devices.gps
+        && t.health.devices.gps.signal;
+      if (sig && sig.num_sv > 0) return "ACQ " + sig.num_sv;
+      return "LOST";
+    }
     if (Number.isFinite(t.fix_seq) || t.has_fix === true || t.position) return "OK";
     return "—";
   }

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -288,3 +288,21 @@ def test_link_loss_manual_still_stops_even_with_continue_mission():
     assert rt.state.mode == ControlModeName.MANUAL     # stop lands in manual...
     cmd = rt.controller.control_tick(0.2)              # next tick applies the stop
     assert cmd.thrust == 0.0                           # ...with thrust CUT
+
+
+def test_health_devices_carries_signal_detail():
+    # A driver exposing status_detail/signal (the u-blox GPS) gets them surfaced
+    # so the UI can say "signal too weak (4 sats)" instead of a bare lost (#142).
+    rt = Runtime()
+
+    class _UbloxLike:
+        healthy = False
+        last_data_monotonic = 95.0
+        status_detail = "signal too weak: 4 sats, ±33.4 m (below receiver quality gate) — acquiring"
+        signal = {"fix_type": 3, "num_sv": 4, "h_acc_m": 33.4, "fix_ok": False}
+
+    rt.gps = _UbloxLike()
+    dev = rt._device_health(now=100.0)["gps"]
+    assert dev["healthy"] is False and dev["data_age_s"] == 5.0
+    assert "quality gate" in dev["detail"]
+    assert dev["signal"]["num_sv"] == 4 and dev["signal"]["fix_ok"] is False

--- a/tests/test_ublox_driver.py
+++ b/tests/test_ublox_driver.py
@@ -74,3 +74,42 @@ async def test_split_and_garbage_bytes_are_tolerated():
     # garbage prefix + the frame split across the buffer still yields exactly one fix
     got, _ = await _drive(b"\x00\xff\xb5garbage" + frame)
     assert len(got) == 1
+
+
+async def _drive_with_driver(frames: bytes):
+    """Like _drive but also returns the driver (for signal/status_detail)."""
+    bus = EventBus()
+    got: list = []
+
+    async def collect(fix):
+        got.append(fix)
+
+    bus.subscribe(events.GPS_FIX_IN, collect)
+    t = FakeSerialTransport()
+    drv = UbloxGps(t, bus, configure=False)
+    t.feed_bytes(frames)
+    await drv.start()
+    for _ in range(20):
+        await asyncio.sleep(0)
+    await asyncio.sleep(0.02)
+    await drv.stop()
+    return drv, got
+
+
+async def test_signal_detail_distinguishes_weak_fix_from_lost():
+    # gnssFixOK=0 (receiver's own quality gate) -> no fix published, but the
+    # driver reports WHY: signal snapshot + operator-facing detail (#142).
+    frames = ubx.build_frame(*ubx.NAV_PVT, _nav_pvt(59.0, 18.0, 0.0, 0.0, valid=False))
+    drv, got = await _drive_with_driver(frames)
+    assert got == []                                  # rejected fix: nothing on the bus
+    assert drv.signal == {"fix_type": 3, "num_sv": 11, "h_acc_m": 0.5, "fix_ok": False}
+    assert "quality gate" in drv.status_detail
+    assert "acquiring" in drv.status_detail
+
+
+async def test_signal_detail_for_a_healthy_fix():
+    frames = ubx.build_frame(*ubx.NAV_PVT, _nav_pvt(59.0, 18.0, 1.0, 0.0, valid=True))
+    drv, got = await _drive_with_driver(frames)
+    assert len(got) == 1
+    assert drv.signal["fix_ok"] is True
+    assert drv.status_detail == "11 sats, ±0.5 m"


### PR DESCRIPTION
**Field report (twice in one morning, dev box + Pi):** "GPS lost" with both the ublox and NMEA sources — while the debug view showed **882 UBX frames flowing** and a 3D fix with `gnssFixOK=0` at **4 sats / ±33 m**. The receiver was fine; reception (indoors) was below its own quality gate, but the UI reduced that to the same bare "GPS LOST" as a dead cable.

## Changes
- **`UbloxGps`** keeps a live `signal` snapshot for *every* decode (`fix_type`, `num_sv`, `h_acc_m`, `fix_ok`) and derives an operator-facing `status_detail`: `"11 sats, ±0.5 m"` · `"signal too weak: 4 sats, ±33.4 m (below receiver quality gate) — acquiring"` · `"no fix (0 sats) — acquiring"`.
- **`_device_health`** surfaces duck-typed `detail` + `signal` per device into the telemetry health block (any future driver can join).
- **`health.js`**: the red banner + alert log use the detail — `GPS: signal too weak: 4 sats…` — falling back to `GPS LOST`.
- **`hud.js`**: shows **`ACQ 4`** instead of `LOST` while satellites are being tracked.

Safety unchanged: rejected fixes still never reach the navigator and the fix-loss failsafe still engages — only the *explanation* improves. First shipped slice of #142.

+3 tests. Full suite green; ruff + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)