### PR TITLE
fix(image): load i2c-dev at boot — dtparam alone never created /dev/i2c-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **SD image: I2C actually works now.** The image set `dtparam=i2c_arm=on`
+  but never loaded the `i2c-dev` kernel module, so `/dev/i2c-1` did not exist
+  on a flashed Pi -- the wizard scan reported "No I2C bus found" and no
+  compass could ever be detected (#114 field report). The image now also adds
+  `i2c-dev` to `/etc/modules`, matching what raspi-config's I2C enable does.
+
 - **Honest error when the update service is missing.** Uploading a bundle on
   a system where the app cannot reach the vanchor-supervisor daemon reported
   "Incompatible bundle" (#114 video), sending the user chasing the bundle

--- a/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
+++ b/deploy/image/stage-vanchor/01-net/01-run-chroot.sh
@@ -23,6 +23,12 @@ if [ -f "$BOOT_DIR/config.txt" ]; then
     # carries smbus2 + the c 89:* device rule; this makes the bus exist.
     grep -q '^dtparam=i2c_arm=on'   "$BOOT_DIR/config.txt" || echo 'dtparam=i2c_arm=on'   >> "$BOOT_DIR/config.txt"
 fi
+# dtparam=i2c_arm=on enables the bus HARDWARE, but /dev/i2c-1 (what smbus2 and
+# the wizard scan open) only appears once the i2c-dev module is loaded --
+# raspi-config's do_i2c sets both, we previously set only the dtparam. Field
+# result (#114): a flashed image reports "No I2C bus found" and no compass can
+# ever be detected. /etc/modules loads it at every boot.
+grep -q '^i2c-dev' /etc/modules 2>/dev/null || echo 'i2c-dev' >> /etc/modules
 if [ -f "$BOOT_DIR/cmdline.txt" ]; then
     # Drop the serial-console token so getty no longer holds the port.
     sed -i -E 's/console=(serial0|ttyAMA0|ttyS0),[0-9]+ ?//g' "$BOOT_DIR/cmdline.txt"


### PR DESCRIPTION
Field-confirmed by the #114 scan screenshot on a freshly flashed a26 image: **"No I²C bus found"** — the honest scan hint from #171 surfaced the real bug. The image sets `dtparam=i2c_arm=on` (bus hardware) but never loads the `i2c-dev` kernel module that exposes `/dev/i2c-1`. `raspi-config`'s I2C enable does both; we did half. Without the device node, `smbus2`, the wizard scan, and every I2C compass are dead on image installs.

The container side was already ready (`c 89:* rmw` device-cgroup rule + read-only `/dev` bind in docker-compose) — the host node was the only missing piece. Fix: append `i2c-dev` to `/etc/modules` in the chroot stage, guarded and idempotent like the neighboring appends.

BENCH-VERIFY: flash the next image on a real Pi, confirm `/dev/i2c-1` exists and the wizard scan lists `I²C bus 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)