### PR TITLE
fix(devices): empty baud box posted 0 — sim GPS couldn't be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vanchor-NG. Dates are ISO-8601.
 
 ## Unreleased
 
+- **"gps_baud must be a positive integer" when saving a sim GPS -- fixed.**
+  An empty baud box posted 0 (JavaScript Number("") is 0), so switching a
+  device back to Simulated could not be saved. Empty numeric fields now post
+  nothing, the server treats 0/"" as "not set", and empty sim-motor shaping
+  fields no longer silently post 0.
+
 ## [1.5.0a29] — 2026-08-18
 
 - **Flash the helm Pico from the app.** Devices -> Motor -> "Helm firmware

--- a/src/vanchor/runtime/devices.py
+++ b/src/vanchor/runtime/devices.py
@@ -167,6 +167,12 @@ class DeviceManager:
         # stopbits 1/1.5/2. Normalise parity to an upper-case letter.
         for dev in ("gps", "compass", "motor", "steering", "thrust"):
             baud = hw_in.get(f"{dev}_baud")
+            # 0 and "" mean "not set", not a rate: older cached clients send
+            # gps_baud:0 for an empty baud box (Number("") is 0 in JS), which
+            # made saving a sim GPS impossible. Normalise to None (keep/clear).
+            if baud == 0 or (isinstance(baud, str) and not baud.strip()):
+                hw_in[f"{dev}_baud"] = None
+                baud = None
             if baud is not None:
                 try:
                     if int(baud) <= 0:

--- a/src/vanchor/ui/static/devices.js
+++ b/src/vanchor/ui/static/devices.js
@@ -321,6 +321,11 @@
   }
 
   function num(v) {
+    // Number("") is 0, not NaN -- an empty input must mean "not set" (null),
+    // never 0. Sending gps_baud:0 made "save" impossible with a sim GPS
+    // (server: "gps_baud must be a positive integer"), and empty sim-motor
+    // fields silently posted 0 instead of leaving the value alone.
+    if (v == null || String(v).trim() === "") return null;
     const n = Number(v);
     return Number.isFinite(n) ? n : null;
   }

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -211,6 +211,29 @@ def test_post_rejects_bad_baudrate(client):
     assert r.status_code == 400
 
 
+def test_post_zero_baud_means_unset_not_error(client):
+    """Regression (#114-era field report): saving with a sim GPS failed with
+    "gps_baud must be a positive integer" because an empty baud box posted
+    gps_baud:0 (JS Number("") is 0). 0 and "" must read as "not set"."""
+    before = client.get("/api/config/devices").json()["hardware"].get("gps_baud")
+    r = client.post("/api/config/devices",
+                    json={"hardware": {"gps_source": "sim", "gps_baud": 0}})
+    assert r.status_code == 200, r.text
+    after = client.get("/api/config/devices").json()["hardware"]
+    assert after["gps_source"] == "sim"
+    assert after.get("gps_baud") == before          # kept, not zeroed
+
+    r = client.post("/api/config/devices",
+                    json={"hardware": {"compass_baud": ""}})
+    assert r.status_code == 200, r.text
+
+
+def test_post_negative_baud_still_rejected(client):
+    r = client.post("/api/config/devices",
+                    json={"hardware": {"gps_baud": -9600}})
+    assert r.status_code == 400
+
+
 def test_post_coerces_int_port_from_string(client):
     r = client.post("/api/config/devices", json={"nmea_tcp": {"port": "10120"}})
     assert r.status_code == 200


### PR DESCRIPTION
Field report: switching GPS back to **Simulated** failed with `gps_baud must be a positive integer`.

Root cause: the client's `num()` helper — JavaScript's `Number("")` is `0`, not `NaN` — so an empty baud box posted `gps_baud: 0`, which the server rejects. The same helper made empty sim-motor shaping fields silently post `0` (actively zeroing values meant to be left untouched).

Fix on both ends:
- **Client**: `num()` returns `null` for empty/whitespace input (key omitted from the payload)
- **Server**: `0`/`""` for any `<dev>_baud` normalize to "not set" (keeps the stored value) — so a phone still running SW-cached old JS can't hit the error either; negative/garbage bauds still 400

Verified against the live failing flow: `{"gps_source":"sim","gps_baud":0}` now saves and preserves the stored baud. New regression tests for 0/""/negative.

Gates: 2348 passed, e2e 29/29, node --check + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)