### PR TITLE
fix(hw): I2C wizard scan probes the real bus; satellite count visible on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Hardware wizard: the I2C scan now really scans.** The scan step listed a
+  static catalog of supported chips as if they had been detected, and rendered
+  it as garbage ("0x0x42 @ bus undefined: undefined") due to a client/server
+  field mismatch (#114 report). The wizard now probes each I2C bus for the
+  known addresses and shows only chips that actually answered; when nothing
+  answers it says so and lists the supported chips as a wiring hint, and when
+  no I2C bus exists it explains how to enable one.
+- **Satellite count now visible on phones.** The main-screen GPS chip
+  collapsed to an anonymous dot on narrow screens, hiding the "9 sat" count
+  on exactly the devices it was requested for (#114). The chip keeps the
+  colored dot and shows the compact value text on mobile too.
+
 ## [1.5.0a25] — 2026-08-12
 
 - **One-tap updates from GitHub, pre-releases included.** "Check for updates"

--- a/src/vanchor/runtime/hwscan.py
+++ b/src/vanchor/runtime/hwscan.py
@@ -180,7 +180,7 @@ class HardwareScan:
         # Demo mode: return sim posture without scanning real hardware
         if getattr(rt.config, "demo", None) and rt.config.demo.enabled:
             return {"ports": [], "i2c_buses": [], "known_i2c": known_i2c,
-                    "capabilities": caps}
+                    "i2c_detected": [], "capabilities": caps}
 
         in_use = self._ports_in_use()
         i2c_owned = self._i2c_addrs_in_use()
@@ -210,8 +210,53 @@ class HardwareScan:
             _owned = any(_b == _bus_n for (_b, _) in i2c_owned)
             i2c_buses.append({"bus": _bus_n, "path": _dev, "in_use": _owned})
 
+        # Actually probe each bus for the known addresses. The catalog alone
+        # reads like a detection result in the wizard ("is my compass seen?")
+        # when it never touched the bus -- a single read_byte per known address
+        # answers the real question: is the chip wired and answering. Probing
+        # only cataloged addresses (never a 0x03..0x77 sweep) keeps this safe;
+        # a concurrent read alongside an active driver is serialized by the
+        # kernel per transaction.
+        i2c_detected = self._probe_known_i2c(i2c_buses, known_i2c)
+
         return {"ports": ports, "i2c_buses": i2c_buses, "known_i2c": known_i2c,
-                "capabilities": caps}
+                "i2c_detected": i2c_detected, "capabilities": caps}
+
+    @staticmethod
+    def _probe_known_i2c(i2c_buses: list[dict], known_i2c: list[dict]) -> list[dict]:
+        """One read_byte per (bus, known address); answering chips only.
+
+        Entries sharing an address (rare) merge into one row with the labels
+        joined, so a hit never renders twice."""
+        by_addr: dict[int, list[dict]] = {}
+        for dev in known_i2c:
+            try:
+                by_addr.setdefault(int(dev["addr"], 16), []).append(dev)
+            except (KeyError, ValueError):
+                continue
+        detected: list[dict] = []
+        try:
+            from smbus2 import SMBus
+        except ImportError:
+            return detected
+        for entry in i2c_buses:
+            bus_n = entry.get("bus")
+            try:
+                with SMBus(bus_n) as sb:
+                    for addr, devs in sorted(by_addr.items()):
+                        try:
+                            sb.read_byte(addr)
+                        except OSError:
+                            continue
+                        detected.append({
+                            "bus": bus_n,
+                            "addr": f"0x{addr:02x}",
+                            "kind": devs[0]["kind"],
+                            "label": " / ".join(d["label"] for d in devs),
+                        })
+            except (OSError, PermissionError):
+                continue
+        return detected
 
     # ------------------------------------------------------------------ #
     # Hardware setup wizard: probe

--- a/src/vanchor/ui/static/hwwizard.js
+++ b/src/vanchor/ui/static/hwwizard.js
@@ -232,9 +232,25 @@
         if (b.label) html += ` <span class="hint">${b.label}</span>`;
         html += "</div>";
       });
-      known.forEach(k => {
-        html += `<div class="scan-row hint">I²C 0x${k.addr.toString(16).padStart(2, "0")} @ bus ${k.bus}: ${k.desc}</div>`;
+      // Real probe results: chips that ANSWERED on a bus. The static catalog
+      // (known) is only a wiring hint when nothing answers -- listing it as
+      // rows reads like a detection result and confuses setup (#114).
+      const found = _scanData.i2c_detected || [];
+      found.forEach(k => {
+        html += `<div class="scan-row"><b>I²C ${k.addr}</b> ${k.label}` +
+          ` <code class="hint">bus ${k.bus}</code></div>`;
       });
+      if (buses.length && !found.length && known.length) {
+        const supported = known.map(k => `${k.addr} (${k.label})`).join(", ");
+        html += `<div class="scan-row hint">No known I²C device answered on the bus.` +
+          ` If one is connected, check the wiring (SDA, SCL, 3.3V, GND).` +
+          ` Supported: ${supported}</div>`;
+      }
+      if (!buses.length && _scanData.capabilities && _scanData.capabilities.i2c) {
+        html += '<div class="scan-row hint">No I²C bus found. On a Raspberry Pi, ' +
+          "enable I²C with <code>sudo raspi-config</code> (Interface Options) " +
+          "or reflash with the latest image, then reboot and rescan.</div>";
+      }
     }
     if (list) list.innerHTML = html;
 

--- a/src/vanchor/ui/static/style.css
+++ b/src/vanchor/ui/static/style.css
@@ -3059,8 +3059,10 @@ body.mobile.ls[data-view="chart"] #map-pills { display: none; }
   /* Tighten chip footprint so 3 health chips fit in #chips. */
   body.mobile .chip  { padding: 3px 5px; font-size: 10px; gap: 4px; }
   body.mobile .chips { gap: 3px; }
-  /* chip-fix: drop val text → dot-only; dot color mirrors data-fix state. */
-  body.mobile #chip-fix .chip-val { display: none; }
+  /* chip-fix: dot + compact value. The value stays VISIBLE on phones — the
+     satellite count ("9 sat") was requested exactly for the phone main screen
+     (#114); an anonymous dot hid it. Dot color mirrors data-fix state. */
+  body.mobile #chip-fix .chip-val { font-size: 10px; white-space: nowrap; }
   body.mobile #chip-fix .chip-dot { display: block; }
   body.mobile #chip-fix[data-fix="ok"]   .chip-dot { background: var(--accent-2); box-shadow: 0 0 5px var(--accent-2); }
   body.mobile #chip-fix[data-fix="bad"]  .chip-dot { background: var(--stop); animation: pulse 0.8s infinite; }

--- a/tests/test_hw_scan_api.py
+++ b/tests/test_hw_scan_api.py
@@ -48,7 +48,8 @@ class TestHwScanShape:
 
     def test_hw_scan_has_required_keys(self, rt):
         result = rt.hw_scan()
-        for key in ("ports", "i2c_buses", "known_i2c", "capabilities"):
+        for key in ("ports", "i2c_buses", "known_i2c", "i2c_detected",
+                    "capabilities"):
             assert key in result, f"hw_scan missing key: {key}"
 
     def test_ports_is_list(self, rt):
@@ -86,6 +87,70 @@ class TestHwScanPortSchema:
         for entry in rt.hw_scan()["known_i2c"]:
             assert "addr" in entry
             assert "kind" in entry
+
+
+# --------------------------------------------------------------------------- #
+# _probe_known_i2c() — real bus probing behind the wizard scan (#114)
+# --------------------------------------------------------------------------- #
+
+class TestProbeKnownI2c:
+    KNOWN = [
+        {"kind": "helm-pico", "addr": "0x42", "label": "Vanchor helm PCB"},
+        {"kind": "magnetometer", "addr": "0x0d", "label": "QMC5883L compass"},
+        {"kind": "magnetometer", "addr": "0x0d", "label": "QMC5883P compass"},
+    ]
+
+    def _install_fake_smbus(self, monkeypatch, answering: set[int]):
+        import sys
+        import types
+
+        class FakeSMBus:
+            def __init__(self, bus):
+                self.bus = bus
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read_byte(self, addr):
+                if addr not in answering:
+                    raise OSError(121, "Remote I/O error")
+                return 0
+
+        mod = types.ModuleType("smbus2")
+        mod.SMBus = FakeSMBus
+        monkeypatch.setitem(sys.modules, "smbus2", mod)
+
+    def test_answering_chip_is_detected_with_hex_addr(self, rt, monkeypatch):
+        self._install_fake_smbus(monkeypatch, answering={0x0D})
+        out = rt._hwscan._probe_known_i2c([{"bus": 1}], self.KNOWN)
+        assert len(out) == 1
+        assert out[0]["addr"] == "0x0d"
+        assert out[0]["bus"] == 1
+        # Shared-address catalog entries merge into ONE row, labels joined.
+        assert "QMC5883L" in out[0]["label"] and "QMC5883P" in out[0]["label"]
+
+    def test_silent_bus_detects_nothing(self, rt, monkeypatch):
+        self._install_fake_smbus(monkeypatch, answering=set())
+        assert rt._hwscan._probe_known_i2c([{"bus": 1}], self.KNOWN) == []
+
+    def test_no_buses_probes_nothing(self, rt, monkeypatch):
+        self._install_fake_smbus(monkeypatch, answering={0x42})
+        assert rt._hwscan._probe_known_i2c([], self.KNOWN) == []
+
+    def test_missing_smbus2_returns_empty(self, rt, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def no_smbus(name, *a, **kw):
+            if name == "smbus2":
+                raise ImportError(name)
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", no_smbus)
+        assert rt._hwscan._probe_known_i2c([{"bus": 1}], self.KNOWN) == []
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Two field reports from discussion #114.

## I2C scan showed garbage — and never actually scanned
The wizard's scan step rendered the **static catalog** of supported I2C chips as if they were detection results, and rendered them broken (`I²C 0x0x42 @ bus undefined: undefined`): the server sends `{kind, addr: "0x42", label}`, the client read `addr` as a number plus nonexistent `bus`/`desc` fields.

Now `hw_scan` **probes each I2C bus** (one `read_byte` per cataloged address — never a 0x03–0x77 sweep) and returns `i2c_detected`. The wizard:
- lists chips that actually answered (`I²C 0x0d QMC5883L compass · bus 1`)
- when the bus is silent: says so and lists supported chips as a wiring hint (SDA/SCL/3.3V/GND)
- when no bus exists: explains raspi-config / latest image

This lets the reporter check whether the Pi sees his QMC5883L at all (it works on his Arduino, so it's wiring vs. bus-enable).

## Satellite count was invisible on phones
The `#114`-requested sat count on the GPS chip was hidden at ≤430px: `body.mobile #chip-fix .chip-val { display: none }` collapsed the chip to an anonymous dot — on exactly the device class that asked for it. The chip now keeps the colored dot **and** shows the compact value ("9 sat" / "LOST" / "ACQ 4"). Verified visually by screenshot at 390px (the previous check read `textContent`, which exists even when `display:none`).

Gates: 2330 passed, e2e 29/29, node --check + ruff clean. New unit tests for the probe (answering chip, silent bus, no bus, no smbus2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)