### PR TITLE
image: WiFi client keep-alive pinger (stops phone radio napping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Steadier phone connection at anchor: the boat now keeps your phone's WiFi
+  awake.** Phones aggressively nap their WiFi radio (worse in Low Power Mode),
+  which showed up as telemetry hiccups and brief "connection lost" moments in
+  the UI. The SD image now runs a small keep-alive service on the Pi that
+  notices each connected phone/tablet within ~1.5 s and streams gentle pings
+  (5/s) to it for as long as it stays on the boat's network -- a standard
+  trick for latency-sensitive AP setups, complementing the app's relaxed WS
+  keepalive. It only ever pings devices on the boat's own WiFi subnet, and a
+  device that leaves is dropped cleanly. BENCH-VERIFY: keep-awake effect vs.
+  real phone power-save timing.
+
 ## [1.5.0a21] — 2026-08-11
 
 - **"GPS lost" now says WHY when the receiver is actually fine.** A u-blox that

--- a/deploy/image/stage-vanchor/01-net/00-run.sh
+++ b/deploy/image/stage-vanchor/01-net/00-run.sh
@@ -14,3 +14,7 @@ install -m 0644 files/vanchor-hotspot.service \
     "${ROOTFS_DIR}/etc/systemd/system/vanchor-hotspot.service"
 install -m 0755 files/vanchor-hotspot-setup.sh \
     "${ROOTFS_DIR}/usr/local/sbin/vanchor-hotspot-setup"
+install -m 0644 files/vanchor-wifi-keepalive.service \
+    "${ROOTFS_DIR}/etc/systemd/system/vanchor-wifi-keepalive.service"
+install -m 0755 files/vanchor-wifi-keepalive.py \
+    "${ROOTFS_DIR}/usr/local/sbin/vanchor-wifi-keepalive"

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -44,3 +44,10 @@ fi
 
 # Enable the access-point service (brings the AP up at every boot; offline-first).
 systemctl enable vanchor-hotspot.service
+
+# Enable the WiFi client keep-alive pinger: constant ICMP toward each
+# associated client stops phones from napping their WiFi radio (telemetry
+# hiccups in the UI, worse in Low Power Mode).
+# BENCH-VERIFY: keep-awake effect vs. real phone power-save timing needs
+# on-water/bench hardware.
+systemctl enable vanchor-wifi-keepalive.service

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.py
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Vanchor WiFi client keep-alive pinger.
+
+The boat Pi is a WiFi AP; the operator's phone naps its WiFi radio
+aggressively (worse in Low Power Mode), which shows up as telemetry
+hiccups/timeouts in the UI. A constant trickle of ICMP traffic toward the
+phone keeps its radio awake -- a standard trick for latency-sensitive AP
+setups. This complements the app's relaxed WS keepalive.
+
+Design:
+- Discover connected clients from BOTH sources, merged:
+    * `iw dev wlan0 station dump`  -> associated MACs (fast truth)
+    * MAC -> IPv4 via the kernel neighbor table (`ip -4 neigh show dev wlan0`)
+      and NetworkManager shared-mode dnsmasq leases
+      (/var/lib/NetworkManager/dnsmasq-wlan0.leases; glob fallback).
+- One long-running `ping -i 0.2 -W 1 -q <ip>` process per client (we run as
+  root, so sub-second intervals are permitted). No per-packet forking.
+- A supervisor loop every ~1.5 s reconciles the client set against running
+  pingers: new client -> pinger started within one loop; departed client ->
+  pinger killed. Exited pingers are reaped every loop, so a dead client can
+  never wedge the loop.
+- Safety: only ever pings IPv4s inside wlan0's own subnet (10.42.0.0/24 by
+  default), never the Pi itself, never external addresses.
+- Quiet: one journal line per client add/remove, nothing per-ping.
+
+BENCH-VERIFY: the actual radio-keep-awake effect (0.2 s ICMP cadence vs. a
+phone's power-save timing, add-latency <= one 1.5 s reconcile loop) is
+unverifiable without real Pi + phone hardware.
+"""
+from __future__ import annotations
+
+import glob
+import ipaddress
+import subprocess
+import time
+
+IFACE = "wlan0"
+RECONCILE_S = 1.5       # supervisor loop cadence
+MAX_PINGERS = 16        # sane cap; an AP-mode Pi rarely serves more clients
+RESTART_BACKOFF_S = 10  # don't respawn a crash-looping ping more often
+LEASES_PRIMARY = "/var/lib/NetworkManager/dnsmasq-wlan0.leases"
+LEASES_GLOB = "/var/lib/NetworkManager/dnsmasq-*.leases"
+
+
+def log(msg: str) -> None:
+    """One-liner to the journal (stdout). Nothing per-ping, ever."""
+    print(msg, flush=True)
+
+
+def _run(cmd: list[str]) -> str | None:
+    """Run a command; None on any failure (absent binary, error, timeout)."""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def iface_network() -> tuple[ipaddress.IPv4Network, ipaddress.IPv4Address | None]:
+    """wlan0's own IPv4 subnet + address. Falls back to NM shared-mode default."""
+    out = _run(["ip", "-4", "-o", "addr", "show", "dev", IFACE])
+    if out:
+        for tok in out.split():
+            if "/" in tok:
+                try:
+                    iface = ipaddress.ip_interface(tok)
+                except ValueError:
+                    continue
+                return iface.network, iface.ip
+    return ipaddress.ip_network("10.42.0.0/24"), None
+
+
+def station_macs() -> set[str] | None:
+    """Associated client MACs from `iw dev wlan0 station dump`.
+
+    Returns None (not empty) when `iw` itself is unavailable/failing, so the
+    caller can fall back to leases/neighbors alone.
+    """
+    out = _run(["iw", "dev", IFACE, "station", "dump"])
+    if out is None:
+        return None
+    macs = set()
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == "Station":
+            macs.add(parts[1].lower())
+    return macs
+
+
+def neigh_map() -> dict[str, str]:
+    """MAC -> IPv4 from the kernel neighbor table, wlan0 only."""
+    out = _run(["ip", "-4", "neigh", "show", "dev", IFACE])
+    mapping: dict[str, str] = {}
+    if not out:
+        return mapping
+    for line in out.splitlines():
+        parts = line.split()
+        # "<ip> lladdr <mac> <STATE>" -- entries without lladdr are useless.
+        if "lladdr" in parts:
+            idx = parts.index("lladdr")
+            if idx >= 1 and idx + 1 < len(parts):
+                mapping[parts[idx + 1].lower()] = parts[0]
+    return mapping
+
+
+def lease_map() -> dict[str, str]:
+    """MAC -> IPv4 from NetworkManager shared-mode dnsmasq leases.
+
+    Column format: expiry MAC IP hostname [clientid]. Absent files are fine.
+    """
+    paths = [LEASES_PRIMARY]
+    paths += [p for p in sorted(glob.glob(LEASES_GLOB)) if p != LEASES_PRIMARY]
+    mapping: dict[str, str] = {}
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            parts = line.split()
+            if len(parts) >= 3:
+                mapping.setdefault(parts[1].lower(), parts[2])
+    return mapping
+
+
+def desired_ips() -> set[str]:
+    """Current client IPv4s to keep alive, filtered to wlan0's own subnet."""
+    network, own_ip = iface_network()
+    # Leases first, neighbor table wins on conflict (it is fresher).
+    mac_to_ip = lease_map()
+    mac_to_ip.update(neigh_map())
+
+    macs = station_macs()
+    if macs is None:
+        # iw unavailable: fall back to every known lease/neighbor on wlan0.
+        candidates = set(mac_to_ip.values())
+    else:
+        candidates = {mac_to_ip[m] for m in macs if m in mac_to_ip}
+
+    ips: set[str] = set()
+    for cand in candidates:
+        try:
+            addr = ipaddress.ip_address(cand)
+        except ValueError:
+            continue
+        # Only ever ping the AP's own subnet: no external addresses, not the
+        # Pi itself, not network/broadcast.
+        if addr not in network:
+            continue
+        if addr == own_ip or addr == network.network_address:
+            continue
+        if addr == network.broadcast_address:
+            continue
+        ips.add(str(addr))
+    return set(sorted(ips)[:MAX_PINGERS])
+
+
+def start_pinger(ip: str) -> subprocess.Popen | None:
+    """One long-running quiet pinger per client; output discarded."""
+    try:
+        return subprocess.Popen(
+            ["ping", "-i", "0.2", "-W", "1", "-q", "-I", IFACE, ip],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return None
+
+
+def stop_pinger(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass  # reaped on our exit; never wedge the loop
+
+
+def main() -> None:
+    log(f"vanchor-wifi-keepalive: watching {IFACE} clients "
+        f"(reconcile {RECONCILE_S}s, cap {MAX_PINGERS})")
+    pingers: dict[str, subprocess.Popen] = {}
+    last_start: dict[str, float] = {}
+
+    while True:
+        # Reap pingers that exited on their own (unreachable client, iface
+        # bounce, ...). Harmless: if the client is still present it gets a
+        # fresh pinger below, backoff-limited so a crash-loop can't spam.
+        for ip, proc in list(pingers.items()):
+            if proc.poll() is not None:
+                del pingers[ip]
+
+        desired = desired_ips()
+        now = time.monotonic()
+
+        for ip in desired - pingers.keys():
+            if now - last_start.get(ip, -RESTART_BACKOFF_S) < RESTART_BACKOFF_S:
+                continue
+            proc = start_pinger(ip)
+            if proc is not None:
+                first_time = ip not in last_start
+                pingers[ip] = proc
+                last_start[ip] = now
+                if first_time:
+                    log(f"keepalive + {ip}")
+
+        for ip in pingers.keys() - desired:
+            stop_pinger(pingers.pop(ip))
+            last_start.pop(ip, None)
+            log(f"keepalive - {ip}")
+
+        # Forget backoff entries for clients that are fully gone.
+        for ip in list(last_start.keys() - desired - pingers.keys()):
+            if now - last_start[ip] > RESTART_BACKOFF_S:
+                del last_start[ip]
+
+        time.sleep(RECONCILE_S)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.service
+++ b/deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Vanchor WiFi client keep-alive pinger (keeps phone radios awake)
+After=NetworkManager.service vanchor-hotspot.service
+Wants=NetworkManager.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/sbin/vanchor-wifi-keepalive
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -149,6 +149,56 @@ def test_net_chroot_frees_gpio_uart():
     assert "disable hciuart" in text                       # BT-UART service off
 
 
+def test_wifi_keepalive_service():
+    """The keep-alive pinger unit must start after NM + the hotspot, restart
+    forever, and run the installed script."""
+    path = STAGE_ROOT / "01-net" / "files" / "vanchor-wifi-keepalive.service"
+    assert path.exists()
+    text = path.read_text()
+    assert "After=NetworkManager.service vanchor-hotspot.service" in text
+    assert "Restart=always" in text
+    assert "WantedBy=multi-user.target" in text
+    assert "ExecStart=/usr/bin/python3 /usr/local/sbin/vanchor-wifi-keepalive" in text
+
+
+def test_wifi_keepalive_script_content():
+    """The pinger must merge BOTH discovery sources (iw station dump + NM
+    dnsmasq leases, MAC->IP via the wlan0 neighbor table), keep ONE
+    long-running sub-second ping process per client (no per-packet forking),
+    kill pingers of departed clients, and never ping outside wlan0's own
+    subnet. Zero-network: no curl/apt/docker-pull."""
+    path = STAGE_ROOT / "01-net" / "files" / "vanchor-wifi-keepalive.py"
+    assert path.exists()
+    text = path.read_text()
+
+    # Discovery: associated stations + leases (with glob fallback), MAC->IP
+    # via the interface-scoped neighbor table.
+    assert "station" in text and "dump" in text, "must read iw station dump"
+    assert "/var/lib/NetworkManager/dnsmasq-wlan0.leases" in text
+    assert "/var/lib/NetworkManager/dnsmasq-*.leases" in text, \
+        "must glob-fallback for NM shared-mode lease files"
+    assert '"neigh"' in text, "must map MAC->IP via the neighbor table"
+
+    # One long-running ping per client at 0.2 s, in parallel; reconciled.
+    assert '"ping", "-i", "0.2", "-W", "1", "-q"' in text
+    assert "Popen" in text, "pingers must be parallel long-running processes"
+    assert "terminate()" in text and "poll()" in text, \
+        "departed clients must be killed and exits reaped"
+
+    # Safety: only the wlan0 subnet is ever pinged -- addresses are checked
+    # against the interface's own network, defaulting to the NM shared range.
+    assert "ipaddress" in text
+    assert "addr not in network" in text, \
+        "must drop any candidate IP outside wlan0's own subnet"
+    assert "10.42.0.0/24" in text, "fallback subnet must be the NM shared range"
+
+    # Zero-network / no package management (also enforced by the boot-time
+    # guard, but assert explicitly here).
+    assert "curl" not in text
+    assert "apt-get" not in text and "apt install" not in text
+    assert "docker pull" not in text
+
+
 def test_hotspot_service():
     path = STAGE_ROOT / "01-net" / "files" / "vanchor-hotspot.service"
     assert path.exists()
@@ -284,6 +334,7 @@ BOOT_TIME_SCRIPTS_FIXED = [
     STAGE_ROOT / "02-stack" / "01-run-chroot.sh",
     STAGE_ROOT / "02-stack" / "files" / "vanchor-load-images.sh",
     STAGE_ROOT / "03-trim" / "00-run-chroot.sh",
+    STAGE_ROOT / "01-net" / "files" / "vanchor-wifi-keepalive.py",
 ]
 
 # 00-docker runs at BUILD time in the pi-gen chroot with network; it's exempt


### PR DESCRIPTION
## Why

The boat Pi is a WiFi AP and the operator's phone naps its WiFi radio aggressively (worse in Low Power Mode). That showed up as telemetry hiccups and brief "connection lost" moments in the UI at anchor. Constant ICMP traffic toward the phone keeps its radio awake — a standard trick for latency-sensitive AP setups. This complements the already-shipped relaxed WS keepalive in the app.

## Design

New `vanchor-wifi-keepalive.service` (python3 stdlib only, runs as root, `Restart=always`, ordered after NetworkManager + vanchor-hotspot):

- **Discovery, two sources merged:** `iw dev wlan0 station dump` gives the associated MACs (fast truth); each MAC is resolved to an IPv4 via the kernel neighbor table (`ip -4 neigh show dev wlan0`, wins on conflict) and NM shared-mode dnsmasq leases (`/var/lib/NetworkManager/dnsmasq-wlan0.leases`, plus a `dnsmasq-*.leases` glob fallback). Absent files/commands degrade gracefully; if `iw` itself is unavailable, it falls back to all known lease/neighbor IPs.
- **One long-running `ping -i 0.2 -W 1 -q -I wlan0 <ip>` process per client** — 5 pings/s, no per-packet forking, output discarded, capped at 16 pingers.
- **Reconcile every ~1.5 s:** the supervisor diffs the current client set against running pingers — a new client gets a pinger within one loop, a departed client's pinger is terminated, and self-exited pingers are reaped each loop (respawn is backoff-limited to once per 10 s) so a dead/unreachable client can never wedge the loop.
- **Safety:** candidate IPs are filtered against wlan0's *own* subnet (read from the interface, falling back to the NM shared default 10.42.0.0/24); the Pi's own address, network and broadcast addresses, and anything external are never pinged. This is asserted in the content test.
- **Quiet:** one journal line per client add/remove, nothing per-ping.

Wired into the image exactly like the hotspot service: installed in `01-net/00-run.sh`, enabled in `01-net/01-run-chroot.sh` (existing installs untouched/unordered). Tests: unit-content + script-content checks added to `tests/test_image_tooling.py`, and the script joins `BOOT_TIME_SCRIPTS_FIXED` (zero-network guard). CHANGELOG entry under Unreleased.

## BENCH-VERIFY caveats

- The actual keep-awake effect (0.2 s ICMP cadence vs. a given phone's power-save timing, especially iOS Low Power Mode) is unverifiable without real Pi + phone hardware.
- Add-latency ≤ one 1.5 s reconcile loop, and NM's lease-file path in shared mode, should be confirmed on the bench.

## Manual install on an existing Pi (no reflash)

```
scp deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.py \
    pi@vanchor:/tmp/
scp deploy/image/stage-vanchor/01-net/files/vanchor-wifi-keepalive.service \
    pi@vanchor:/tmp/
ssh pi@vanchor
  sudo install -m 0755 /tmp/vanchor-wifi-keepalive.py /usr/local/sbin/vanchor-wifi-keepalive
  sudo install -m 0644 /tmp/vanchor-wifi-keepalive.service /etc/systemd/system/vanchor-wifi-keepalive.service
  sudo systemctl daemon-reload
  sudo systemctl enable --now vanchor-wifi-keepalive.service
  journalctl -fu vanchor-wifi-keepalive   # expect "keepalive + <phone ip>" when a phone joins
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)