### PR TITLE
feat(hw): in-app helm-Pico firmware flasher (UF2 via phone → picotool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **Flash the helm Pico from the app.** Devices -> Motor -> "Helm firmware
+  (Pico)": the phone downloads the latest vanchor-pcb firmware release
+  (Pico 2 or original Pico) and the boat computer flashes the USB-connected
+  board with picotool -- no BOOTSEL button, no computer, no toolchain. A
+  manual .uf2 file upload works too (offline / self-built firmware). Flashing
+  is refused while a guided mode drives (force overrides), uploads are
+  validated as real UF2 images, and installs without the flasher (older
+  images) say so honestly. The firmware itself now ships as drag-and-drop
+  UF2s from vanchor-pcb CI (fw-v* releases).
+
 ## [1.5.0a28] — 2026-08-17
 
 - **Sharp satellite imagery.** The Satellite layer was capped at zoom 17 to

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,20 @@ COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
 RUN pip install --no-cache-dir --prefix=/install --no-deps .
 
+# picotool: flashes the helm-Pico firmware from the app (Devices → Motor →
+# Helm firmware). Built from source — Debian bookworm has no package. The
+# pico-sdk clone is headers-only input for the build; nothing of it ships.
+FROM python:3.12-slim-bookworm AS picotool
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git cmake g++ make pkg-config libusb-1.0-0-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch 2.1.1 https://github.com/raspberrypi/pico-sdk /pico-sdk \
+    && git clone --depth 1 --branch 2.1.1 https://github.com/raspberrypi/picotool /picotool-src \
+    && cmake -S /picotool-src -B /picotool-build \
+         -DPICO_SDK_PATH=/pico-sdk -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build /picotool-build -j \
+    && cmake --install /picotool-build --prefix /opt/picotool
+
 FROM python:3.12-slim-bookworm
 LABEL org.opencontainers.image.source="https://github.com/AlexAsplund/Vanchor" \
       org.opencontainers.image.title="vanchor" \
@@ -16,10 +30,12 @@ LABEL org.opencontainers.image.source="https://github.com/AlexAsplund/Vanchor" \
 # The NM daemon is NOT started in the container — nmcli only talks D-Bus
 # to the host NM daemon via the socket bind-mount in docker-compose.yml.
 # BENCH-VERIFY: polkit policy for uid-0-in-container D-Bus NM access.
+# libusb-1.0-0 is picotool's only runtime dependency.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        network-manager \
+        network-manager libusb-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /install /usr/local
+COPY --from=picotool /opt/picotool/bin/picotool /usr/local/bin/picotool
 ENV VANCHOR_HOST=0.0.0.0 \
     VANCHOR_DATA_DIR=/data \
     PYTHONUNBUFFERED=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - "c 188:* rmw"             # ttyUSB* (FTDI/CH340 adapters)
       - "c 204:* rmw"             # ttyAMA* / serial0 (Pi UART)
       - "c 89:* rmw"              # i2c-*
+      - "c 189:* rmw"             # /dev/bus/usb — picotool (helm-Pico flasher)
     devices:
       # SoC-fixed GPIO chip — comment out on non-Pi hosts (compose fails on
       # missing device paths; Pi has /dev/gpiochip0 always).

--- a/src/vanchor/hardware/pico_flash.py
+++ b/src/vanchor/hardware/pico_flash.py
@@ -1,0 +1,87 @@
+"""Flash helm-controller firmware (UF2) onto a USB-connected Pico.
+
+The vanchor-pcb helm firmware ships as UF2 release assets
+(``vanchor-helm-pico.uf2`` / ``vanchor-helm-pico2.uf2``). The phone downloads
+one with its own internet and uploads it here; this module drives ``picotool``
+to do the actual flashing:
+
+    picotool load -f -x <file.uf2>
+
+``-f`` reboots a RUNNING firmware into the BOOTSEL bootloader over the USB
+stdio reset interface (the helm firmware exposes it), so no button press is
+needed; ``-x`` reboots into the freshly flashed application afterwards. The
+board's EN pulldowns keep both motor bridges disabled for the whole window.
+
+picotool is baked into the container image (built from source -- Debian
+bookworm has no package) and needs USB access: the compose contract carries a
+``c 189:*`` device-cgroup rule for /dev/bus/usb. Older installs that were
+bundle-updated (container recreated from an old compose/containers.json)
+lack that rule -- picotool then reports no accessible devices; the endpoint
+surfaces that as a reflash hint rather than a mystery failure.
+
+BENCH-VERIFY: full flash cycle against a real Pico 2 on the boat Pi
+(reset-interface reboot with the CDC port held open by the motor driver,
+cgroup rule on a fresh image, re-enumeration afterwards).
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+# UF2 block layout: 512-byte blocks, magics at offsets 0/4 of every block.
+_UF2_MAGIC0 = b"UF2\n"                      # 0x0A324655 little-endian
+_UF2_MAGIC1 = (0x9E5D5157).to_bytes(4, "little")
+MAX_UF2_BYTES = 8 * 1024 * 1024             # helm UF2s are ~0.5 MB; 8 MB cap
+
+_FLASH_TIMEOUT_S = 120.0
+
+
+def picotool_path() -> str | None:
+    """Absolute path of the picotool binary, or None when not installed."""
+    return shutil.which("picotool")
+
+
+def validate_uf2(data: bytes) -> str | None:
+    """Reject anything that is not a plausible UF2 image. None when OK.
+
+    The firmware itself is the real validator (a wrong-chip UF2 is refused by
+    the bootloader); this only stops obvious mistakes (HTML error pages,
+    bundle.tar uploads) before they reach the flash step.
+    """
+    if len(data) == 0:
+        return "empty file"
+    if len(data) > MAX_UF2_BYTES:
+        return "file too large for a firmware image"
+    if len(data) < 512 or len(data) % 512 != 0:
+        return "not a UF2 image (size is not a multiple of 512)"
+    if data[0:4] != _UF2_MAGIC0 or data[4:8] != _UF2_MAGIC1:
+        return "not a UF2 image (bad magic)"
+    return None
+
+
+def flash(path: str, run=subprocess.run) -> tuple[bool, str]:
+    """Flash the UF2 at ``path``; (ok, human-readable output).
+
+    ``run`` is a test seam with the subprocess.run signature.
+    """
+    tool = picotool_path()
+    if tool is None:
+        return False, ("picotool is not installed in this image -- update the "
+                       "boat to the latest SD image to get the flasher.")
+    try:
+        proc = run(
+            [tool, "load", "-f", "-x", str(path)],
+            capture_output=True, text=True, timeout=_FLASH_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "picotool timed out -- unplug/replug the Pico and retry"
+    except OSError as exc:
+        return False, f"could not run picotool: {exc}"
+    out = ((proc.stdout or "") + "\n" + (proc.stderr or "")).strip()
+    if proc.returncode != 0:
+        if "No accessible" in out or "no accessible" in out:
+            out += ("\nNo Pico visible over USB. Check the cable, or if this "
+                    "boat was updated by bundle (not reflashed) the container "
+                    "may lack USB access -- reflash the SD card once.")
+        return False, out
+    return True, out

--- a/src/vanchor/ui/partials/panel-devices.html
+++ b/src/vanchor/ui/partials/panel-devices.html
@@ -241,6 +241,30 @@
             </div>
             <div id="dev-menus-motor"></div>
 
+            <!-- Helm firmware flasher: fetch the latest UF2 with the PHONE's
+                 internet (vanchor-pcb releases), upload it, the Pi flashes the
+                 USB-connected Pico via picotool (no BOOTSEL button needed). -->
+            <details class="adv" id="pico-fw-card">
+              <summary>Helm firmware (Pico)…</summary>
+              <div class="hint">Flash the vanchor motor-controller firmware onto a Raspberry Pi Pico / Pico&nbsp;2 plugged into the boat computer by USB. Your phone downloads the firmware; the boat flashes it. The motor stays disabled during flashing.</div>
+              <label class="dev-srcrow">
+                <span>Board</span>
+                <select id="pico-fw-board">
+                  <option value="pico2">Pico 2 (RP2350) — recommended</option>
+                  <option value="pico">Pico (RP2040)</option>
+                </select>
+              </label>
+              <button type="button" class="btn-ghost" id="pico-fw-check">Check latest firmware</button>
+              <div class="hint" id="pico-fw-latest"></div>
+              <button type="button" class="btn-primary wide" id="pico-fw-flash" style="display:none">Download &amp; flash</button>
+              <label class="dev-srcrow">
+                <span>Or UF2 file</span>
+                <input type="file" id="pico-fw-file" accept=".uf2,application/octet-stream" />
+              </label>
+              <button type="button" class="btn-ghost" id="pico-fw-flash-file">Flash selected file</button>
+              <div class="hint" id="pico-fw-status"></div>
+            </details>
+
             <!-- Advanced: split channels — independent Steering + Thrust sources.
                  Hidden (closed <details>) by default; auto-opened by devices.js
                  when the saved config has explicit steering_source/thrust_source.

--- a/src/vanchor/ui/server.py
+++ b/src/vanchor/ui/server.py
@@ -1222,6 +1222,48 @@ def create_app(runtime: "Runtime", *, telemetry_hz: float = 5.0) -> FastAPI:
             media_type="application/json",
         )
 
+    @app.get("/api/hw/pico/flash")
+    async def pico_flash_status() -> dict:
+        """Whether this install can flash a Pico (picotool baked in)."""
+        from ..hardware import pico_flash as _pf
+        return {"picotool": _pf.picotool_path() is not None}
+
+    @app.post("/api/hw/pico/flash")
+    async def pico_flash_run(file: UploadFile = File(...), force: bool = False):
+        """Flash an uploaded UF2 onto the USB-connected helm Pico.
+
+        Safety interlock: refused while any guided mode drives (the motor
+        controller goes away mid-flash; the board's EN pulldowns keep the
+        bridges disabled, but the BOAT loses steering/thrust) -- same rule as
+        the supervisor's update/rollback paths; ``force=true`` overrides.
+        400 = not a UF2; 200 with {ok, output} otherwise."""
+        from ..hardware import pico_flash as _pf
+        if not force and runtime.state.mode != "manual":
+            return Response(
+                content=json.dumps({
+                    "ok": False,
+                    "error": "underway",
+                    "detail": (f"Boat is in an active guided mode "
+                               f"({runtime.state.mode}); flashing removes the "
+                               "motor controller. Stop first, or force=true."),
+                }),
+                media_type="application/json",
+                status_code=409,
+            )
+        data = await file.read()
+        err = _pf.validate_uf2(data)
+        if err is not None:
+            return Response(
+                content=json.dumps({"ok": False, "error": err}),
+                media_type="application/json",
+                status_code=400,
+            )
+        dest = Path(runtime.config.data_dir) / "helm-firmware.uf2"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        ok, out = await asyncio.to_thread(_pf.flash, str(dest))
+        return {"ok": ok, "output": out[-4000:]}
+
     @app.get("/api/devices/{kind}/debug")
     async def device_debug(kind: str) -> dict:
         """Human-readable raw-data snapshot for one device (gps/compass/depth/

--- a/src/vanchor/ui/static/index.html
+++ b/src/vanchor/ui/static/index.html
@@ -1396,6 +1396,7 @@
   <script src="/static/trips.js"></script>
   <script src="/static/gpscal.js"></script>
   <script src="/static/devices.js"></script>
+  <script src="/static/picoflash.js"></script>
   <script src="/static/hwwizard.js"></script>
   <script src="/static/backup.js"></script>
   <script src="/static/supervisor.js"></script>

--- a/src/vanchor/ui/static/picoflash.js
+++ b/src/vanchor/ui/static/picoflash.js
@@ -1,0 +1,135 @@
+/* Vanchor-NG — helm-Pico firmware flasher (Devices → Motor → Helm firmware).
+ *
+ * The split of labour mirrors the app-update path: the PHONE (which has
+ * internet over cellular; the boat usually has none) fetches the UF2 from the
+ * vanchor-pcb GitHub releases, then uploads it to the boat, and the boat
+ * flashes the USB-connected Pico with picotool — no BOOTSEL button, no
+ * computer, no toolchain. Releases are tagged fw-v*; assets are
+ * vanchor-helm-<board>.uf2. UF2s are small (~0.5 MB) so a single POST is fine
+ * (no chunking needed, unlike the app bundles).
+ */
+"use strict";
+
+(function () {
+  const VA = window.VA;
+  const RELEASES_URL =
+    "https://api.github.com/repos/AlexAsplund/vanchor-pcb/releases?per_page=10";
+
+  const $ = (id) => document.getElementById(id);
+  const setStatus = (msg) => { const el = $("pico-fw-status"); if (el) el.textContent = msg; };
+
+  let _latest = null;   // { tag, asset: {name, browser_download_url, size} }
+
+  function assetForBoard(release, board) {
+    const want = "vanchor-helm-" + board + ".uf2";
+    return (release.assets || []).find((a) => a && a.name === want) || null;
+  }
+
+  function latestFirmware(releases, board) {
+    for (const r of releases) {
+      if (!r || !r.tag_name || !r.tag_name.startsWith("fw-v")) continue;
+      const asset = assetForBoard(r, board);
+      if (asset) return { tag: r.tag_name, asset };
+    }
+    return null;
+  }
+
+  async function doCheck() {
+    const board = $("pico-fw-board") ? $("pico-fw-board").value : "pico2";
+    setStatus("");
+    VA.setText("pico-fw-latest", "Checking…");
+    try {
+      const resp = await fetch(RELEASES_URL, { headers: { Accept: "application/vnd.github+json" } });
+      if (!resp.ok) throw new Error("GitHub API " + resp.status);
+      _latest = latestFirmware(await resp.json(), board);
+      if (!_latest) {
+        VA.setText("pico-fw-latest", "No firmware release found for this board.");
+        return;
+      }
+      VA.setText("pico-fw-latest",
+        "Latest: " + _latest.tag + " (" + Math.round(_latest.asset.size / 1024) + " kB)");
+      const btn = $("pico-fw-flash");
+      if (btn) btn.style.display = "";
+    } catch (err) {
+      _latest = null;
+      VA.setText("pico-fw-latest",
+        "Check failed: " + err.message + " — is this device online?");
+    }
+  }
+
+  async function uploadAndFlash(blob, label) {
+    setStatus("Uploading " + label + " to the boat…");
+    const fd = new FormData();
+    fd.append("file", blob, label);
+    let resp, data;
+    try {
+      resp = await fetch("/api/hw/pico/flash", { method: "POST", body: fd });
+      data = await resp.json();
+    } catch (err) {
+      setStatus("Upload failed: " + err.message);
+      return;
+    }
+    if (resp.status === 409) {
+      setStatus("Refused: " + (data.detail || "boat is underway — stop first."));
+      return;
+    }
+    if (!resp.ok || !data.ok) {
+      setStatus("Flash failed: " + (data.error || data.output || "unknown error"));
+      return;
+    }
+    setStatus("Flashed OK — the Pico restarts into the new firmware. " +
+      (data.output ? "" : "") + "If the motor card shows an error chip for a " +
+      "few seconds, that is the USB re-plug and it heals itself.");
+    if (VA.logAlert) VA.logAlert("info", "Helm firmware flashed");
+  }
+
+  async function doFlashLatest() {
+    if (!_latest) return;
+    const btn = $("pico-fw-flash");
+    if (btn) btn.disabled = true;
+    try {
+      setStatus("Downloading " + _latest.asset.name + " with this device's internet…");
+      const resp = await fetch(_latest.asset.browser_download_url);
+      if (!resp.ok) throw new Error("download " + resp.status);
+      const blob = await resp.blob();
+      await uploadAndFlash(blob, _latest.asset.name);
+    } catch (err) {
+      setStatus("Download failed: " + err.message);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  async function doFlashFile() {
+    const input = $("pico-fw-file");
+    const f = input && input.files && input.files[0];
+    if (!f) { setStatus("Pick a .uf2 file first."); return; }
+    const btn = $("pico-fw-flash-file");
+    if (btn) btn.disabled = true;
+    try { await uploadAndFlash(f, f.name || "firmware.uf2"); }
+    finally { if (btn) btn.disabled = false; }
+  }
+
+  function init() {
+    if (!$("pico-fw-card")) return;
+    const bind = (id, fn) => { const el = $(id); if (el) el.addEventListener("click", fn); };
+    bind("pico-fw-check", doCheck);
+    bind("pico-fw-flash", doFlashLatest);
+    bind("pico-fw-flash-file", doFlashFile);
+    // Hide the whole card when this install cannot flash (no picotool).
+    fetch("/api/hw/pico/flash").then((r) => r.json()).then((d) => {
+      if (!d.picotool) {
+        const card = $("pico-fw-card");
+        if (card) {
+          card.querySelectorAll("button").forEach((b) => { b.disabled = true; });
+          setStatus("This install has no flasher (picotool) — update the " +
+            "boat to the latest SD image to enable it.");
+        }
+      }
+    }).catch(() => {});
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else init();
+})();

--- a/src/vanchor/ui/static/sw.js
+++ b/src/vanchor/ui/static/sw.js
@@ -113,6 +113,7 @@ const SHELL = [
   "/static/trips.js",
   "/static/gpscal.js",
   "/static/devices.js",
+  "/static/picoflash.js",
   "/static/hwwizard.js",
   "/static/backup.js",
   "/static/supervisor.js",

--- a/supervisor/vanchor_supervisor/core.py
+++ b/supervisor/vanchor_supervisor/core.py
@@ -65,6 +65,7 @@ _DEFAULT_CONTAINERS = [
             "c 188:* rmw",
             "c 204:* rmw",
             "c 89:* rmw",
+            "c 189:* rmw",  # /dev/bus/usb -- picotool (helm-Pico flasher)
         ],
         "devices": ["/dev/gpiochip0"],
         "restart": "unless-stopped",

--- a/tests/test_docker_artifacts.py
+++ b/tests/test_docker_artifacts.py
@@ -54,6 +54,7 @@ def test_compose_cgroup_rules_exact(compose):
         "c 188:* rmw",
         "c 204:* rmw",
         "c 89:* rmw",
+        "c 189:* rmw",
     }
     assert set(rules) == expected, f"Expected cgroup rules {expected!r}, got {rules!r}"
 
@@ -110,7 +111,7 @@ def test_dockerfile_final_stage_apt_only_allowed_packages(dockerfile_text):
     # Adoption task 6 adds network-manager (provides nmcli for WiFi setup).
     # This set is the exhaustive allowlist — adding any other package requires
     # an explicit review and an update here.
-    ALLOWED = {"network-manager"}
+    ALLOWED = {"network-manager", "libusb-1.0-0"}
 
     # Split on FROM: the last FROM block is the final stage.
     blocks = dockerfile_text.split("FROM ")

--- a/tests/test_pico_flash.py
+++ b/tests/test_pico_flash.py
@@ -1,0 +1,136 @@
+"""Helm-Pico firmware flasher: UF2 validation, picotool runner, endpoints."""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vanchor.app import Runtime
+from vanchor.core.config import load
+from vanchor.hardware import pico_flash
+from vanchor.ui.server import create_app
+
+
+def make_uf2(blocks: int = 2) -> bytes:
+    """A minimally valid UF2 image: n 512-byte blocks with both magics."""
+    block = bytearray(512)
+    block[0:4] = b"UF2\n"
+    block[4:8] = (0x9E5D5157).to_bytes(4, "little")
+    return bytes(block) * blocks
+
+
+@pytest.fixture()
+def rt():
+    return Runtime(load(None))
+
+
+@pytest.fixture()
+def client(rt):
+    with TestClient(create_app(rt)) as c:
+        yield c
+
+
+class TestValidateUf2:
+    def test_valid_image_passes(self):
+        assert pico_flash.validate_uf2(make_uf2()) is None
+
+    def test_empty_rejected(self):
+        assert pico_flash.validate_uf2(b"") is not None
+
+    def test_wrong_magic_rejected(self):
+        bad = bytearray(make_uf2())
+        bad[0] = 0x00
+        assert "magic" in pico_flash.validate_uf2(bytes(bad))
+
+    def test_unaligned_size_rejected(self):
+        assert "512" in pico_flash.validate_uf2(make_uf2() + b"x")
+
+    def test_html_error_page_rejected(self):
+        assert pico_flash.validate_uf2(b"<html>Not Found</html>" * 32) is not None
+
+    def test_oversized_rejected(self):
+        blocks = pico_flash.MAX_UF2_BYTES // 512 + 1
+        assert "large" in pico_flash.validate_uf2(make_uf2(blocks))
+
+
+class TestFlashRunner:
+    def test_missing_picotool_is_clear(self, monkeypatch):
+        monkeypatch.setattr(pico_flash, "picotool_path", lambda: None)
+        ok, out = pico_flash.flash("/tmp/x.uf2")
+        assert not ok and "picotool is not installed" in out
+
+    def test_success_passes_flags(self, monkeypatch):
+        monkeypatch.setattr(pico_flash, "picotool_path", lambda: "/usr/bin/picotool")
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="Loading... OK", stderr="")
+
+        ok, out = pico_flash.flash("/tmp/x.uf2", run=fake_run)
+        assert ok and "OK" in out
+        # -f = reboot the running app into BOOTSEL; -x = reboot into the app.
+        assert seen["cmd"][1:4] == ["load", "-f", "-x"]
+
+    def test_no_device_gets_reflash_hint(self, monkeypatch):
+        monkeypatch.setattr(pico_flash, "picotool_path", lambda: "/usr/bin/picotool")
+
+        def fake_run(cmd, **kw):
+            return SimpleNamespace(returncode=1, stdout="",
+                                   stderr="No accessible RP-series devices")
+
+        ok, out = pico_flash.flash("/tmp/x.uf2", run=fake_run)
+        assert not ok and "reflash the SD card" in out
+
+    def test_timeout_is_reported(self, monkeypatch):
+        monkeypatch.setattr(pico_flash, "picotool_path", lambda: "/usr/bin/picotool")
+
+        def fake_run(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 120)
+
+        ok, out = pico_flash.flash("/tmp/x.uf2", run=fake_run)
+        assert not ok and "timed out" in out
+
+
+class TestFlashEndpoint:
+    def test_status_reports_picotool(self, client):
+        r = client.get("/api/hw/pico/flash")
+        assert r.status_code == 200
+        assert isinstance(r.json()["picotool"], bool)
+
+    def test_garbage_upload_is_400(self, client):
+        r = client.post("/api/hw/pico/flash",
+                        files={"file": ("x.uf2", b"not a firmware")})
+        assert r.status_code == 400
+        assert r.json()["ok"] is False
+
+    def test_underway_is_409(self, rt, client, monkeypatch):
+        rt.state.mode = "anchor"
+        r = client.post("/api/hw/pico/flash",
+                        files={"file": ("x.uf2", make_uf2())})
+        assert r.status_code == 409
+        assert r.json()["error"] == "underway"
+
+    def test_valid_flash_invokes_runner(self, rt, client, monkeypatch, tmp_path):
+        called = {}
+
+        def fake_flash(path):
+            called["path"] = path
+            return True, "Loading... OK"
+
+        monkeypatch.setattr(pico_flash, "flash", fake_flash)
+        r = client.post("/api/hw/pico/flash",
+                        files={"file": ("fw.uf2", make_uf2())})
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"] is True
+        assert called["path"].endswith("helm-firmware.uf2")
+
+    def test_force_overrides_underway(self, rt, client, monkeypatch):
+        rt.state.mode = "anchor"
+        monkeypatch.setattr(pico_flash, "flash", lambda p: (True, "OK"))
+        r = client.post("/api/hw/pico/flash?force=true",
+                        files={"file": ("fw.uf2", make_uf2())})
+        assert r.status_code == 200
+        assert r.json()["ok"] is True


### PR DESCRIPTION
Closes the loop promised in #114: flashing the helm controller with zero tooling.

## Flow
Devices → Motor → **Helm firmware (Pico)**: the phone downloads `vanchor-helm-<board>.uf2` from the vanchor-pcb `fw-v*` releases (client-side fetch, same pattern as app updates — the boat needs no internet), uploads it (single multipart POST, ~0.5 MB), and the Pi runs `picotool load -f -x`: `-f` reboots the running firmware into BOOTSEL over the USB reset interface (**no BOOTSEL button**), `-x` boots the new app. EN pulldowns keep the bridges disabled throughout. Manual `.uf2` upload also supported.

## Safety + honesty
- 409 while a guided mode drives (flashing removes the motor controller); `force=true` overrides — same interlock as supervisor update/rollback
- uploads validated as real UF2 images (512-byte blocks + both magics)
- installs without picotool (older images) disable the card with a reflash hint

## Plumbing
- picotool built from source in a Docker stage (no bookworm package; runtime dep = libusb-1.0-0)
- `c 189:*` (/dev/bus/usb) added to compose **and** supervisor containers.json defaults; contract tests (cgroup sets, apt allowlist, cross-file match) updated deliberately
- vanchor-pcb CI (already live) builds both boards' UF2s, host tests gate, `fw-v*` tags publish — **fw-v1.0.0 released**

## Verified
Live against the real GitHub API: both boards resolve fw-v1.0.0 with the correct asset; no-picotool degradation verified on the dev box. 15 new tests (UF2 validation, runner seam, endpoint interlock/force). BENCH-VERIFY: full flash cycle on the boat Pi with a real Pico 2.

Gates: 2346 passed, e2e 29/29, node --check + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)