### PR TITLE
fix(image): enable I2C out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **SD image enables I2C out of the box** (`dtparam=i2c_arm=on`). Wired I2C
+  sensors — the combo-GPS magnetometers (BE-880 class) and the INA226 battery
+  shunt — previously needed a manual `raspi-config` step before `/dev/i2c-1`
+  even existed, the same trap the GPIO UART had. Now they just work on a
+  fresh flash.
+
 - **Device failures now say WHY, right on the device card (#142, #161).** A
   serial device that can't open its port used to die silently for the whole
   session with only a server-log line. Now: the error is classified into an

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -17,6 +17,11 @@ BOOT_DIR=/boot/firmware        # Bookworm; older layouts use /boot
 if [ -f "$BOOT_DIR/config.txt" ]; then
     grep -q '^enable_uart=1'        "$BOOT_DIR/config.txt" || echo 'enable_uart=1'        >> "$BOOT_DIR/config.txt"
     grep -q '^dtoverlay=disable-bt' "$BOOT_DIR/config.txt" || echo 'dtoverlay=disable-bt' >> "$BOOT_DIR/config.txt"
+    # I2C for wired sensors (combo-GPS magnetometers, INA226 battery shunt):
+    # without this /dev/i2c-1 doesn't exist and every I2C device needs a manual
+    # raspi-config step -- the same trap the UART had. The container already
+    # carries smbus2 + the c 89:* device rule; this makes the bus exist.
+    grep -q '^dtparam=i2c_arm=on'   "$BOOT_DIR/config.txt" || echo 'dtparam=i2c_arm=on'   >> "$BOOT_DIR/config.txt"
 fi
 if [ -f "$BOOT_DIR/cmdline.txt" ]; then
     # Drop the serial-console token so getty no longer holds the port.

--- a/docs/compass-magnetometer.md
+++ b/docs/compass-magnetometer.md
@@ -30,8 +30,9 @@ Raspberry Pi:
 | SDA | GPIO 2 (SDA1) |
 | SCL | GPIO 3 (SCL1) |
 
-Enable I2C on the Pi once: `sudo raspi-config` → **Interface Options → I2C →
-Yes**, then reboot. The bus is then `/dev/i2c-1`.
+The SD image enables I2C out of the box (the bus is `/dev/i2c-1`). Only on a
+self-installed Pi OS do you need to enable it once: `sudo raspi-config` →
+**Interface Options → I2C → Yes**, then reboot.
 
 ## Enable it
 

--- a/tests/test_image_tooling.py
+++ b/tests/test_image_tooling.py
@@ -110,6 +110,8 @@ def test_net_chroot_speeds_up_offline_boot():
     assert "systemctl disable NetworkManager-wait-online.service" in text
     assert "disable_splash=1" in text
     assert "boot_delay=0" in text
+    # I2C bus must exist out of the box (magnetometer / INA226 without raspi-config).
+    assert "dtparam=i2c_arm=on" in text
 
 
 def test_dnsmasq_aliases_connectivity_checks():


### PR DESCRIPTION
I2C was never enabled in the image — only the container-side pieces existed (smbus2 baked in, `c 89:*` cgroup rule), but without `dtparam=i2c_arm=on` the host has no `/dev/i2c-1` at all, so every wired I2C sensor (BE-880-class magnetometers, INA226 battery shunt) required a manual `raspi-config` step — the same trap the GPIO UART had before #141. One line in the same chroot block fixes it; docs updated (image = works out of the box; self-installed OS = the old manual step); +1 image test. BENCH-VERIFY: confirm `/dev/i2c-1` exists on the next flashed boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)