### PR TITLE
feat(updates): working release discovery incl. pre-releases, one-tap install, iOS-proof sideload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **One-tap updates from GitHub, pre-releases included.** "Check for updates"
+  was silently broken: it filtered for an asset name pattern that no release
+  has used (`vanchor-app-*-arm64…`), so it always said no release found. Fixed
+  to match the real `vanchor-update-<ver>.bundle.tar` assets (legacy pattern
+  still accepted), pre-releases are labeled, and a new **Download & install**
+  button streams the bundle from GitHub straight into the chunked upload --
+  the phone's internet does the fetching; no Files-app round trip.
+- **Sideload upload no longer rejects renamed bundles.** iPhones rename
+  duplicate downloads ("…bundle 2.tar"), which the upload refused with a
+  dead-end message. The name is now canonicalized automatically (the bundle's
+  own manifest remains the real validator at inspect time), and the file
+  picker accepts what iOS actually presents (tar/octet-stream).
+
 - **Satellite count on the main screen** (requested in discussion #114). The
   GPS chip in the top status bar now shows the actual number of satellites
   ("9 sat") instead of an anonymous OK dot, on every source that reports it:

--- a/src/vanchor/ui/partials/panel-data.html
+++ b/src/vanchor/ui/partials/panel-data.html
@@ -31,12 +31,14 @@
             <b id="sys-latest-line">—</b>
             <a id="sys-download-link" class="btn-ghost" href="#" download hidden>Download</a>
           </div>
+          <button id="sys-install-btn" class="btn-primary wide" type="button" style="display:none">Download &amp; install</button>
 
           <div class="ctx-sub">Sideload update bundle</div>
-          <div class="hint">Download a <code>.bundle.tar</code> on your phone/laptop, then upload it here.</div>
+          <div class="hint">Or pick a downloaded <code>.bundle.tar</code> manually (the phone's file
+            app may have renamed it — that's fine, it is fixed automatically).</div>
           <label class="backup-file-row">
             <span>Bundle file</span>
-            <input type="file" id="sys-upload-file" accept=".tar" />
+            <input type="file" id="sys-upload-file" accept=".tar,.bundle.tar,application/x-tar,application/octet-stream" />
           </label>
           <progress id="sys-upload-progress" value="0" max="1" style="width:100%;display:none"></progress>
           <div id="sys-upload-status" class="hint"></div>

--- a/src/vanchor/ui/static/supervisor.js
+++ b/src/vanchor/ui/static/supervisor.js
@@ -68,6 +68,7 @@
   let _bundleName = null;   // after successful upload (passed to inspect/apply)
   let _manifestData = null; // last inspect result
   let _appVersion = null;   // from telemetry
+  let _latestAsset = null;  // GitHub release asset chosen by "Check for updates"
   let _supAvailable = false;
   let _activeJob = null;    // from telemetry while WS alive
   let _reconnecting = false;
@@ -195,37 +196,43 @@
     fetch("https://api.github.com/repos/AlexAsplund/Vanchor/releases?per_page=15")
       .then(function (r) { return r.json(); })
       .then(function (releases) {
-        // Find the latest release with an arm64 bundle asset
+        // Find the newest release (INCLUDING pre-releases -- every vanchor
+        // release is an alpha) carrying an update bundle. Assets are named
+        // vanchor-update-<ver>.bundle.tar; accept the legacy vanchor-app-*
+        // -arm64 pattern too.
+        function isBundle(a) {
+          return a && a.name && a.name.endsWith(".bundle.tar") &&
+            (a.name.startsWith("vanchor-update-") || a.name.startsWith("vanchor-app-"));
+        }
         let latest = null;
         for (const rel of releases) {
           if (!rel.tag_name) continue;
-          const hasBundle = (rel.assets || []).some(function (a) {
-            return a.name && a.name.startsWith("vanchor-app-") && a.name.endsWith("-arm64.bundle.tar");
-          });
-          if (!hasBundle) continue;
+          const asset = (rel.assets || []).find(isBundle);
+          if (!asset) continue;
           const ver = rel.tag_name.replace(/^v/, "");
           if (!latest || verGt(ver, latest.ver)) {
-            const asset = rel.assets.find(function (a) {
-              return a.name.startsWith("vanchor-app-") && a.name.endsWith("-arm64.bundle.tar");
-            });
-            latest = { ver, tag: rel.tag_name, asset };
+            latest = { ver, tag: rel.tag_name, asset, prerelease: !!rel.prerelease };
           }
         }
         if (!latest) {
-          setText("sys-check-status", "No arm64 bundle release found.");
+          setText("sys-check-status", "No release with an update bundle found.");
           return;
         }
         const currentVer = _appVersion;
         const isNewer = currentVer ? verGt(latest.ver, currentVer) : true;
         setText("sys-check-status",
           isNewer ? ("Update available: v" + latest.ver) : "Already up to date (v" + latest.ver + ")");
-        setText("sys-latest-line", "v" + latest.ver + (isNewer ? " ★ new" : ""));
+        setText("sys-latest-line", "v" + latest.ver
+          + (latest.prerelease ? " (pre-release)" : "") + (isNewer ? " ★ new" : ""));
         const link = $("sys-download-link");
         if (link && latest.asset) {
           link.href = latest.asset.browser_download_url;
           link.download = latest.asset.name;
           link.hidden = false;
         }
+        _latestAsset = latest.asset;
+        const inst = $("sys-install-btn");
+        if (inst) inst.style.display = isNewer ? "" : "none";
         show("sys-latest-row", true);
       })
       .catch(function (err) {
@@ -246,59 +253,116 @@
     show("sys-compat-warning", false);
   });
 
+  // Canonicalize a picked filename for the upload endpoint (#25): iOS Files
+  // renames duplicates ("...bundle 2.tar"), Safari can mangle extensions, and
+  // the server requires ^[A-Za-z0-9][A-Za-z0-9._-]*\.bundle\.tar$. The NAME is
+  // only a storage key -- the bundle's own manifest (checked at inspect) is the
+  // real validator -- so never hard-reject on the name alone.
+  function canonicalBundleName(raw) {
+    let name = String(raw || "").replace(/[^A-Za-z0-9._\-]/g, "_");
+    if (/^[A-Za-z0-9][A-Za-z0-9._\-]{0,127}$/.test(name) && name.endsWith(".bundle.tar")) {
+      return name;
+    }
+    const dup = name.match(/^(.*\.bundle)[._\-][^.]*\.tar$/);   // "...bundle_2.tar"
+    if (dup) name = dup[1] + ".tar";
+    else if (/\.tar$/.test(name)) name = name.replace(/\.tar$/, ".bundle.tar");
+    else name = "upload.bundle.tar";                             // inspect will judge it
+    if (!/^[A-Za-z0-9]/.test(name) || name.length > 128) name = "upload.bundle.tar";
+    return name;
+  }
+
+  // Shared chunked-upload pump: POSTs sequential chunks produced by
+  // nextChunk(offset) -> Promise<Blob|null> (null = source exhausted).
+  // totalSize drives the progress bar. Calls inspectBundle() on completion.
+  function pumpUpload(name, totalSize, nextChunk, onFail) {
+    const prog = $("sys-upload-progress");
+    if (prog) { prog.style.display = ""; prog.value = 0; }
+    let offset = 0;
+    function step() {
+      nextChunk(offset).then(function (chunk) {
+        const isDone = chunk === null || offset + chunk.size >= totalSize;
+        const body = chunk === null ? new Blob([]) : chunk;
+        const url = "/api/supervisor/upload?name=" + encodeURIComponent(name)
+          + "&offset=" + offset + "&done=" + (isDone ? 1 : 0);
+        return fetch(url, { method: "POST", body: body })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (!data.ok && data.error !== "bad_offset") {
+              throw new Error(data.error || "unknown");
+            }
+            offset = data.size;
+            if (prog && totalSize) prog.value = offset / totalSize;
+            if (isDone && data.ok) {
+              _bundleName = data.bundle;
+              setText("sys-upload-status", "Upload complete. Inspecting…");
+              if (prog) prog.style.display = "none";
+              inspectBundle();
+              return;
+            }
+            step();
+          });
+      }).catch(function (err) {
+        setText("sys-upload-status", "Upload error: " + err.message);
+        if (prog) prog.style.display = "none";
+        onFail && onFail(err);
+      });
+    }
+    step();
+  }
+
   $("sys-upload-btn") && $("sys-upload-btn").addEventListener("click", function () {
     const input = $("sys-upload-file");
     const f = input && input.files && input.files[0];
     if (!f) return;
-    const name = f.name.replace(/[^A-Za-z0-9._\-]/g, "_");
-    if (!name.endsWith(".bundle.tar")) {
-      setText("sys-upload-status", "File must end in .bundle.tar");
-      return;
-    }
+    const name = canonicalBundleName(f.name);
     enable("sys-upload-btn", false);
-    const prog = $("sys-upload-progress");
-    if (prog) { prog.style.display = ""; prog.value = 0; }
-    setText("sys-upload-status", "Uploading…");
+    setText("sys-upload-status", "Uploading…"
+      + (name !== f.name ? " (as " + name + ")" : ""));
+    pumpUpload(name, f.size, function (offset) {
+      return Promise.resolve(f.slice(offset, offset + CHUNK));
+    }, function () { enable("sys-upload-btn", true); });
+  });
 
-    let offset = 0;
-    function uploadChunk() {
-      const isDone = offset + CHUNK >= f.size;
-      const chunk = f.slice(offset, offset + CHUNK);
-      const url = "/api/supervisor/upload?name=" + encodeURIComponent(name)
-        + "&offset=" + offset + "&done=" + (isDone ? 1 : 0);
-      fetch(url, { method: "POST", body: chunk })
-        .then(function (r) { return r.json(); })
-        .then(function (data) {
-          if (data.error === "bad_offset") {
-            // Resume from server's current size
-            offset = data.size;
-            uploadChunk();
-            return;
-          }
-          if (!data.ok) {
-            setText("sys-upload-status", "Upload error: " + (data.error || "unknown"));
-            enable("sys-upload-btn", true);
-            if (prog) prog.style.display = "none";
-            return;
-          }
-          offset = data.size;
-          if (prog) prog.value = offset / f.size;
-          if (isDone) {
-            _bundleName = data.bundle;
-            setText("sys-upload-status", "Upload complete. Inspecting…");
-            if (prog) prog.style.display = "none";
-            inspectBundle();
-          } else {
-            uploadChunk();
-          }
-        })
-        .catch(function (err) {
-          setText("sys-upload-status", "Upload error: " + err.message);
-          enable("sys-upload-btn", true);
-          if (prog) prog.style.display = "none";
-        });
-    }
-    uploadChunk();
+  // ---- one-tap Download & install (#26): the PHONE has internet (cellular);
+  // stream the GitHub release asset through fetch and pipe it straight into
+  // the chunked upload -- no Files-app round trip, no full-file memory.
+  // BENCH-VERIFY: asset CORS + a full run on a real iPhone over the boat AP.
+  $("sys-install-btn") && $("sys-install-btn").addEventListener("click", function () {
+    const asset = _latestAsset;
+    if (!asset) return;
+    const btn = $("sys-install-btn");
+    if (btn) btn.disabled = true;
+    setText("sys-upload-status", "Downloading " + asset.name + "…");
+    fetch(asset.browser_download_url)
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("HTTP " + resp.status + " from GitHub");
+        const reader = resp.body.getReader();
+        let buf = new Uint8Array(0);
+        let sourceDone = false;
+        function fill() {
+          if (sourceDone || buf.length >= CHUNK) return Promise.resolve();
+          return reader.read().then(function (r) {
+            if (r.done) { sourceDone = true; return; }
+            const merged = new Uint8Array(buf.length + r.value.length);
+            merged.set(buf); merged.set(r.value, buf.length);
+            buf = merged;
+            return fill();
+          });
+        }
+        pumpUpload(canonicalBundleName(asset.name), asset.size, function () {
+          return fill().then(function () {
+            if (buf.length === 0 && sourceDone) return null;
+            const take = buf.slice(0, CHUNK);
+            buf = buf.slice(take.length);
+            return new Blob([take]);
+          });
+        }, function () { if (btn) btn.disabled = false; });
+      })
+      .catch(function (err) {
+        setText("sys-upload-status", "Download failed: " + err.message
+          + " — use the Download link + manual upload instead.");
+        if (btn) btn.disabled = false;
+      });
   });
 
   function inspectBundle() {


### PR DESCRIPTION
Resolves the two queued update-path items.

## Release discovery (#26)
"Check for updates" was silently broken: it filtered for `vanchor-app-*-arm64.bundle.tar` — an asset name **no release has ever used** (real: `vanchor-update-<ver>.bundle.tar`) — so it always said nothing was available. Fixed filter (legacy kept), pre-releases labeled, and a **Download & install** button that fetches the asset with the *phone's* internet and streams it directly into the existing chunked upload (8 MB buffered stream chunks, no full-file memory, no Files-app round trip).

## iOS sideload failure (#25)
iPhones rename duplicate downloads (`…bundle 2.tar`); the upload hard-rejected the name with a dead end. Now `canonicalBundleName()` recovers the duplicate pattern / appends the suffix / falls back to `upload.bundle.tar` — the bundle **manifest at inspect time** is the real validator, so a filename is never grounds for refusal. Picker `accept` broadened (iOS grays out octet-stream files under a bare `.tar`).

## Verified live
- Real GitHub API → `v1.5.0a24 (pre-release) ★ new`, Install button shown, correct asset URL
- A file literally named `vanchor-update-1.5.0a24.bundle 2.tar` uploads, lands under the canonical name in `updates/`, and gets judged by inspect (junk payload → clean "Incompatible bundle"), not by its name

BENCH-VERIFY: full streamed install on a real iPhone over the boat AP (GitHub asset CORS + memory behavior).

Full suite 2326 passed; e2e 29/29; node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)