### PR TITLE
feat(ublox-tools): read + set which NMEA sentences the receiver transmits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Receiver setup can now read and edit which NMEA sentences the u-blox
+  transmits.** The GPS card's "Receiver setup (u-blox)" section gained an NMEA
+  sentences panel: **Read current** shows the chip's per-sentence output state
+  (RMC/GGA/GLL/GSA/GSV/VTG, via UBX CFG-VALGET), toggles set them on/off on
+  both UART and USB (optionally saved to flash), with RMC/GGA marked as what
+  vanchor actually needs and a confirmation guard before turning RMC off (it
+  carries the speed + course vanchor relies on). Fixes the "receiver only sends
+  GGA/GLL" class of problem at the source instead of widening the parser.
+  Bench-verified against a real M9N (VALGET read-back + GLL on/off round-trip).
+
 ## [1.5.0a22] — 2026-08-11
 
 - **Devices menu overhauled: everything for one device in one place.** The

--- a/src/vanchor/nav/ubx.py
+++ b/src/vanchor/nav/ubx.py
@@ -217,10 +217,74 @@ KEY_MSGOUT_NAV_PVT_UART1 = 0x20910007  # U1
 KEY_MSGOUT_NAV_PVT_USB = 0x20910009    # U1
 
 MON_VER = (0x0A, 0x04)  # UBX-MON-VER (poll for sw/hw version)
+CFG_VALGET = (0x06, 0x8B)  # UBX-CFG-VALGET (poll current config values)
 ACK_ACK = (0x05, 0x01)
 ACK_NAK = (0x05, 0x00)
 
+# CFG-MSGOUT rates (U1, messages-per-epoch) for the standard NMEA sentences,
+# per output port. From the u-blox gen-9 interface description (M9, PROTVER
+# 27+). BENCH-VERIFY: confirmed against a real M9N over USB (VALGET reads them
+# back and VALSET toggling GLL was observed in the live stream).
+NMEA_MSGOUT_KEYS: dict[str, dict[str, int]] = {
+    #        I2C         UART1       UART2       USB         SPI
+    "GGA": {"uart1": 0x209100BB, "usb": 0x209100BD},
+    "GLL": {"uart1": 0x209100CA, "usb": 0x209100CC},
+    "GSA": {"uart1": 0x209100C0, "usb": 0x209100C2},
+    "GSV": {"uart1": 0x209100C5, "usb": 0x209100C7},
+    "RMC": {"uart1": 0x209100AC, "usb": 0x209100AE},
+    "VTG": {"uart1": 0x209100B1, "usb": 0x209100B3},
+}
+
 _SUPPORTED_BAUDS = (4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800)
+
+
+def cfg_valget_request(keys: list[int], *, layer: int = 0) -> bytes:
+    """UBX-CFG-VALGET request for the current values of ``keys``.
+
+    ``layer`` 0 = RAM (the active config). The receiver answers with a VALGET
+    response (same class/id) whose payload carries version=1 + key/value pairs;
+    decode it with :func:`parse_valget_response`."""
+    payload = bytearray(struct.pack("<BBH", 0, layer, 0))  # version, layer, position
+    for key in keys:
+        payload += struct.pack("<I", key)
+    return build_frame(CFG_VALGET[0], CFG_VALGET[1], bytes(payload))
+
+
+def parse_valget_response(payload: bytes) -> dict[int, int]:
+    """Decode a CFG-VALGET response payload into ``{key_id: value}``.
+
+    Value widths are inferred from each key's size bits (28-30), like VALSET.
+    Returns {} for a payload too short to carry the 4-byte header."""
+    out: dict[int, int] = {}
+    if len(payload) < 4:
+        return out
+    i = 4  # skip version/layer/position header
+    while i + 4 <= len(payload):
+        key = int.from_bytes(payload[i:i + 4], "little")
+        width = _KEY_SIZE_BYTES.get((key >> 28) & 0x7)
+        if width is None or i + 4 + width > len(payload):
+            break  # unknown size code / truncated pair -> stop cleanly
+        out[key] = int.from_bytes(payload[i + 4:i + 4 + width], "little")
+        i += 4 + width
+    return out
+
+
+def cfg_set_nmea_messages(rates: dict[str, int], *, layers: int = 1) -> bytes:
+    """VALSET the per-epoch output rate (0 = off, 1 = every fix) of standard
+    NMEA sentences on BOTH UART1 and USB. ``rates`` maps sentence name (see
+    :data:`NMEA_MSGOUT_KEYS`) -> rate 0..255."""
+    items: list[tuple[int, int]] = []
+    for name, rate in rates.items():
+        keys = NMEA_MSGOUT_KEYS.get(name.upper())
+        if keys is None:
+            raise ValueError(f"unknown NMEA sentence {name!r}; "
+                             f"known: {sorted(NMEA_MSGOUT_KEYS)}")
+        if not 0 <= int(rate) <= 255:
+            raise ValueError(f"rate for {name} out of range 0..255: {rate}")
+        items += [(keys["uart1"], int(rate)), (keys["usb"], int(rate))]
+    if not items:
+        raise ValueError("no sentences given")
+    return cfg_valset(items, layers=layers)
 
 
 def poll(msg_class: int, msg_id: int) -> bytes:

--- a/src/vanchor/runtime/ublox_tools.py
+++ b/src/vanchor/runtime/ublox_tools.py
@@ -125,6 +125,76 @@ async def _await_ack(transport: Any, *, timeout: float, clock: Callable[[], floa
     return None
 
 
+async def _await_frame(transport: Any, want: tuple[int, int], *, timeout: float,
+                       clock: Callable[[], float],
+                       sleep: Callable[[float], Any]) -> bytes | None:
+    """Read until a frame of class/id ``want`` arrives; return its payload."""
+    buf = b""
+    end = clock() + timeout
+    while clock() < end:
+        try:
+            data = await asyncio.wait_for(transport.read(4096), timeout=0.3)
+        except (asyncio.TimeoutError, EOFError):
+            data = b""
+        if not data:
+            await sleep(0.02)
+            continue
+        buf += data
+        frames, buf = ubx.parse_stream(buf)
+        for cls, mid, payload in frames:
+            if (cls, mid) == want:
+                return payload
+    return None
+
+
+async def read_nmea_messages(transport: Any, *, timeout: float = 2.0,
+                             clock: Callable[[], float] = time.monotonic,
+                             sleep: Callable[[float], Any] = asyncio.sleep) -> dict:
+    """Read which standard NMEA sentences the receiver currently emits.
+
+    CFG-VALGET on the RAM layer for GGA/GLL/GSA/GSV/RMC/VTG on UART1 + USB.
+    Returns ``{ok, messages: {RMC: {uart1: rate, usb: rate}, ...}}`` -- rate 0
+    means off. ``ok: False`` with an error when the receiver doesn't answer
+    (not a u-blox / UBX input disabled)."""
+    keys = [k for m in ubx.NMEA_MSGOUT_KEYS.values() for k in m.values()]
+    await transport.open()
+    try:
+        await transport.write(ubx.cfg_valget_request(keys))
+        payload = await _await_frame(transport, ubx.CFG_VALGET,
+                                     timeout=timeout, clock=clock, sleep=sleep)
+    finally:
+        await transport.close()
+    if payload is None:
+        return {"ok": False, "error": "no VALGET answer (not a u-blox, or UBX "
+                "input disabled on this port)"}
+    values = ubx.parse_valget_response(payload)
+    messages = {
+        name: {port: values.get(key) for port, key in ports.items()}
+        for name, ports in ubx.NMEA_MSGOUT_KEYS.items()
+    }
+    return {"ok": True, "messages": messages}
+
+
+async def set_nmea_messages(transport: Any, rates: dict, *, persist: bool = False,
+                            ack_timeout: float = 1.0,
+                            clock: Callable[[], float] = time.monotonic,
+                            sleep: Callable[[float], Any] = asyncio.sleep) -> dict:
+    """Set per-sentence NMEA output rates (0 = off) on UART1 + USB.
+
+    ``persist`` writes RAM+BBR+Flash. Raises ValueError for unknown sentences /
+    out-of-range rates BEFORE anything is sent."""
+    layers = 0x07 if persist else 0x01
+    frame = ubx.cfg_set_nmea_messages(rates, layers=layers)  # may raise
+    await transport.open()
+    try:
+        await transport.write(frame)
+        ack = await _await_ack(transport, timeout=ack_timeout, clock=clock,
+                               sleep=sleep)
+    finally:
+        await transport.close()
+    return {"ok": ack is True, "ack": ack}
+
+
 # What each setting maps to (name -> frame builder taking the value + layers).
 def _frames_for(nmea: bool | None, rate_hz: float | None, baud: int | None,
                 layers: int) -> list[tuple[str, bytes]]:

--- a/src/vanchor/ui/partials/panel-devices.html
+++ b/src/vanchor/ui/partials/panel-devices.html
@@ -126,6 +126,15 @@
               </label>
               <button id="ubxt-apply" class="btn-primary wide" type="button">Apply settings</button>
               <div id="ubxt-result" class="hint"></div>
+
+              <div class="ctx-sub">NMEA sentences</div>
+              <div class="hint">Which sentences the chip transmits. vanchor needs
+                <b>RMC</b> (position+speed+course) and uses <b>GGA</b> (fix quality);
+                the rest only cost bandwidth on a wired UART.</div>
+              <button id="ubxt-nmea-read" class="btn-ghost wide" type="button">Read current</button>
+              <div id="ubxt-nmea-list" class="ubxt-nmea-list"></div>
+              <button id="ubxt-nmea-apply" class="btn-primary wide hidden" type="button">Apply sentence changes</button>
+              <div id="ubxt-nmea-result" class="hint"></div>
             </details>
 
             <div id="dev-menus-gps"></div>

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -1085,6 +1085,39 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
         of the user hand-typing ``/dev/tty...`` (OpenPlotter-style auto-detect)."""
         return {"ports": runtime.list_serial_ports()}
 
+    @app.get("/api/tools/ublox/nmea-messages")
+    async def ublox_nmea_messages(port: str, baud: int = 38400) -> dict:
+        """Which standard NMEA sentences the receiver currently emits (CFG-VALGET
+        on UART1+USB for GGA/GLL/GSA/GSV/RMC/VTG). Rate 0 = off."""
+        from ..runtime import ublox_tools
+        try:
+            return await ublox_tools.read_nmea_messages(_ublox_transport(port, baud))
+        except Exception as exc:  # noqa: BLE001 - busy/missing port
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+    @app.post("/api/tools/ublox/nmea-messages")
+    async def ublox_nmea_messages_set(payload: dict) -> Response:
+        """Set per-sentence NMEA output rates: {port, baud?, rates: {RMC: 1,
+        GLL: 0, ...}, persist?}. Rate 0 disables a sentence."""
+        from ..runtime import ublox_tools
+        data = payload or {}
+        port = data.get("port")
+        rates = data.get("rates")
+        if not port or not isinstance(rates, dict) or not rates:
+            return Response(json.dumps({"ok": False,
+                            "error": "port and non-empty rates required"}),
+                            media_type="application/json", status_code=400)
+        try:
+            res = await ublox_tools.set_nmea_messages(
+                _ublox_transport(port, data.get("baud") or 38400), rates,
+                persist=bool(data.get("persist")))
+        except ValueError as exc:  # unknown sentence / bad rate -> nothing sent
+            return Response(json.dumps({"ok": False, "error": str(exc)}),
+                            media_type="application/json", status_code=400)
+        except Exception as exc:  # noqa: BLE001
+            res = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return Response(json.dumps(res), media_type="application/json")
+
     # -- Client fetch relay result (#147) ---------------------------------- #
     _RELAY_MAX_BYTES = 32 * 1024 * 1024  # defensive cap on a relayed resource
 

--- a/src/vanchor/ui/static/tools.js
+++ b/src/vanchor/ui/static/tools.js
@@ -158,11 +158,77 @@
     } catch (e) { res.textContent = "Error: " + e; }
   }
 
+  // --- NMEA sentence output config (read via VALGET, set via VALSET) ------ #
+  const NMEA_SENTENCES = ["RMC", "GGA", "GLL", "GSA", "GSV", "VTG"];
+  const NMEA_NEEDED = { RMC: "required", GGA: "used" };
+
+  async function readNmeaMessages() {
+    const port = $("ubxt-port").value, baud = $("ubxt-baud").value;
+    const res = $("ubxt-nmea-result"), list = $("ubxt-nmea-list");
+    if (!port) { res.textContent = "Pick a serial port first."; return; }
+    res.textContent = "Reading \u2026";
+    try {
+      const r = await fetch("/api/tools/ublox/nmea-messages?port=" +
+        encodeURIComponent(port) + "&baud=" + encodeURIComponent(baud));
+      const d = await r.json();
+      if (!d.ok) { res.textContent = "Error: " + (d.error || "no response"); return; }
+      list.innerHTML = "";
+      NMEA_SENTENCES.forEach((name) => {
+        const m = (d.messages || {})[name] || {};
+        const on = (m.uart1 || 0) > 0 || (m.usb || 0) > 0;
+        const row = document.createElement("label");
+        row.className = "switch";
+        const cb = document.createElement("input");
+        cb.type = "checkbox"; cb.checked = on; cb.dataset.nmea = name;
+        cb.addEventListener("change", () => $("ubxt-nmea-apply").classList.remove("hidden"));
+        const track = document.createElement("span"); track.className = "track";
+        row.appendChild(cb); row.appendChild(track);
+        const tag = NMEA_NEEDED[name];
+        row.appendChild(document.createTextNode(" " + name +
+          (tag ? " \u2014 " + (tag === "required" ? "needed by vanchor" : "used by vanchor") : "")));
+        list.appendChild(row);
+      });
+      res.textContent = "";
+    } catch (e) { res.textContent = "Error: " + e; }
+  }
+
+  async function applyNmeaMessages() {
+    const port = $("ubxt-port").value;
+    const res = $("ubxt-nmea-result");
+    const rates = {};
+    document.querySelectorAll("#ubxt-nmea-list input[data-nmea]").forEach((cb) => {
+      rates[cb.dataset.nmea] = cb.checked ? 1 : 0;
+    });
+    if (rates.RMC === 0 && !window.confirm(
+        "Turning RMC off removes speed + course from vanchor (GPS shows 0 kn, " +
+        "no compass-loss fallback). Turn it off anyway?")) {
+      return;
+    }
+    res.textContent = "Applying \u2026";
+    try {
+      const r = await fetch("/api/tools/ublox/nmea-messages", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ port: port, baud: parseInt($("ubxt-baud").value, 10),
+                               rates: rates, persist: $("ubxt-persist").checked }),
+      });
+      const d = await r.json();
+      if (d.ok) {
+        res.textContent = "Applied \u2713" + ($("ubxt-persist").checked ? " \u00b7 saved to flash" : "");
+        $("ubxt-nmea-apply").classList.add("hidden");
+      } else {
+        res.textContent = "Failed: " + (d.error || JSON.stringify(d));
+      }
+    } catch (e) { res.textContent = "Error: " + e; }
+  }
+
   function init() {
     const read = $("ubxt-read"), apply = $("ubxt-apply");
     if (!read && !apply) return;   // toolbox markup not present
     if (read) read.addEventListener("click", readStats);
     if (apply) apply.addEventListener("click", applySettings);
+    const nmeaRead = $("ubxt-nmea-read"), nmeaApply = $("ubxt-nmea-apply");
+    if (nmeaRead) nmeaRead.addEventListener("click", readNmeaMessages);
+    if (nmeaApply) nmeaApply.addEventListener("click", applyNmeaMessages);
     // Refresh the port list + prefill from the GPS config on every open of the
     // disclosure (prefill runs AFTER the refresh so it can't be clobbered).
     const det = $("ublox-tools-card");

--- a/tests/test_ublox_tools.py
+++ b/tests/test_ublox_tools.py
@@ -116,3 +116,41 @@ async def test_apply_settings_bad_value_raises_before_sending() -> None:
     with pytest.raises(ValueError):
         await tools.apply_settings(tr, baud=12345)
     assert tr.written == []  # nothing sent when the plan can't be built
+
+
+async def test_read_nmea_messages_decodes_receiver_answer() -> None:
+    clk = FakeClock()
+    keys = ubx.NMEA_MSGOUT_KEYS
+    resp = bytes([1, 0, 0, 0])
+    for name, rate in (("RMC", 1), ("GGA", 1), ("GLL", 0)):
+        for port in ("uart1", "usb"):
+            resp += keys[name][port].to_bytes(4, "little") + bytes([rate])
+    tr = FakeTransport([ubx.build_frame(*ubx.CFG_VALGET, resp)])
+    out = await tools.read_nmea_messages(tr, clock=clk.now, sleep=clk.sleep)
+    assert out["ok"] is True
+    assert out["messages"]["RMC"] == {"uart1": 1, "usb": 1}
+    assert out["messages"]["GLL"] == {"uart1": 0, "usb": 0}
+    assert out["messages"]["GSV"] == {"uart1": None, "usb": None}  # not answered
+    # The request actually asked for all table keys.
+    frames, _ = ubx.parse_stream(tr.written[0])
+    assert frames[0][:2] == ubx.CFG_VALGET
+
+
+async def test_read_nmea_messages_no_answer_is_clear_error() -> None:
+    clk = FakeClock()
+    out = await tools.read_nmea_messages(FakeTransport([]), timeout=0.3,
+                                         clock=clk.now, sleep=clk.sleep)
+    assert out["ok"] is False and "VALGET" in out["error"]
+
+
+async def test_set_nmea_messages_acks_and_validates() -> None:
+    clk = FakeClock()
+    ack = ubx.build_frame(*ubx.ACK_ACK, b"\x06\x8a")
+    tr = FakeTransport([ack])
+    out = await tools.set_nmea_messages(tr, {"GLL": 0}, clock=clk.now, sleep=clk.sleep)
+    assert out == {"ok": True, "ack": True}
+    import pytest
+    tr2 = FakeTransport([])
+    with pytest.raises(ValueError):
+        await tools.set_nmea_messages(tr2, {"BAD": 1})
+    assert tr2.written == []                             # nothing sent on bad input

--- a/tests/test_ublox_tools_api.py
+++ b/tests/test_ublox_tools_api.py
@@ -27,3 +27,15 @@ def test_apply_requires_a_port(tmp_path):
     with _client(tmp_path) as c:
         r = c.post("/api/tools/ublox/apply", json={"nmea": True})
         assert r.status_code == 400 and r.json()["ok"] is False
+
+
+def test_nmea_messages_post_validation(tmp_path):
+    with _client(tmp_path) as c:
+        r = c.post("/api/tools/ublox/nmea-messages", json={"rates": {"RMC": 1}})
+        assert r.status_code == 400                      # port required
+        r = c.post("/api/tools/ublox/nmea-messages", json={"port": "/dev/x"})
+        assert r.status_code == 400                      # rates required
+        r = c.post("/api/tools/ublox/nmea-messages",
+                   json={"port": "/dev/x", "rates": {"ZDA": 1}})
+        assert r.status_code == 400                      # unknown sentence
+        assert "ZDA" in r.json()["error"]

--- a/tests/test_ubx.py
+++ b/tests/test_ubx.py
@@ -342,3 +342,49 @@ def test_describe_marine_config_matches_frame() -> None:
     items = _valset_items(ubx.cfg_marine_10hz())
     assert items[ubx.KEY_UART1OUTPROT_NMEA] == 0 and items[ubx.KEY_USBOUTPROT_NMEA] == 0
     assert items[ubx.KEY_RATE_MEAS] == 100  # 10 Hz
+
+
+# --- NMEA message output config (toolbox read/set) -------------------------- #
+
+def test_cfg_valget_request_and_response_roundtrip() -> None:
+    keys = [ubx.NMEA_MSGOUT_KEYS["RMC"]["uart1"], ubx.NMEA_MSGOUT_KEYS["GLL"]["usb"]]
+    req = ubx.cfg_valget_request(keys)
+    frames, rem = ubx.parse_stream(req)
+    assert rem == b"" and frames[0][:2] == ubx.CFG_VALGET
+    payload = frames[0][2]
+    assert payload[0] == 0 and payload[1] == 0          # version, RAM layer
+    assert len(payload) == 4 + 4 * len(keys)
+    # A receiver-style response: version=1 header + key/value pairs (U1 values).
+    resp = bytes([1, 0, 0, 0])
+    for k, v in ((keys[0], 1), (keys[1], 0)):
+        resp += k.to_bytes(4, "little") + bytes([v])
+    out = ubx.parse_valget_response(resp)
+    assert out == {keys[0]: 1, keys[1]: 0}
+
+
+def test_parse_valget_response_truncated_and_short() -> None:
+    assert ubx.parse_valget_response(b"") == {}
+    assert ubx.parse_valget_response(b"\x01\x00\x00") == {}
+    # A truncated trailing pair is dropped without raising.
+    key = ubx.NMEA_MSGOUT_KEYS["GGA"]["uart1"]
+    resp = bytes([1, 0, 0, 0]) + key.to_bytes(4, "little")  # key, no value byte
+    assert ubx.parse_valget_response(resp) == {}
+
+
+def test_cfg_set_nmea_messages_builds_both_ports() -> None:
+    frame = ubx.cfg_set_nmea_messages({"RMC": 1, "GLL": 0})
+    items = _valset_items(frame)
+    assert items[ubx.NMEA_MSGOUT_KEYS["RMC"]["uart1"]] == 1
+    assert items[ubx.NMEA_MSGOUT_KEYS["RMC"]["usb"]] == 1
+    assert items[ubx.NMEA_MSGOUT_KEYS["GLL"]["uart1"]] == 0
+    assert items[ubx.NMEA_MSGOUT_KEYS["GLL"]["usb"]] == 0
+
+
+def test_cfg_set_nmea_messages_validates() -> None:
+    import pytest
+    with pytest.raises(ValueError):
+        ubx.cfg_set_nmea_messages({"ZDA": 1})            # not in the table
+    with pytest.raises(ValueError):
+        ubx.cfg_set_nmea_messages({"RMC": 300})          # rate out of range
+    with pytest.raises(ValueError):
+        ubx.cfg_set_nmea_messages({})


### PR DESCRIPTION
Follow-on from the "what if the GPS only sends GGA/GLL?" discussion: instead of widening the NMEA parser, **fix it at the source** — the u-blox toolbox can now read and edit the chip's per-sentence output configuration.

## What it does
GPS card → Receiver setup → **NMEA sentences**:
- **Read current** — UBX `CFG-VALGET` for RMC/GGA/GLL/GSA/GSV/VTG on UART1 + USB, shown as toggles
- **Apply** — `CFG-VALSET` on both ports (rate 1/0), with the existing *Save to flash* switch
- RMC is labeled **"needed by vanchor"** (position+speed+course), GGA **"used by vanchor"** — and turning RMC off requires an explicit confirmation explaining what breaks (SOG=0, no compass-loss fallback)

## Bench-verified on a real M9N (`/dev/ttyACM0`)
- VALGET reads all six sentences × both ports (all rate 1 on this unit)
- `GLL 1→0→1`: both sets ACK'd and the read-back reflects each state — key IDs confirmed against hardware, not just the interface manual

## Layers
`nav/ubx.py` (VALGET builder/parser + key table + set builder, all unit-tested) → `runtime/ublox_tools.py` (transport-seam service, clear "no VALGET answer" error for non-u-blox devices) → two endpoints → tools.js UI.

+8 tests. Full suite **2321 passed**; e2e 29/29; ruff + node clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)