### PR TITLE
feat(hud): actual satellite count on the main-screen GPS chip (#114 request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Satellite count on the main screen** (requested in discussion #114). The
+  GPS chip in the top status bar now shows the actual number of satellites
+  ("9 sat") instead of an anonymous OK dot, on every source that reports it:
+  GGA on plain NMEA receivers (BE-880 class), NAV-PVT on the u-blox driver.
+  RMC-only cycles carry the last count forward; sim/no-count sources keep the
+  old labels. Also new in telemetry: a `gps` block (`num_sv`, `h_acc_m`) --
+  which makes the GPS-walk analysis tool's accuracy-honesty check work on
+  real recordings too.
+
 ## [1.5.0a24] — 2026-08-11
 
 - **Alerts no longer pile into an unreadable stack.** When several alerts fire

--- a/src/vanchor/core/contract.py
+++ b/src/vanchor/core/contract.py
@@ -83,6 +83,7 @@ TELEMETRY_FIELDS: dict[str, dict] = {
     "rtl_recommended": {"type": "boolean", "desc": "return-to-launch recommended (e.g. low battery)"},
     "mob": {"type": "object|null", "desc": "man-overboard mark state"},
     "launch": {"type": "object|null", "desc": "captured launch point (for RTL)"},
+    "gps": {"type": "object", "desc": "receiver quality: num_sv (satellites used; GGA/NAV-PVT, null on sim), h_acc_m"},
     # --- battery / power ---
     "battery": {"type": "object", "desc": "battery snapshot (SoC, voltage, current, range)"},
     # --- charts / depth ---

--- a/src/vanchor/core/models.py
+++ b/src/vanchor/core/models.py
@@ -61,6 +61,10 @@ class GpsFix:
     vel_d_mps: float | None = None   # NED velocity, down (m/s)
     h_acc_m: float | None = None     # horizontal position accuracy estimate (m)
     s_acc_mps: float | None = None   # speed accuracy estimate (m/s)
+    # Satellites used in the solution: GGA field 7 on the NMEA path, NAV-PVT
+    # numSV on the UBX path; None on sim / RMC-only cycles (the navigator
+    # carries the last GGA value forward).
+    num_sv: int | None = None
 
     # Source-agnostic capability flags: downstream (nav.fusion) activates the
     # richer behaviour off WHAT the fix carries, not which driver produced it --

--- a/src/vanchor/core/state.py
+++ b/src/vanchor/core/state.py
@@ -235,6 +235,13 @@ class NavigationState:
             "heading_deg": round(self.heading_deg, 2),
             "heading_from_cog": self.heading_from_cog,
             "sog_knots": round(self.sog_knots, 2),
+            # GPS receiver quality (source-agnostic: GGA on NMEA, NAV-PVT on
+            # UBX; None on sim). Drives the main-screen satellite count.
+            "gps": {
+                "num_sv": self.fix.num_sv if self.fix else None,
+                "h_acc_m": (round(self.fix.h_acc_m, 1)
+                            if self.fix and self.fix.h_acc_m is not None else None),
+            },
             "fusion": {
                 "yaw_rate_dps": (round(self.yaw_rate_dps, 2)
                                  if self.yaw_rate_dps is not None else None),

--- a/src/vanchor/hardware/drivers/ublox.py
+++ b/src/vanchor/hardware/drivers/ublox.py
@@ -141,6 +141,7 @@ class UbloxGps(Sensor):
             sog_knots=pvt.sog_knots, cog_deg=pvt.cog_deg, valid=True,
             vel_n_mps=pvt.vel_n_mps, vel_e_mps=pvt.vel_e_mps, vel_d_mps=pvt.vel_d_mps,
             h_acc_m=pvt.h_acc_m, s_acc_mps=pvt.s_acc_mps,
+            num_sv=pvt.num_sv,
         )
         if self.bus is not None:
             await self.bus.publish(events.GPS_FIX_IN, fix)

--- a/src/vanchor/nav/navigator.py
+++ b/src/vanchor/nav/navigator.py
@@ -366,11 +366,14 @@ class Navigator:
         if isinstance(parsed, nmea.RMC):
             point = self._apply_offset(parsed.point)
             if parsed.valid and self.guard.check_position(point):
+                _prev = self.state.fix
                 fix = GpsFix(
                     point=point,
                     sog_knots=parsed.sog_knots,
                     cog_deg=parsed.cog_deg,
                     valid=True,
+                    # RMC carries no satellite count -- keep the last GGA's.
+                    num_sv=_prev.num_sv if _prev is not None else None,
                 )
                 self.state.fix = fix
                 self.state.fix_seq += 1
@@ -395,6 +398,7 @@ class Navigator:
                     sog_knots=self.state.sog_knots,
                     cog_deg=cog,
                     valid=True,
+                    num_sv=parsed.satellites or None,
                 )
                 self.state.fix = fix
                 self.state.fix_seq += 1

--- a/src/vanchor/ui/static/hud.js
+++ b/src/vanchor/ui/static/hud.js
@@ -33,10 +33,15 @@
 
   VA.onTelemetry(function renderHud(t) {
     // ---- top status-bar chips ----
-    const fix = fixLabel(t);
+    // The GPS chip shows the ACTUAL satellite count when the receiver reports
+    // it (discussion #114 request) -- "12 sat" beats an anonymous green dot.
+    // Sim / satellite-less sources fall back to the old OK/NO FIX labels.
+    let fix = fixLabel(t);
+    const sv = t.gps && Number.isFinite(t.gps.num_sv) ? t.gps.num_sv : null;
+    if (fix === "OK" && sv !== null) fix = sv + " sat";
     VA.setText("chip-fix-val", fix);
     const fixChip = document.getElementById("chip-fix");
-    if (fixChip) fixChip.dataset.fix = (fix === "OK") ? "ok" : (fix === "—") ? "none" : "bad";
+    if (fixChip) fixChip.dataset.fix = (fix === "OK" || sv !== null) ? "ok" : (fix === "—") ? "none" : "bad";
 
     const sog = VA.fin(t.sog_knots);
     VA.setText("chip-sog", sog === null ? "—" : sog.toFixed(1));

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -103,3 +103,25 @@ def test_gga_after_rmc_carries_forward_cog():
     assert state.fix.cog_deg == pytest.approx(90.0), (
         "GGA-only fix should carry forward the last known cog, not reset to 0"
     )
+
+
+def test_satellite_count_from_gga_carried_through_rmc():
+    """#114 request: GGA's satellite count reaches state.fix (and telemetry's
+    gps.num_sv) and survives RMC-only cycles, which carry no satellites."""
+    from vanchor.core.state import NavigationState
+    from vanchor.nav.navigator import Navigator
+
+    state = NavigationState()
+    nav = Navigator(state, bus=None)
+    nav.handle_sentence(nmea.encode_gga(GeoPoint(59.0, 18.0), satellites=9))
+    assert state.fix.num_sv == 9
+    assert state.to_dict()["gps"]["num_sv"] == 9
+    # RMC has no satellite field -> the last GGA count is carried forward.
+    nav.handle_sentence(nmea.encode_rmc(GeoPoint(59.0001, 18.0), sog_knots=1.0, cog_deg=0.0))
+    assert state.fix.num_sv == 9
+    # Sim/no-count sources stay None-safe.
+    s2 = NavigationState()
+    Navigator(s2, bus=None).handle_sentence(
+        nmea.encode_rmc(GeoPoint(59.0, 18.0), sog_knots=1.0, cog_deg=0.0))
+    assert s2.fix.num_sv is None
+    assert s2.to_dict()["gps"]["num_sv"] is None


### PR DESCRIPTION
Requested in discussion #114: show the real satellite count on the main screen instead of the green dot. Source-agnostic: GGA field 7 on plain NMEA receivers (the BE-880 case — already parsed, previously discarded), NAV-PVT numSV on the u-blox driver; RMC-only cycles carry the last GGA count forward; sim stays on the old labels. New telemetry `gps` block ({num_sv, h_acc_m}, contract-declared) — which also makes `gps_walk`'s accuracy-honesty check work on real recordings. Chip reads e.g. **`GPS · 9 sat`**. +1 test; full suite 2326 passed; e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)