### PR TITLE
fix(updates): honest message when the supervisor daemon is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Honest error when the update service is missing.** Uploading a bundle on
+  a system where the app cannot reach the vanchor-supervisor daemon reported
+  "Incompatible bundle" (#114 video), sending the user chasing the bundle
+  instead of the boat computer. It now says the update service is not
+  reachable and recommends reflashing.
+
 ## [1.5.0a26] — 2026-08-16
 
 - **Hardware wizard: the I2C scan now really scans.** The scan step listed a

--- a/src/vanchor/ui/static/supervisor.js
+++ b/src/vanchor/ui/static/supervisor.js
@@ -371,6 +371,19 @@
       .then(function (data) {
         _manifestData = data;
         show("sys-compat-warning", false);
+        // postJSON returns the body even on 503 -- without this check a missing
+        // supervisor daemon reads as "Incompatible bundle" (#114 video), which
+        // sends the user chasing the bundle instead of the boat computer.
+        if (data && data.error === "supervisor_unavailable") {
+          setText("sys-compat-warning",
+            "The update service on the boat computer is not reachable, so the "
+            + "app cannot install updates right now. Reflash the SD card with "
+            + "the latest image instead.");
+          show("sys-compat-warning", true);
+          setText("sys-upload-status", "Update service not reachable.");
+          enable("sys-apply-btn", false);
+          return;
+        }
         if (data.compatible) {
           const ver = (data.manifest && data.manifest.app_version) || "?";
           setText("sys-upload-status",


### PR DESCRIPTION
From the #114 field video: the user's bundle upload succeeded, then the UI said **"Incompatible bundle"** — but the bundle was fine. The supervisor proxy had answered `503 {"error":"supervisor_unavailable"}`; `postJSON` resolves the body regardless of HTTP status, so `inspectBundle` read the missing `compatible` field as an incompatibility and blamed the file.

Now `supervisor_unavailable` gets its own message ("The update service on the boat computer is not reachable… reflash the SD card with the latest image instead") and the apply button stays disabled.

Why the supervisor is unreachable on his flashed image at all is a separate question — needs bench reproduction on a real Pi (issue to follow).

Gates: 2330 passed, e2e 29/29, node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)