### PR TITLE
feat(devices): classify + surface serial link faults on the device chips (#142, #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Device failures now say WHY, right on the device card (#142, #161).** A
+  serial device that can't open its port used to die silently for the whole
+  session with only a server-log line. Now: the error is classified into an
+  actionable message ("permission denied — the app isn't in the dialout
+  group…", "no device at /dev/ttyUSB0 — check the cable/port", "port in use",
+  "link unstable — reconnected 4× in the last minute"), shown on the device
+  chip (amber ⚠), in the debug view ("NOT RECEIVING — …"), and logged once per
+  change in the alert history. Better still, a failed open no longer kills the
+  device: the reconnect loop keeps retrying, so plugging the cable in later
+  just works. The u-blox driver's open failures get the same treatment.
+
 - **Nested settings disclosures now clearly look expandable.** The sub-cards
   inside a device card ("Advanced (8N1)…", "Receiver setup (u-blox)…") had no
   expand indicator at all (their flex summaries suppressed the browser's

--- a/src/vanchor/hardware/drivers/ublox.py
+++ b/src/vanchor/hardware/drivers/ublox.py
@@ -50,6 +50,8 @@ class UbloxGps(Sensor):
         self._last_pvt: ubx.NavPvt | None = None
         # Latest signal quality (every decode, incl. rejected fixes); see _emit.
         self.signal: dict | None = None
+        # Link fault (open failure etc., #142); cleared when frames flow.
+        self.last_error: str | None = None
         self._last_pvt_monotonic: float | None = None
         self._frames_received = 0
 
@@ -86,6 +88,9 @@ class UbloxGps(Sensor):
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001 - port not ready -> back off
+                from ..serial_devices import classify_serial_error
+                self.last_error = classify_serial_error(
+                    exc, str(getattr(self.transport, "port", "?")))
                 logger.warning("%s: open failed (%s); retrying", self._name, exc)
                 self.healthy = False
                 await asyncio.sleep(2.0)
@@ -121,6 +126,7 @@ class UbloxGps(Sensor):
         self._last_pvt = pvt
         self._last_pvt_monotonic = time.monotonic()
         self._frames_received += 1
+        self.last_error = None            # frames flowing -> link fault cleared
         # Live signal-quality snapshot, kept for EVERY decode (valid or not) so
         # the UI can say "receiving, fix below quality gate (4 sats)" instead of
         # a bare "GPS lost" (#142). Read by _device_health via duck typing.
@@ -144,6 +150,8 @@ class UbloxGps(Sensor):
         """Operator-facing one-liner distinguishing "no data" / "acquiring" /
         "fix below the receiver's quality gate" from a healthy fix -- so the UI
         never reduces a weak-signal state to a bare "GPS lost"."""
+        if self.last_error is not None:
+            return self.last_error        # link fault outranks signal quality
         s = self.signal
         if s is None:
             return None

--- a/src/vanchor/hardware/serial_devices.py
+++ b/src/vanchor/hardware/serial_devices.py
@@ -196,6 +196,21 @@ class _SerialReadSupervisor:
         self._stop = asyncio.Event()
         self.healthy: bool = False
         self.last_data_monotonic: float | None = None
+        # Operator-facing failure state (#142): why the link is down, plus a
+        # reconnect-storm detector (a link that keeps flapping is its own fault
+        # class even though each individual reconnect "works").
+        self.last_error: str | None = None
+        self._reconnect_times: deque[float] = deque(maxlen=8)
+
+    def _note_reconnected(self) -> None:
+        now = _time.monotonic()
+        self._reconnect_times.append(now)
+        recent = [ts for ts in self._reconnect_times if now - ts <= 60.0]
+        if len(recent) >= 4:
+            self.last_error = (f"link unstable \u2014 reconnected "
+                               f"{len(recent)}\u00d7 in the last minute")
+        else:
+            self.last_error = None
 
     def request_stop(self) -> None:
         """Ask the loop to exit; unblocks a backoff wait immediately."""
@@ -225,6 +240,8 @@ class _SerialReadSupervisor:
                 await self._reconnect()
                 continue
             self.last_data_monotonic = _time.monotonic()
+            if self.last_error is not None and len(self._reconnect_times) < 4:
+                self.last_error = None      # data flowing again -> fault cleared
             await self._handle_line(line)
 
     def _warn_garbage(self, exc: BaseException, last_warn: float) -> float:
@@ -257,6 +274,8 @@ class _SerialReadSupervisor:
                 raise
             except Exception as exc:
                 next_backoff = min(backoff * 2, self._backoff_max)
+                port = getattr(self.transport, "port", "?")
+                self.last_error = classify_serial_error(exc, str(port))
                 logger.warning(
                     "%s: reconnect failed (%s); retrying in %.0fs",
                     self._name,
@@ -267,6 +286,7 @@ class _SerialReadSupervisor:
                 continue
             logger.info("%s: serial reconnected", self._name)
             self.healthy = True
+            self._note_reconnected()
             return
 
     async def _wait(self, delay: float) -> bool:
@@ -355,6 +375,9 @@ class _SerialNmeaSensor(Sensor):
         try:
             port = getattr(self.transport, "port", None) or repr(self.transport)
             if not self._recent_lines:
+                err = self._sup.last_error
+                if err:
+                    return f"{cls}: NOT RECEIVING \u2014 {err}"
                 return f"{cls}: waiting for data…"
             lines = [
                 cls,
@@ -375,8 +398,25 @@ class _SerialNmeaSensor(Sensor):
         # task, so a shared port never gets two readers on one stream.
         if self._task is not None and not self._task.done():
             return
-        await self.transport.open()
+        try:
+            await self.transport.open()
+        except Exception as exc:  # noqa: BLE001 - record + keep retrying (#142)
+            # A failed open used to kill the device for the whole session with
+            # only a server-log line to show for it. Record an actionable error
+            # (shown on the device chip + debug view) and start the supervisor
+            # anyway: its reconnect loop retries with backoff, so a cable
+            # plugged in later just works.
+            port = getattr(self.transport, "port", "?")
+            self._sup.last_error = classify_serial_error(exc, str(port))
+            logger.warning("%s: open failed (%s); will keep retrying",
+                           type(self).__name__, exc)
         self._task = asyncio.ensure_future(self._sup.run())
+
+    @property
+    def status_detail(self) -> str | None:
+        """Operator-facing link fault (#142), or None when the link is fine.
+        Surfaced by _device_health onto the device chip and debug view."""
+        return self._sup.last_error
 
     async def stop(self) -> None:
         if self._task is None:
@@ -399,6 +439,25 @@ class SerialCompass(_SerialNmeaSensor):
 # Motor controller
 # --------------------------------------------------------------------------- #
 TimeFn = Callable[[], float]
+
+
+def classify_serial_error(exc: BaseException, port: str) -> str:
+    """Operator-facing one-liner for a serial open/read failure (#142).
+
+    The raw exceptions ("[Errno 13] could not open port ...") explain nothing
+    actionable; these do. Kept deliberately blunt -- they render on the device
+    chip and in the debug view."""
+    msg = str(exc)
+    if isinstance(exc, PermissionError) or "Errno 13" in msg or "Permission" in msg:
+        return (f"permission denied opening {port} \u2014 the app isn't in the "
+                "dialout group (automatic on the SD image; on a dev box run "
+                "under `sg dialout` or add the user and re-login)")
+    if isinstance(exc, FileNotFoundError) or "Errno 2" in msg or "No such file" in msg:
+        return f"no device at {port} \u2014 check the cable/port"
+    if "in use" in msg or "busy" in msg.lower() or "Errno 16" in msg:
+        return f"{port} is in use by another program"
+    return f"cannot open {port}: {msg[:120]}"
+
 
 
 class SerialMotorController(MotorController):

--- a/src/vanchor/ui/static/health.js
+++ b/src/vanchor/ui/static/health.js
@@ -192,12 +192,26 @@
     if (el.dataset.state !== state) el.dataset.state = state;
   }
 
+  const prevDevErr = {};   // per-device edge trigger for the alert log (#142)
+
   function renderDevChips(h) {
     const devs = (h && h.devices) || {};
     ["gps", "compass", "depth", "motor"].forEach(function (name) {
       const d = devs[name];
       if (!d) { setChip("dev-chip-" + name, "—", ""); return; }
       const fresh = !!d.healthy && d.data_age_s != null && d.data_age_s < FRESH_S;
+      // Fault detail (#142/#161): a device that is configured but broken says
+      // WHY on its chip (permission, missing device, link storm, weak signal)
+      // instead of a mute "no data". Edge-triggered alert-log entry per change.
+      if (!fresh && d.detail) {
+        setChip("dev-chip-" + name, "⚠ " + d.detail, "warn");
+        if (prevDevErr[name] !== d.detail) {
+          prevDevErr[name] = d.detail;
+          if (VA.logAlert) VA.logAlert("warn", name.toUpperCase() + ": " + d.detail, { kind: "device" });
+        }
+        return;
+      }
+      if (prevDevErr[name]) prevDevErr[name] = null;
       if (!fresh) { setChip("dev-chip-" + name, "no data", "stale"); return; }
       let txt = "● " + fmtAge(d.data_age_s);
       if (name === "gps" && d.signal && d.signal.num_sv != null) {

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -711,6 +711,7 @@ input[type=range]::-moz-range-thumb { width: 18px; height: 18px; border-radius: 
   border-radius: 999px; padding: 2px 8px;
 }
 .dev-chip[data-state="ok"] { color: var(--accent-2); border-color: color-mix(in srgb, var(--accent-2) 40%, var(--line)); }
+.dev-chip[data-state="warn"] { color: var(--warn, #e0a63a); border-color: color-mix(in srgb, var(--warn, #e0a63a) 45%, var(--line)); max-width: 60%; }
 /* Guided-setup front door (Task 5): extra prominence while nothing is
    configured yet; devices.js toggles the class (demoted = plain .btn-ghost). */
 #hwwiz-open.frontdoor { min-height: 56px; font-size: 16px; }

--- a/tests/test_serial_devices.py
+++ b/tests/test_serial_devices.py
@@ -510,3 +510,58 @@ async def test_motor_feedback_reconnects_after_eof() -> None:
     await _pump(lambda: motor.last_feedback == SteeringFeedback(2.0, False, 5.0))
     assert motor.last_feedback == SteeringFeedback(2.0, False, 5.0)
     await motor.stop()
+
+
+# --- Operator-facing failure state (#142) ----------------------------------- #
+
+def test_classify_serial_error_messages():
+    from vanchor.hardware.serial_devices import classify_serial_error
+    assert "dialout" in classify_serial_error(
+        PermissionError(13, "could not open port /dev/ttyACM0"), "/dev/ttyACM0")
+    assert "check the cable" in classify_serial_error(
+        FileNotFoundError(2, "No such file or directory"), "/dev/ttyUSB3")
+    assert "in use" in classify_serial_error(OSError("Device or resource busy"), "/dev/x")
+    assert "cannot open /dev/y" in classify_serial_error(RuntimeError("weird"), "/dev/y")
+
+
+async def test_open_failure_records_error_and_keeps_retrying():
+    # A failed open no longer kills the device: the error is recorded (chip +
+    # debug) and the supervisor's reconnect loop heals when the port appears.
+    from vanchor.hardware.serial_devices import SerialGps
+    from vanchor.hardware.serial_link import FakeSerialTransport
+
+    async def instant(_s):  # collapse the backoff for the test
+        return None
+
+    t = FakeSerialTransport()
+    t._open_failures = 2                     # first open + first reconnect fail
+    gps = SerialGps(t, None, sleep=instant)
+    await gps.start()                        # does not raise
+    assert gps.status_detail is not None
+    assert "cannot open" in gps.status_detail or "no device" in gps.status_detail
+    assert "NOT RECEIVING" in gps.debug()
+    # Give the reconnect loop a few turns: second retry succeeds, then a line
+    # flows and the fault clears.
+    t.feed("$GPRMC,x*00")
+    for _ in range(40):
+        await asyncio.sleep(0)
+    assert gps.healthy
+    assert gps.status_detail is None         # fault cleared by flowing data
+    await gps.stop()
+
+
+async def test_reconnect_storm_is_reported():
+    from vanchor.hardware.serial_devices import _SerialReadSupervisor
+    from vanchor.hardware.serial_link import FakeSerialTransport
+
+    async def handle(_line):
+        return None
+
+    async def instant(_s):
+        return None
+
+    t = FakeSerialTransport()
+    sup = _SerialReadSupervisor(t, handle, name="x", sleep=instant)
+    for _ in range(4):
+        sup._note_reconnected()
+    assert sup.last_error is not None and "link unstable" in sup.last_error


### PR DESCRIPTION
Closes #142, closes #161.

Every debugging saga this week shared one root cause: **failures were invisible**. This finishes the visibility work:

- **Classified, actionable errors**: `PermissionError` → *"permission denied — the app isn't in the dialout group (automatic on the SD image; on a dev box run under `sg dialout`)"*; `ENOENT` → *"no device at /dev/ttyX — check the cable/port"*; busy → *"port in use"*; ≥4 reconnects/min → *"link unstable — reconnected N× in the last minute"*.
- **Surfaced everywhere it matters**: amber **⚠ chip** on the device card, `NOT RECEIVING — <why>` in the debug view, one alert-history entry per distinct fault (edge-triggered).
- **Self-healing opens**: a failed open no longer kills the device for the session — the supervisor loop retries with backoff, so plugging in the cable later just works (previously required a restart).
- u-blox driver open failures get identical treatment; its weak-signal detail (a21) now reaches the chip as well.

+3 tests. Full suite **2324 passed**; e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)