### PR TITLE
ux: explicit expand chevrons on nested disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Nested settings disclosures now clearly look expandable.** The sub-cards
+  inside a device card ("Advanced (8N1)…", "Receiver setup (u-blox)…") had no
+  expand indicator at all (their flex summaries suppressed the browser's
+  default triangle) — they now carry an accent ▸ chevron that rotates when
+  open, and the device cards' own trailing chevron is bigger and brighter.
+
 ## [1.5.0a23] — 2026-08-11
 
 - **Receiver setup can now read and edit which NMEA sentences the u-blox

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -2738,6 +2738,19 @@ body[data-view="instruments"] #hud .hud-sub { font-size: 15px; }
   display: flex; align-items: center;
 }
 #dev-body details.adv[open] > summary { color: var(--text); }
+/* Expand affordance (operator feedback): summary's display:flex suppresses the
+   browser's default disclosure triangle, leaving these nested cards looking
+   like static text. Add an explicit leading chevron that rotates when open. */
+#dev-body details.adv > summary::before {
+  content: "\25B8"; display: inline-block; flex: 0 0 auto;
+  margin-right: 6px; color: var(--accent); font-size: 13px;
+  transition: transform 0.2s;
+}
+#dev-body details.adv[open] > summary::before { transform: rotate(90deg); }
+/* Device sub-cards keep the theme's trailing chevron but make it unmissable. */
+.command-menu details.dev-card > summary::after {
+  color: var(--text); font-size: 15px;
+}
 
 /* Sticky dirty-state Save (Task 4): hidden until the form is edited, then
    sticks to the bottom of the settings scroll on the panel background so the


### PR DESCRIPTION
Operator feedback on the a22 Devices overhaul: the nested sub-cards ("Advanced (8N1)…", "Receiver setup (u-blox)…") gave no visual hint they expand — their flex summaries suppress the browser's default disclosure triangle and no custom marker was added. Now: leading accent **▸** chevron on every nested disclosure (rotates 90° when open), and the device cards' own trailing chevron rendered bigger/brighter. CSS-only; rendering verified via computed style + screenshot in a 390 px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)