### PR TITLE
docs: mark the Arduino firmware path as legacy; point everything at helm-pico

### DIFF
--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -31,6 +31,11 @@ Pi's UART):
 
 ### Motor & steering — the firmware boundary
 
+> **Preferred controller for new builds:** one Raspberry Pi Pico 2 running
+> [`helm-pico`](https://github.com/AlexAsplund/vanchor-pcb/tree/master/firmware/helm-pico) replaces the two Arduino boards described below
+> (same protocol, same `motor_port` config — the Pi cannot tell the
+> difference). The Arduino description remains valid for existing boats.
+
 The Pi does **not** drive high current directly. It sends a normalized
 `MotorCommand` (`thrust ∈ [-1,1]`, `steering ∈ [-1,1]`) over serial to the
 Arduino firmware in [`firmware/`](../firmware/README.md), which turns it into

--- a/docs/firmware.md
+++ b/docs/firmware.md
@@ -1,7 +1,16 @@
-# Firmware integration (Pi ↔ Arduino)
+# Firmware integration (Pi ↔ motor controller)
 
-How the Arduino firmware in [`firmware/`](../firmware/README.md) plugs into the
-Vanchor-NG Python app. Full schematics, pin maps, wiring and BOM live in
+> [!IMPORTANT]
+> **Two firmware paths exist.** The preferred one for new builds is the
+> single-board **Pico firmware** ([`helm-pico`, vanchor-pcb repo](https://github.com/AlexAsplund/vanchor-pcb/tree/master/firmware/helm-pico)):
+> one Pico 2 / Pico replaces both Arduinos, speaks the exact same protocol
+> described on this page, and can be flashed from the app (Devices → Motor →
+> Helm firmware). The Arduino path below remains maintained for existing
+> boats. Everything on this page about the protocol, failsafes and Pi-side
+> integration applies to BOTH.
+
+How the motor-controller firmware in [`firmware/`](../firmware/README.md)
+(and its Pico successor) plugs into the Vanchor-NG Python app. Full schematics, pin maps, wiring and BOM live in
 `firmware/README.md`; this page is the **software contract** and the one change
 the Pi needs to read steering feedback.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,5 +1,14 @@
 # Vanchor-NG firmware
 
+> [!IMPORTANT]
+> **New builds: use the Pico firmware instead.** One Raspberry Pi Pico 2 /
+> Pico replaces both Arduino boards below with a single firmware —
+> [`helm-pico` in the vanchor-pcb repo](https://github.com/AlexAsplund/vanchor-pcb/tree/master/firmware/helm-pico) — same protocol, AS5600
+> magnetic encoder, ready-made UF2 files, flashable from the vanchor app
+> (Devices → Motor → Helm firmware), and the target for new features
+> (NMEA2000 etc.). The Arduino sketches below remain maintained for existing
+> boats and stay the reference for the hijacked-speed-controller approach.
+
 Arduino firmware that lets the Raspberry Pi autopilot drive the boat's **engine
 (thrust)** and **steering (azimuth)** hardware over USB serial. Two independent
 sketches, one shared protocol header:

--- a/firmware/engine/README.md
+++ b/firmware/engine/README.md
@@ -1,0 +1,16 @@
+# engine.ino — legacy Arduino thrust firmware
+
+> [!IMPORTANT]
+> **This is not the preferred path for new builds.** One Raspberry Pi
+> **Pico 2 / Pico** now replaces BOTH Arduino boards (engine + steering) with a
+> single firmware: [`helm-pico` in the vanchor-pcb repo](https://github.com/AlexAsplund/vanchor-pcb/tree/master/firmware/helm-pico).
+> It speaks the same protocol, adds an AS5600 magnetic encoder instead of the
+> feedback pot, ships as drag-and-drop UF2 files, and can be flashed from the
+> vanchor app (Devices → Motor → Helm firmware). It is where new features land.
+>
+> `engine.ino` remains maintained for existing boats (it is what runs on the
+> author's boat today) and as the reference for the hijacked-speed-controller
+> approach, but new functionality (NMEA2000 etc.) will target the Pico.
+
+Wiring, pin map, BOM and bring-up for this sketch: see the
+["Engine board" section of ../README.md](../README.md#2-engine-board--hijacked-commercial-speed-controller).

--- a/firmware/steering/README.md
+++ b/firmware/steering/README.md
@@ -1,0 +1,18 @@
+# steering.ino — legacy Arduino steering firmware
+
+> [!IMPORTANT]
+> **This is not the preferred path for new builds.** One Raspberry Pi
+> **Pico 2 / Pico** now replaces BOTH Arduino boards (steering + engine) with a
+> single firmware: [`helm-pico` in the vanchor-pcb repo](https://github.com/AlexAsplund/vanchor-pcb/tree/master/firmware/helm-pico).
+> It speaks the same protocol, uses an AS5600 magnetic encoder instead of the
+> feedback pot (no pot wear, multi-turn), ships as drag-and-drop UF2 files, and
+> can be flashed from the vanchor app (Devices → Motor → Helm firmware). It is
+> where new features land.
+>
+> `steering.ino` remains maintained for existing boats (it is what runs on the
+> author's boat today), but new functionality will target the Pico.
+
+Wiring, pin map, BOM and bring-up for this sketch: see the
+["Steering board" section of ../README.md](../README.md#3-steering-board--closed-loop-azimuth).
+The host-side protocol tests in `tests/` cover the shared parser used by BOTH
+the Arduino and Pico firmwares — they stay authoritative regardless of path.

--- a/src/vanchor/ui/partials/hw-wizard.html
+++ b/src/vanchor/ui/partials/hw-wizard.html
@@ -134,6 +134,7 @@
           <details style="margin-top:.75rem">
             <summary class="hint">Wiring help — Motor (vanchor firmware)</summary>
             <ul class="hint" style="margin:.25rem 0 0 1rem">
+              <li>A Raspberry Pi Pico / Pico&nbsp;2 with the vanchor helm firmware over USB (one board drives both thrust and steering — the preferred setup).</li>
               <li>One or two Arduino Nanos over USB (engine = thrust, steering = azimuth) at 115200.</li>
               <li>Wiring, pin maps and BOM: <code>firmware/README.md</code>.</li>
               <li>The probe only <b>listens</b> for the firmware's A/E feedback lines — it never sends a motor command; nothing can spin.</li>


### PR DESCRIPTION
The Pico firmware is now the preferred motor controller for new builds, but the docs still presented the two-Arduino path as *the* path — the #114 builder had to ask in the discussion to discover the Pico route existed.

Every documentation entry point now states the preference and links the alternative:

- **`firmware/engine/README.md` + `firmware/steering/README.md` (new)** — clear `[!IMPORTANT]` notices rendered directly under each sketch's directory listing on GitHub
- **`firmware/README.md`** — banner after the title
- **`docs/firmware.md`** — retitled "Pi ↔ motor controller"; clarifies the protocol/failsafe contract applies to BOTH firmwares
- **`docs/deploy-pi.md`** — preferred-controller note at the firmware boundary (same protocol, same `motor_port`, the Pi can't tell the difference)
- **hw-wizard connect hint** — lists the Pico option first

The Arduino sketches remain maintained (they run on the author's boat today) and stay the reference for the hijacked-speed-controller approach; new features target the Pico.

Gates: 2348 passed, e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)