### PR TITLE
feat(map): native z19 satellite with placeholder fallback; firmware parser hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Sharp satellite imagery.** The Satellite layer was capped at zoom 17 to
+  dodge Esri's "Map data not yet available" placeholder tiles, which made
+  EVERY area blurry (#114 report). It now loads native zoom-19 tiles and
+  falls back per tile: placeholders are detected by pixel sampling and
+  replaced with the scaled parent tile, and they are never stored in the
+  offline tile cache.
+- **Firmware protocol hardening (Arduino + Pico).** The shared line-protocol
+  parser accumulated digits with wrapping arithmetic -- on 32-bit boards a
+  noise line like "CMD 4294967551 F 0" could wrap to pwm 255 (full ahead).
+  Digits now saturate, and a line too long for its buffer is dropped instead
+  of shipped without its CRC. The I2C motor-tunnel transport also caps a
+  corrupted byte-count so one flipped bit cannot stall commands past the
+  firmware watchdog.
+
 ## [1.5.0a27] — 2026-08-17
 
 - **SD image: I2C actually works now.** The image set `dtparam=i2c_arm=on`

--- a/firmware/common/vanchor_protocol.h
+++ b/firmware/common/vanchor_protocol.h
@@ -1,3 +1,21 @@
+/* Saturating base-10 digit accumulator. `v = v*10 + d` with no width guard is
+ * signed-overflow UB and, on 32-bit `long` (the RP2040/RP2350 and AVR case),
+ * wraps at 10 digits -- "CMD 4294967551 F 0" must read as huge-then-clamped,
+ * never wrap to 255 (full ahead from line noise on CRC-less links). Digits are
+ * consumed to the end either way; the cap parks the value far above every
+ * caller's clamp so saturated garbage lands on the clamp exactly like any
+ * large value would. */
+inline long vanchorAccumDigits(const char **pp) {
+  const char *p = *pp;
+  long v = 0;
+  while (*p >= '0' && *p <= '9') {
+    if (v <= 100000L) v = v * 10 + (*p - '0');
+    p++;
+  }
+  *pp = p;
+  return v;
+}
+
 /*
  * vanchor_protocol.h  --  shared line protocol for the Vanchor-NG hardware bridge.
  *
@@ -190,8 +208,7 @@ inline bool vanchorParseCmd(const char *line, int *pwm, char *dir, int *steer,
   // --- pwm ---
   while (*p == ' ') p++;
   if (*p < '0' || *p > '9') return false;
-  long v = 0;
-  while (*p >= '0' && *p <= '9') { v = v * 10 + (*p - '0'); p++; }
+  long v = vanchorAccumDigits(&p);
   if (v < 0) v = 0;
   if (v > 255) v = 255;
 
@@ -207,8 +224,7 @@ inline bool vanchorParseCmd(const char *line, int *pwm, char *dir, int *steer,
   if (*p == '-') { sign = -1; p++; }
   else if (*p == '+') { p++; }
   if (*p < '0' || *p > '9') return false;
-  long s = 0;
-  while (*p >= '0' && *p <= '9') { s = s * 10 + (*p - '0'); p++; }
+  long s = vanchorAccumDigits(&p);
   s *= sign;
   if (s < -100) s = -100;
   if (s > 100) s = 100;
@@ -221,8 +237,7 @@ inline bool vanchorParseCmd(const char *line, int *pwm, char *dir, int *steer,
   const char *pq = p;
   while (*pq == ' ') pq++;
   if (*pq >= '0' && *pq <= '9') {
-    q = 0;
-    while (*pq >= '0' && *pq <= '9') { q = q * 10 + (*pq - '0'); pq++; }
+    q = vanchorAccumDigits(&pq);
     if (q > VANCHOR_SEQ_MAX) q = VANCHOR_SEQ_MAX;
   }
 
@@ -272,8 +287,7 @@ inline bool vanchorParseSteerDeg(const char *line, float *deg, int *seq = 0) {
   const char *pq = p;
   while (*pq == ' ') pq++;
   if (*pq >= '0' && *pq <= '9') {
-    q = 0;
-    while (*pq >= '0' && *pq <= '9') { q = q * 10 + (*pq - '0'); pq++; }
+    q = vanchorAccumDigits(&pq);
     if (q > VANCHOR_SEQ_MAX) q = VANCHOR_SEQ_MAX;
   }
 
@@ -349,7 +363,15 @@ inline bool vanchorAcceptLine(char *line) {
 inline void vanchorAppendCrc(char *buf, unsigned int cap) {
   unsigned int len = 0;
   while (buf[len]) len++;
-  if (len + 4 > cap) return;
+  if (len + 4 > cap) {
+    // No room for "*HH\0": DROP the line rather than ship it CRC-less. A
+    // CRC-less line passes as an old-peer's authentic traffic on the
+    // receiving side, so silently omitting the CRC would downgrade the
+    // link's integrity check exactly when the line is most likely malformed
+    // (it just overflowed its buffer).
+    buf[0] = '\0';
+    return;
+  }
   unsigned char c = vanchorCrc8(buf, len);
   const char *hex = "0123456789ABCDEF";
   buf[len] = '*';

--- a/firmware/steering/tests/test_parse_cmd.cpp
+++ b/firmware/steering/tests/test_parse_cmd.cpp
@@ -254,4 +254,29 @@ static void runCrcVectors() {
   char out[64] = "A -12.4 1 -7 42";
   vanchorAppendCrc(out, sizeof out);
   CHECK(std::strcmp(out, "A -12.4 1 -7 42*C8") == 0);
+
+  // Digit-overflow saturation (the accumulator must never wrap 32-bit long:
+  // "CMD 4294967551 F 0" is 2^32+255 -- a wrapping parser reads pwm 255 FULL
+  // AHEAD from garbage; the saturating one clamps identically on any width).
+  {
+    char big[64] = "CMD 4294967551 F 0";
+    int bpwm; char bdir; int bsteer;
+    CHECK(vanchorParseCmd(big, &bpwm, &bdir, &bsteer, 0));
+    CHECK(bpwm == 255 && bdir == 'F' && bsteer == 0);
+    char big2[64] = "CMD 99999999999999999999 R -99999999999999999999";
+    CHECK(vanchorParseCmd(big2, &bpwm, &bdir, &bsteer, 0));
+    CHECK(bpwm == 255 && bdir == 'R' && bsteer == -100);
+    char big3[64] = "CMD 10 F 5 99999999999999999999";
+    int bseq;
+    CHECK(vanchorParseCmd(big3, &bpwm, &bdir, &bsteer, &bseq));
+    CHECK(bpwm == 10 && bsteer == 5 && bseq == VANCHOR_SEQ_MAX);
+  }
+
+  // AppendCrc with no room must DROP the line (empty string), never ship a
+  // CRC-less line that the peer would accept as authentic old-peer traffic.
+  {
+    char tight[8] = "A 1 2";      // needs 5+4=9 > 8
+    vanchorAppendCrc(tight, sizeof tight);
+    CHECK(tight[0] == '\0');
+  }
 }

--- a/src/vanchor/hardware/i2c_link.py
+++ b/src/vanchor/hardware/i2c_link.py
@@ -432,6 +432,13 @@ class I2cTransport(SerialTransport):
                 async with self._lock:
                     # 1. TXA: one 2-byte read starting at 0x02.
                     n = await asyncio.to_thread(self._read_txa)
+                    # The count crosses the wire with no integrity check; the
+                    # firmware FIFO is 1024 bytes, so anything larger is a
+                    # corrupted count -- and honoring it (up to 64 KiB) would
+                    # hold _lock through a ~1 s bus read, stalling write_line
+                    # past the firmware's 800 ms command watchdog (failsafe
+                    # stop mid-run from one flipped bit).
+                    n = min(n, 1024)
 
                     # 2. Drain DATA if bytes are available.
                     if n > 0:

--- a/src/vanchor/ui/static/map-core.js
+++ b/src/vanchor/ui/static/map-core.js
@@ -72,6 +72,127 @@
     return endpoint + (endpoint.indexOf("?") >= 0 ? "&" : "?") + qs;
   }
 
+  // ---- Satellite with per-tile fallback (#114 "low resolution" report) ----
+  // Esri World_Imagery serves native z19 over most shorelines, but the layer
+  // was capped at maxNativeZoom 17 to dodge the "Map data not yet available"
+  // placeholder tiles Esri returns (HTTP 200, so tileerror never fires) in
+  // remote areas -- which made EVERY area blurry. This subclass requests
+  // native tiles up to 19 and falls back per tile: on a load error OR a
+  // detected placeholder (uniform rgb(204,204,204) at 5 sample points --
+  // verified against live Esri tiles; real imagery never matches), it swaps in
+  // the parent tile CSS-scaled to the right quadrant, recursing down to
+  // fallbackFloorZoom (a custom option -- NOT minNativeZoom, which would make
+  // Leaflet upsample z13 tiles when zoomed out below it). Fallback mechanics adapted from ghybs/leaflet.tilelayer
+  // .fallback (MIT). crossOrigin is required for the canvas sampling; if the
+  // canvas taints anyway, the tile is kept as-is (today's behavior).
+  const PLACEHOLDER_RGB = 204, PLACEHOLDER_TOL = 4, PLACEHOLDER_MIN_Z = 16;
+  let _satCanvas = null;
+  // True when the drawable (img or ImageBitmap) is Esri's uniform-gray
+  // "Map data not yet available" tile. May throw (tainted canvas) -- callers
+  // catch and keep the tile.
+  function _samplePlaceholder(drawable) {
+    if (!_satCanvas) {
+      _satCanvas = document.createElement("canvas");
+      _satCanvas.width = _satCanvas.height = 256;
+    }
+    const ctx = _satCanvas.getContext("2d", { willReadFrequently: true });
+    ctx.drawImage(drawable, 0, 0, 256, 256);
+    return [[8, 8], [248, 8], [8, 248], [248, 248], [128, 40]].every(([x, y]) => {
+      const d = ctx.getImageData(x, y, 1, 1).data;
+      return Math.abs(d[0] - PLACEHOLDER_RGB) <= PLACEHOLDER_TOL &&
+             Math.abs(d[1] - PLACEHOLDER_RGB) <= PLACEHOLDER_TOL &&
+             Math.abs(d[2] - PLACEHOLDER_RGB) <= PLACEHOLDER_TOL;
+    });
+  }
+  const SatelliteLayer = L.TileLayer.extend({
+    createTile(coords, done) {
+      const tile = L.TileLayer.prototype.createTile.call(this, coords, done);
+      tile._origCoords = coords;
+      return tile;
+    },
+    _tileOnLoad(done, tile) {
+      if (this._looksLikePlaceholder(tile) && this._fallbackStep(tile)) return;
+      L.TileLayer.prototype._tileOnLoad.call(this, done, tile);
+    },
+    _tileOnError(done, tile, e) {
+      if (this._fallbackStep(tile)) return;
+      L.TileLayer.prototype._tileOnError.call(this, done, tile, e);
+    },
+    _looksLikePlaceholder(tile) {
+      const z = tile._curCoords ? tile._curCoords.z : (tile._origCoords ? tile._origCoords.z : 0);
+      if (z < PLACEHOLDER_MIN_Z) return false;
+      try {
+        return _samplePlaceholder(tile);
+      } catch (err) {
+        return false;   // canvas tainted (no CORS) or decode issue -> keep tile
+      }
+    },
+    // ---- hooks consulted by patchTileLayerForCache (the ACTIVE tile path
+    // whenever VA.tileCache exists; the _tileOnLoad/_tileOnError overrides
+    // above only serve the rare no-cache fallback). --------------------------
+    _vetTileBlob(blob, coords) {
+      if (coords.z < PLACEHOLDER_MIN_Z) return Promise.resolve(true);
+      if (typeof createImageBitmap !== "function") return Promise.resolve(true);
+      return createImageBitmap(blob)
+        .then((bmp) => {
+          let placeholder = false;
+          try { placeholder = _samplePlaceholder(bmp); } catch (e) { /* keep */ }
+          if (bmp.close) bmp.close();
+          return !placeholder;
+        })
+        .catch(() => true);   // undecodable -> let the normal error path run
+    },
+    _fallbackParent(img, origCoords, curCoords) {
+      if (curCoords.z - 1 < (this.options.fallbackFloorZoom || 0)) return null;
+      const next = {
+        x: Math.floor(curCoords.x / 2),
+        y: Math.floor(curCoords.y / 2),
+        z: curCoords.z - 1,
+        fallback: true,
+      };
+      const scale = Math.pow(2, origCoords.z - next.z);
+      const ts = this.getTileSize();
+      img.style.width = (ts.x * scale) + "px";
+      img.style.height = (ts.y * scale) + "px";
+      img.style.marginTop = (-((origCoords.y - next.y * scale) * ts.y)) + "px";
+      img.style.marginLeft = (-((origCoords.x - next.x * scale) * ts.x)) + "px";
+      return next;
+    },
+    _fallbackStep(tile) {
+      const orig = tile._origCoords;
+      if (!orig) return false;
+      if (!tile._curCoords) {
+        const c = this._wrapCoords(orig);
+        tile._curCoords = { x: c.x, y: c.y, z: c.z, fallback: true };
+      }
+      const cur = tile._curCoords;
+      if (cur.z - 1 < (this.options.fallbackFloorZoom || 0)) return false;
+      cur.z -= 1;
+      cur.x = Math.floor(cur.x / 2);
+      cur.y = Math.floor(cur.y / 2);
+      const scale = tile._fallbackScale = (tile._fallbackScale || 1) * 2;
+      const ts = this.getTileSize();
+      tile.style.width = (ts.x * scale) + "px";
+      tile.style.height = (ts.y * scale) + "px";
+      tile.style.marginTop = (-((orig.y - cur.y * scale) * ts.y)) + "px";
+      tile.style.marginLeft = (-((orig.x - cur.x * scale) * ts.x)) + "px";
+      tile.src = this.getTileUrl(cur);   // re-fires load/error -> recurses
+      return true;
+    },
+    getTileUrl(coords) {
+      // Same template data as L.TileLayer.getTileUrl, but honor the fallback
+      // coords' own z instead of the map's current url zoom.
+      const data = {
+        r: L.Browser.retina ? "@2x" : "",
+        s: this._getSubdomain(coords),
+        x: coords.x,
+        y: coords.y,
+        z: coords.fallback ? coords.z : this._getZoomForUrl(),
+      };
+      return L.Util.template(this._url, L.Util.extend(data, this.options));
+    },
+  });
+
   const base = {
     "Dark": L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
@@ -85,11 +206,11 @@
     // tint (#map.base-nautical). Pairs with the Sea-marks + depth overlays.
     "Nautical": L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
-    "Satellite": L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-      // maxNativeZoom kept where real imagery exists (remote water/shore has none
-      // deeper) so Leaflet UPSCALES the deepest available tile past it instead of
-      // fetching Esri's "Map data not available" placeholder.
-      { maxZoom: 22, maxNativeZoom: 17, attribution: "© Esri, Maxar, Earthstar Geographics" }),
+    "Satellite": new SatelliteLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      // Native z19 where Esri has imagery; the SatelliteLayer fallback swaps
+      // placeholder/missing tiles for the CSS-scaled parent down to z13.
+      { maxZoom: 22, maxNativeZoom: 19, fallbackFloorZoom: 13, crossOrigin: true,
+        attribution: "© Esri, Maxar, Earthstar Geographics" }),
     "Light": L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
       { maxZoom: 22, maxNativeZoom: 20, attribution: OSM + ", " + CARTO }),
     "Topo": L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
@@ -370,6 +491,34 @@
   // one-cache-key invariant as the basemaps.
   function patchTileLayerForCache(layer) {
     const origCreate = layer.createTile;
+    // Resolve url -> displayable src through hot-LRU -> IndexedDB -> network.
+    // When the layer defines _vetTileBlob (the Satellite placeholder check),
+    // blobs are vetted BEFORE display/caching; a vetted-out blob resolves to
+    // null (and is never cached -- placeholders must not poison the offline
+    // store). Hot-LRU entries were vetted on insert, so hits skip the check.
+    // Cached blobs re-vet (pre-fix caches may hold placeholders).
+    function resolveTile(coords, url) {
+      const cache = VA.tileCache;
+      const vet = (blob) => (layer._vetTileBlob
+        ? layer._vetTileBlob(blob, coords) : Promise.resolve(true));
+      const hot = lruGet(url);
+      if (hot !== undefined) return Promise.resolve(hot);
+      return cache.get(url).then((blob) => {
+        if (blob) {
+          return vet(blob).then((ok) => (ok ? lruPut(url, blob) : null));
+        }
+        // not cached: download the tile ONCE via fetch, then use that single
+        // blob for BOTH the <img> (object URL) and the cache. (A second plain
+        // fetch of the same URL used to double-download every uncached tile.)
+        return fetch(url)
+          .then((r) => (r.ok ? r.blob() : Promise.reject(new Error("tile fetch failed"))))
+          .then((blob) => vet(blob).then((ok) => {
+            if (!ok) return null;
+            if (cache.put) { try { cache.put(url, blob); } catch (e) {} }
+            return lruPut(url, blob);
+          }));
+      });
+    }
     layer.createTile = function (coords, done) {
       const img = document.createElement("img");
       const url = this.getTileUrl(coords);
@@ -380,44 +529,28 @@
         // no cache installed — fall back to default network behaviour
         return origCreate.call(this, coords, done);
       }
-      const hot = lruGet(url);
-      if (hot !== undefined) {
-        img.onload = () => done(null, img);
-        img.onerror = () => done(new Error("cached tile decode failed"), img);
-        img.src = hot;
-        return img;
-      }
-      cache.get(url).then((blob) => {
-        if (blob) {
-          img.onload = () => done(null, img);
-          img.onerror = () => done(new Error("cached tile decode failed"), img);
-          img.src = lruPut(url, blob);
-          return;
-        }
-        // not cached: download the tile ONCE via fetch, then use that single blob
-        // for BOTH the <img> (object URL) and the cache. Previously we set
-        // img.src=url AND fetch(url) separately, downloading every uncached tile
-        // twice. (perf) The plain fetch of the same URL is CORS-safe (the old
-        // second fetch already worked).
-        fetch(url)
-          .then((r) => (r.ok ? r.blob() : Promise.reject(new Error("tile fetch failed"))))
-          .then((blob) => {
-            img.onload = () => done(null, img);
-            img.onerror = () => done(new Error("tile load failed"), img);
-            img.src = lruPut(url, blob);
-            if (cache.put) { try { cache.put(url, blob); } catch (e) {} }
-          })
-          .catch(() => {
-            // Network fetch failed — fall back to a direct <img> load.
-            img.onload = () => done(null, img);
-            img.onerror = () => done(new Error("tile load failed"), img);
-            img.src = url;
-          });
-      }).catch(() => {
-        img.src = url;
+      const layerRef = this;
+      const show = (src) => {
         img.onload = () => done(null, img);
         img.onerror = () => done(new Error("tile load failed"), img);
-      });
+        img.src = src;
+      };
+      // One resolve step at the given coords; on a vetted-out tile descend to
+      // the parent (layer._fallbackParent supplies the coords + CSS placement)
+      // until the layer declines, then show the original url as-is (today's
+      // behaviour). Non-satellite layers have no hooks: identical pipeline.
+      function step(curCoords, curUrl) {
+        resolveTile(curCoords, curUrl)
+          .then((src) => {
+            if (src !== null) { show(src); return; }
+            const next = layerRef._fallbackParent
+              ? layerRef._fallbackParent(img, coords, curCoords) : null;
+            if (next) step(next, layerRef.getTileUrl(next));
+            else show(url);
+          })
+          .catch(() => { show(curUrl); });   // cache/network error → direct load
+      }
+      step(coords, url);
       return img;
     };
   }

--- a/tests/test_i2c_link.py
+++ b/tests/test_i2c_link.py
@@ -551,3 +551,19 @@ class TestImport:
         t = I2cTransport(3)   # no smbus_factory → will try real smbus2
         with pytest.raises(RuntimeError, match="pip install vanchor\\[i2c\\]"):
             await t.open()
+
+    async def test_glitched_txa_count_is_capped_to_fifo_size(self) -> None:
+        """A corrupted TXA count (bit-flip on the wire; register reads have no
+        integrity check) must be capped at the firmware FIFO size (1024) --
+        honoring e.g. 0x8014 would hold the poll lock through a ~32 KiB bus
+        read, stalling write_line past the firmware's 800 ms watchdog."""
+        bus = _open_ok_bus()
+        bus.stage(0x02, bytes([0x14, 0x80]))     # TXA reads as 0x8014 = 32788
+        bus.stage(0x10, b"OK\n" + b"\x00" * 2000)
+        t = await _open_transport(bus)
+        await asyncio.wait_for(t.read_line(), timeout=2.0)
+        await t.close()
+        data_reads = [tx for tx in bus.transactions
+                      if tx[0] == "read" and tx[2] == 0x10]
+        assert data_reads, "no DATA read happened"
+        assert max(tx[1] for tx in data_reads) <= 1024, data_reads


### PR DESCRIPTION
See commit message: native z19 Satellite with per-tile placeholder fallback (pixel-sampled, never cached offline, parent-tile upscale to z13, verified live); vanchorAccumDigits saturating parser fix (32-bit wrap could turn line noise into pwm 255 full ahead on CRC-less links) + AppendCrc drop-on-overflow, 281 host checks; Pi-side I2C TXA count capped at the 1024-byte FIFO (bit-flipped count stalled commands past the firmware watchdog). Gates: 2331 passed, e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)